### PR TITLE
Underlay Canvas (part of Artboard framework barebone)

### DIFF
--- a/src/@types/artboard.d.ts
+++ b/src/@types/artboard.d.ts
@@ -1,6 +1,7 @@
 /**
  * Interface for the Artboard component's View props.
  */
+import p5 from 'p5';
 export interface IArtboardProps {
     /** id of the artboard */
     id: number;
@@ -83,4 +84,19 @@ export interface ITurtleModel {
     update: () => void;
     show: () => void;
     pressed: () => void;
+}
+
+export interface SketchProps {
+    [key: string]: any;
+}
+
+export interface Sketch {
+    (instance: p5): void;
+}
+export interface P5WrapperProps extends SketchProps {
+    sketch: Sketch;
+}
+
+export interface P5Instance extends p5 {
+    updateWithProps?: (props: SketchProps) => void;
 }

--- a/src/components/artboard/Underlay.tsx
+++ b/src/components/artboard/Underlay.tsx
@@ -1,0 +1,53 @@
+// -- types ----------------------------------------------------------------------------------------
+import p5 from 'p5';
+import React, { useEffect, useState, createRef } from 'react';
+
+import { P5Instance, SketchProps, P5WrapperProps } from '../../@types/artboard';
+
+export const Sketch = (sketch: P5Instance): void => {
+  let underlayCanvas: p5.Element;
+  let bgcolor: number;
+  bgcolor = 129; // default background color
+
+  /** This is a setup function.*/
+  sketch.setup = () => {
+    underlayCanvas = sketch.createCanvas(1200, 600);
+    underlayCanvas.position(150, 100);
+    sketch.background(bgcolor);
+  };
+
+  sketch.updateWithProps = (props: SketchProps) => {
+    if (props.color) {
+      bgcolor = parseInt(props.color, 10);
+    }
+  };
+
+  /** This is a draw function */
+  sketch.draw = () => {
+    sketch.background(bgcolor);
+  };
+};
+
+export const UnderlaySketch: React.FC<P5WrapperProps> = ({ sketch, children, ...props }) => {
+  /** Skecth takes a P5Instance of canvas, props contains attributes such as background color, etc*/
+  const underlaySketch = createRef<HTMLDivElement>();
+  const [instance, setInstance] = useState<P5Instance>();
+  const id = `underlay-sketch`;
+  useEffect(() => {
+    instance?.updateWithProps?.(props);
+  }, [props]);
+
+  useEffect(() => {
+    if (underlaySketch.current === null) return;
+    instance?.remove();
+    const canvas = new p5(Sketch, document.getElementById(id) as HTMLElement) as P5Instance;
+    canvas.updateWithProps?.(props);
+    setInstance(canvas);
+  }, [sketch, underlaySketch.current]);
+
+  return (
+    <div style={{ position: 'absolute' }} id={id} ref={underlaySketch}>
+      {children}
+    </div>
+  );
+};


### PR DESCRIPTION
In this PR, an underlay canvas is added, which resolves a sub task of #58
It adds a canvas in the background which is created using p5.
The background color of this underlay canvas can be changed by passing color as a prop when calling this component 
 ( UnderlaySketch ).
After importing `Sketch` and `UnderlaySketch`  in the current file:
Sample code for calling this component - 
` <UnderlaySketch sketch={Sketch} color={state.color} />`
`color` is passed as a prop and its handler function can be called using hooks like this -
 ` const [color, setColor] = useState('red'); `   
 `<input onChange={(event) => setColor({color: event.target.value})} />` 

 