### PR TITLE
Added ElementSetXY

### DIFF
--- a/src/components/editor/core/index.ts
+++ b/src/components/editor/core/index.ts
@@ -29,7 +29,11 @@ export function buildProgram(code: string): Promise<boolean> {
         for (const line of lines) {
             const units = line.split(' ');
             if (
-                !(units.length === 2 || (units.length === 4 && units[0] === '' && units[1] === ''))
+                !(
+                    units.length === 2 ||
+                    units.length === 3 ||
+                    (units.length === 4 && units[0] === '' && units[1] === '')
+                )
             ) {
                 return false;
             }

--- a/src/components/painter/index.ts
+++ b/src/components/painter/index.ts
@@ -41,6 +41,7 @@ import {
     ElementMoveBackward,
     ElementTurnLeft,
     ElementTurnRight,
+    ElementSetXY,
     ElementSetColor,
     ElementSetThickness,
 } from './painter';
@@ -80,6 +81,12 @@ export const specification: {
         type: 'Statement',
         category: 'Graphics',
         prototype: ElementTurnRight,
+    },
+    'set-xy': {
+        label: 'set xy',
+        type: 'Statement',
+        category: 'Graphics',
+        prototype: ElementSetXY,
     },
     'set-color': {
         label: 'set color',

--- a/src/components/painter/painter.ts
+++ b/src/components/painter/painter.ts
@@ -175,6 +175,32 @@ export class ElementTurnLeft extends ElementStatement {
 
 /**
  * @class
+ * Defines a `graphics` statement element that updates the sprite position to (x, y).
+ */
+export class ElementSetXY extends ElementStatement {
+    constructor() {
+        super('set-xy' as TElementName, 'set-xy', { x: ['number'], y: ['number'] });
+    }
+
+    /**
+     * Updates the sprite position to (`x`, `y`).
+     */
+    onVisit(params: { [key: string]: TData }): void {
+        const [x1, y1, x2, y2] = [
+            _state.position.x,
+            _state.position.y,
+            -params['x'] as number,
+            params['y'] as number,
+        ];
+
+        _state.position = { x: x2, y: y2 };
+
+        sketch.drawLine(x1, y1, x2, y2);
+    }
+}
+
+/**
+ * @class
  * Defines a `pen` statement element that sets the pen color.
  */
 export class ElementSetColor extends ElementStatement {


### PR DESCRIPTION
The PR adds this Syntax Element class (as per this issue[https://github.com/sugarlabs/musicblocks-v4/issues/137]): 
[x]ElementSetXY: Updates sprite position to (x, y)
- name: set-xy
- label: set-xy
- args:
- 1. x: number
- 2. y: number

I am not sure abt the changes I did in src/components/editor/core/index.ts for the validation. Please let me know if you have a suggestion for it.