### PR TITLE
new syntax element setHeading fixes #137

### DIFF
--- a/src/components/painter/index.ts
+++ b/src/components/painter/index.ts
@@ -47,6 +47,7 @@ import {
     ElementTurnLeft,
     ElementTurnRight,
     ElementSetXY,
+    ElementSetHeading,
     ElementSetColor,
     ElementSetThickness,
     ElementPenUp,
@@ -90,6 +91,12 @@ export const specification: {
         type: 'Statement',
         category: 'Graphics',
         prototype: ElementSetXY,
+    },
+    'set-heading': {
+        label: 'set heading',
+        type: 'Statement',
+        category: 'Graphics',
+        prototype: ElementSetHeading,
     },
     'set-color': {
         label: 'set color',

--- a/src/components/painter/painter.ts
+++ b/src/components/painter/painter.ts
@@ -175,7 +175,7 @@ export class ElementTurnLeft extends ElementStatement {
     }
 
     /**
-     * Rotates the sprite left sby `angle`.
+     * Rotates the sprite left by `angle`.
      */
     onVisit(params: { [key: string]: TData }): void {
         _turn(params['angle'] as number);
@@ -207,20 +207,21 @@ export class ElementSetXY extends ElementStatement {
         sketch.drawLine(x1, y1, x2, y2);
     }
 }
+
 /**
  * @class
- * Defines a `graphics` statement element that updates the sprite heading to the angle(degrees).
+ * Defines a `graphics` statement element that updates the sprite heading.
  */
- export class ElementSetHeading extends ElementStatement {
+export class ElementSetHeading extends ElementStatement {
     constructor() {
         super('set-heading' as TElementName, 'set-heading', { angle: ['number'] });
     }
+
     /**
-     * Set the sprite heading to the `angle`.
+     * Sets the sprite heading to the `angle`.
      */
-     onVisit(params: { [key: string]: TData }): void {
-         const angle = params['angle'] as number;
-        _state.heading = angle;
+    onVisit(params: { [key: string]: TData }): void {
+        _state.heading = (params['angle'] as number) + 90;
     }
 }
 

--- a/src/components/painter/painter.ts
+++ b/src/components/painter/painter.ts
@@ -207,6 +207,22 @@ export class ElementSetXY extends ElementStatement {
         sketch.drawLine(x1, y1, x2, y2);
     }
 }
+/**
+ * @class
+ * Defines a `graphics` statement element that updates the sprite heading to the angle(degrees).
+ */
+ export class ElementSetHeading extends ElementStatement {
+    constructor() {
+        super('set-heading' as TElementName, 'set-heading', { angle: ['number'] });
+    }
+    /**
+     * Set the sprite heading to the `angle`.
+     */
+     onVisit(params: { [key: string]: TData }): void {
+         const angle = params['angle'] as number;
+        _state.heading = angle;
+    }
+}
 
 /**
  * @class


### PR DESCRIPTION
This PR add the Syntax element class as per issue #137 Task 2
ElementSetHeading: Updates sprite heading to angle degrees
    name: set-heading
    label: set-heading 
    args:
        angle: number
        
I have checked and this command works on my local system. Please check and tell for any changes required.