### PR TITLE
Painter: fixes

### DIFF
--- a/src/components/painter/core/sketchP5.ts
+++ b/src/components/painter/core/sketchP5.ts
@@ -62,6 +62,7 @@ export function drawArc(
     start: number,
     stop: number,
 ): void {
+    sketch.noFill();
     sketch.arc(x, y, w, h, start, stop, sketch.OPEN);
 }
 

--- a/src/components/painter/core/utils.ts
+++ b/src/components/painter/core/utils.ts
@@ -4,7 +4,7 @@
  * @returns value in degrees
  */
 export function radToDeg(radians: number): number {
-    return (radians / 180) * Math.PI;
+    return (radians / Math.PI) * 180;
 }
 
 /**

--- a/src/components/painter/painter.ts
+++ b/src/components/painter/painter.ts
@@ -4,7 +4,7 @@ import * as sketchP5 from './core/sketchP5';
 import { updatePosition, updateHeading } from './view/sprite';
 import { updateBackgroundColor } from './view';
 
-import { degToRad, radToDeg } from './core/utils';
+import { degToRad } from './core/utils';
 
 // -- private variables ----------------------------------------------------------------------------
 
@@ -65,8 +65,8 @@ function _move(distance: number): void {
     const [x1, y1, x2, y2] = [
         _state.position.x,
         _state.position.y,
-        _state.position.x + distance * Math.cos(radToDeg(_state.heading)),
-        _state.position.y + distance * Math.sin(radToDeg(_state.heading)),
+        _state.position.x + distance * Math.cos(degToRad(_state.heading)),
+        _state.position.y + distance * Math.sin(degToRad(_state.heading)),
     ];
 
     _state.position = { x: x2, y: y2 };

--- a/src/components/painter/painter.ts
+++ b/src/components/painter/painter.ts
@@ -217,7 +217,9 @@ export class ElementSetXY extends ElementStatement {
 
         _state.position = { x: x2, y: y2 };
 
-        sketch.drawLine(x1, y1, x2, y2);
+        if (_state.drawing) {
+            sketch.drawLine(x1, y1, x2, y2);
+        }
     }
 }
 


### PR DESCRIPTION
- fix `radToDeg` function in painter/utils
- add no fill for drawing arcs
- use `degToRad` in `_move` function of painter
- don't draw line in `ElementSetXY` if drawing state is not enabled