### PR TITLE
painter: [fix] added drawing condition to draw-arc

### DIFF
--- a/src/components/painter/painter.ts
+++ b/src/components/painter/painter.ts
@@ -264,10 +264,11 @@ export class ElementDrawArc extends ElementStatement {
             _state.position.y + radius * Math.sin(degToRad(_state.heading + direction * 90)),
         ];
 
-        const [startAngle, stopAngle] =
-            direction === 1 ? [theta - angle, theta] : [theta, theta - angle];
-        sketch.drawArc(xCentre, yCentre, radius * 2, radius * 2, startAngle, stopAngle);
-
+        if (_state.drawing) {
+            const [startAngle, stopAngle] =
+                direction === 1 ? [theta - angle, theta] : [theta, theta - angle];
+            sketch.drawArc(xCentre, yCentre, radius * 2, radius * 2, startAngle, stopAngle);
+        }
         _state.heading += angle;
         _state.position = {
             x: xCentre + radius * Math.cos(degToRad(theta)),


### PR DESCRIPTION
Signed-off-by: Devesh <deves125@gmail.com>

As per issue #150, this PR adds the condition to check if the state `ElementPenDown` is true before drawing an arc.
Now it will only draw an arc if the `_state.drawing` is true.


Is this a good solution?
