### PR TITLE
painter: [fix] add drawing state check to ElementDrawArc

### DIFF
--- a/src/components/painter/painter.ts
+++ b/src/components/painter/painter.ts
@@ -264,9 +264,11 @@ export class ElementDrawArc extends ElementStatement {
             _state.position.y + radius * Math.sin(degToRad(_state.heading + direction * 90)),
         ];
 
-        const [startAngle, stopAngle] =
-            direction === 1 ? [theta - angle, theta] : [theta, theta - angle];
-        sketch.drawArc(xCentre, yCentre, radius * 2, radius * 2, startAngle, stopAngle);
+        if (_state.drawing) {
+            const [startAngle, stopAngle] =
+                direction === 1 ? [theta - angle, theta] : [theta, theta - angle];
+            sketch.drawArc(xCentre, yCentre, radius * 2, radius * 2, startAngle, stopAngle);
+        }
 
         _state.heading += angle;
         _state.position = {


### PR DESCRIPTION
As per the issue https://github.com/sugarlabs/musicblocks-v4/issues/150, Draws arc on the artboard only if drawing state is enabled, otherwise, sprite just moves along the arc.
Now it will only draw an arc if the `_state.drawing` is true.

closes #150.