### PR TITLE
docs: Setup disclaimer added to readme

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,6 @@ jobs:
           JAVASCRIPT_ES_CONFIG_FILE: .eslintrc
           TYPESCRIPT_ES_CONFIG_FILE: .eslintrc
           MARKDOWN_CONFIG_FILE: .markdownlint.jsonc
-          NATURAL_LANGUAGE_CONFIG_FILE: .textlintrc
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_CSS: false
           VALIDATE_DOCKERFILE: false

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -246,5 +246,15 @@
   "MD048": {
     // Code fence syle
     "style": "consistent"
+  },
+
+  // MD049/emphasis-style - Emphasis style should be consistent
+  "MD049": {
+    "style": "consistent"
+  },
+
+  // MD050/strong-style - Strong style should be consistent
+  "MD050": {
+    "style": "consistent"
   }
 }

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ top of the repository to follow and/or discuss about the planning progress.
 A prototype has been built currently. Parallel development of the programming framework will be done
 in the [**musicblocks-v4-lib**](https://github.com/sugarlabs/musicblocks-v4-lib) repository as mentioned
 above. For updates, follow the `develop` branch and the feature branches that branch out of it.
-Please look out for *Issues* tab of both repositories.
+Please look out for _Issues_ tab of both repositories.
 
 ### New Contributors
 

--- a/README.md
+++ b/README.md
@@ -336,6 +336,16 @@ Windows) this repository using
     docker compose down
     ```
 
+### Disclaimer
+
+Hot reloading currently does not work, so every time you make a change, you need to refresh the
+browser manually. This issue does not occur in productions builds. The production build works
+totally fine on the Chromium-based webkit browsers, Firefox, and Safari.
+
+This project is setup using `create-react-app` which uses `react-scripts@v4.0.3`.The webpack
+version it uses has some issues with hot-reloading which is causing the problem. This problem is
+temporary and will be fixed in the future.
+
 ## Commands
 
 **Note: This repository uses `sugarlabs/musicblocks-v4-lib` as an _npm_ package which is published to


### PR DESCRIPTION
#153 
This PR adds a disclaimer in the `README.md` file under [Setup Development Environment](https://github.com/sugarlabs/musicblocks-v4#setup-development-environment) regarding the hot-reloading problem in the app mentioned [here](https://github.com/sugarlabs/musicblocks-v4/issues/153).