### PR TITLE
Chore: use musicblocks-v4-lib@^0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
-    "@sugarlabs/musicblocks-v4-lib": "^1.0.1",
+    "@sugarlabs/musicblocks-v4-lib": "^0.2.0",
     "jquery": "^3.6.0",
     "p5": "^1.4.0",
     "react": "^17.0.2",


### PR DESCRIPTION
`musicblocks-v4-lib` versions have been reset down (convention fix)