### PR TITLE
chore: change version of musicblocks-v4-lib to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@sugarlabs/musicblocks-v4-lib": "^1.0.1",
+        "@sugarlabs/musicblocks-v4-lib": "^0.2.0",
         "jquery": "^3.6.0",
         "p5": "^1.4.0",
         "react": "^17.0.2",
@@ -2538,9 +2538,9 @@
       }
     },
     "node_modules/@sugarlabs/musicblocks-v4-lib": {
-      "version": "1.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@sugarlabs/musicblocks-v4-lib/1.0.1/21e78eb0485ea4f0c78d4c86d1aeb4e58577254d474eb9db7cd73296e67d1291",
-      "integrity": "sha512-1CVbo04kBVGUYZfjBz1nYbCVroGMHX7irt3WmnTVbvdtnjsCSv7JDGz6/vVekFzb4w3EiG9keIcY3yqMBQVZIw==",
+      "version": "0.2.0",
+      "resolved": "https://npm.pkg.github.com/download/@sugarlabs/musicblocks-v4-lib/0.2.0/eb1a37fa05f90da7a598d9f5c8b9ce61dc0431bea0c7b76e922327392c492da3",
+      "integrity": "sha512-fhh4NXYZlxdS233VRIBSilDHwxUvb6UM7Xnfj3FQYA5VKCkN09XUxzJtv6iFpM4BcCny107aA/qy3lDctQz42Q==",
       "license": "AGPL-3.0",
       "dependencies": {
         "uuid": "^8.3.2"
@@ -23775,9 +23775,9 @@
       }
     },
     "@sugarlabs/musicblocks-v4-lib": {
-      "version": "1.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@sugarlabs/musicblocks-v4-lib/1.0.1/21e78eb0485ea4f0c78d4c86d1aeb4e58577254d474eb9db7cd73296e67d1291",
-      "integrity": "sha512-1CVbo04kBVGUYZfjBz1nYbCVroGMHX7irt3WmnTVbvdtnjsCSv7JDGz6/vVekFzb4w3EiG9keIcY3yqMBQVZIw==",
+      "version": "0.2.0",
+      "resolved": "https://npm.pkg.github.com/download/@sugarlabs/musicblocks-v4-lib/0.2.0/eb1a37fa05f90da7a598d9f5c8b9ce61dc0431bea0c7b76e922327392c492da3",
+      "integrity": "sha512-fhh4NXYZlxdS233VRIBSilDHwxUvb6UM7Xnfj3FQYA5VKCkN09XUxzJtv6iFpM4BcCny107aA/qy3lDctQz42Q==",
       "requires": {
         "uuid": "^8.3.2"
       }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
-    "@sugarlabs/musicblocks-v4-lib": "^1.0.1",
+    "@sugarlabs/musicblocks-v4-lib": "^0.2.0",
     "jquery": "^3.6.0",
     "p5": "^1.4.0",
     "react": "^17.0.2",


### PR DESCRIPTION
The test-synth branch had the wrong version of the musicblocks-v4-lib package because the package's versioning scheme was updated; this pull request updates the package.json and package-lock.json files to reflect the new version.