### PR TITLE
feat: sanitize content in SImageVector

### DIFF
--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint src"
   },
   "dependencies": {
-    "@sugarlabs/mb4-assets": "*"
+    "@sugarlabs/mb4-assets": "*",
+    "dompurify": "^3.0.6"
   },
   "peerDependencies": {
     "react": "~18.x",

--- a/lib/components/src/SImageVector/index.tsx
+++ b/lib/components/src/SImageVector/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import DOMPurify from 'dompurify';
 
 // -- stylesheet -----------------------------------------------------------------------------------
 
@@ -17,7 +18,8 @@ export default function (props: {
 
   useEffect(() => {
     const _wrapper = wrapper.current! as HTMLDivElement;
-    _wrapper.innerHTML = props.content;
+    const sanitizedContent = DOMPurify.sanitize(props.content);
+    _wrapper.innerHTML = sanitizedContent;
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Fix for Cross-Site Scripting (XSS) Vulnerability

I've identified a Cross-Site Scripting (XSS) vulnerability in the @sugarlabs/mb4-components package.

**Vulnerability Details:**
- **Severity**: High/Critical
- **Description**: There's a risk of malicious script execution when the content is controlled by an adversory.

**Steps to Reproduce:**
In a React.js project:
```
import { SImageVector } from '@sugarlabs/mb4-components'

<SImageVector content={`<img src='' onError=alert(1)>`} />
```
Then the malicious code alert(1) will be executed.

**Suggested Fix or Mitigation:**
It's a best practice for a React.js components package to sanitize the HTML content before passing it to innerHTML.

I've already fixed and tested this issue, and have submitted a pull request with the necessary changes. Please review and merge my pull request at your earliest convenience to resolve this vulnerability. Thanks!


