### PR TITLE
Added Popover text on import and export Closes #372

### DIFF
--- a/modules/menu/src/view/components/index.tsx
+++ b/modules/menu/src/view/components/index.tsx
@@ -16,6 +16,9 @@ export function Menu(props: TPropsMenu): JSX.Element {
     <>
       <>
         <label className={`menu-btn ${!props.injected.flags.uploadFile ? 'menu-btn-hidden' : ''}`}>
+          <p className="menu-btn-label">
+            <span>{'Export Project'}</span>
+          </p>
           <div className="menu-btn-img">
             <SImage asset={props.injected.assets['image.icon.uploadFile']} />
           </div>
@@ -52,6 +55,9 @@ export function Menu(props: TPropsMenu): JSX.Element {
         </button>
 
         <label className={`menu-btn ${!props.injected.flags.loadProject ? 'menu-btn-hidden' : ''}`}>
+          <p className="menu-btn-label">
+            <span>{'Import Project'}</span>
+          </p>
           <div className="menu-btn-img">
             <SImage asset={props.injected.assets['image.icon.loadProject']} />
           </div>


### PR DESCRIPTION
Here is the popover text on both import and export button
![image](https://github.com/sugarlabs/musicblocks-v4/assets/121949298/80ff02ae-096d-42a6-8deb-72ee14ec4b1e)
![image](https://github.com/sugarlabs/musicblocks-v4/assets/121949298/854072fa-ef5c-482d-9544-b28103960778)

