### PR TITLE
Add Python (and pip) to Dockerfile for dependency installation (#433)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM node:lts-alpine
 RUN apk update && apk add --no-cache \
     build-base \
     python3 \
+    py3-pip \
     py3-setuptools
 
 # Install simple http server for serving static content


### PR DESCRIPTION
While following the setup steps in _doc.md_, some dependencies failed to install because Python was missing in the Docker container. Certain Node packages (via _node-gyp_ and similar tools) require Python and pip during their build process.

This PR updates the Dockerfile to install:

1. **python3** – Python interpreter
2. **py3-pip** – Python package installer
3. **py3-setuptools** – Required for Python packaging
4. **build-base** – Compilation tools for native modules

These additions ensure that Python-based build dependencies can be installed without manual intervention.

**Changes:**
- Updated apk add step in Dockerfile to include py3-pip.

**Testing:**
- Built the Docker image locally and verified that packages requiring Python now install successfully.

**Closes:** #433