### PR TITLE
Refactor Config Page Component for Clarity and Maintainability

### DIFF
--- a/app/src/config/ConfigPage.tsx
+++ b/app/src/config/ConfigPage.tsx
@@ -4,13 +4,21 @@ import type { IComponentDefinitionExtended, TComponentId } from '#/@types/compon
 
 import Config from './Config';
 
-// -- stylesheet -----------------------------------------------------------------------------------
-
+// -- Stylesheet -----------------------------------------------------------------------------------
 import './index.scss';
 
-// -- component definition -------------------------------------------------------------------------
+// -- Component Definition -------------------------------------------------------------------------
 
-export default function (props: {
+/**
+ * Configuration Page Component
+ * 
+ * Renders the application configuration interface and handles updates to app settings.
+ */
+export default function ConfigPage({
+  config,
+  definitions,
+  handlerUpdate,
+}: {
   /** App configurations. */
   config: IAppConfig;
   /** Map of component definitions. */
@@ -18,15 +26,13 @@ export default function (props: {
   /** Callback for when configurations are updated. */
   handlerUpdate: (config: IAppConfig) => unknown;
 }): JSX.Element {
-  // ---------------------------------------------------------------------------
-
   return (
     <div id="config-page">
       <div id="config-page-content-wrapper">
         <Config
-          definitions={props.definitions}
-          config={props.config}
-          handlerUpdate={props.handlerUpdate}
+          definitions={definitions}
+          config={config}
+          handlerUpdate={handlerUpdate}
         />
       </div>
     </div>


### PR DESCRIPTION
This PR improves the ConfigPage component by introducing several refinements for readability, debugging, and consistency:
Named the default export (ConfigPage) for better stack traces and IDE recognition.
Destructured props for cleaner JSX and improved code readability.
Preserved strong TypeScript typings and doc comments.
Ensured consistent import and section labeling for maintainability.

No functional behavior is changed — this is a non-breaking, code-quality improvement to support future enhancements and debugging.

<img width="1536" height="1024" alt="ChatGPT Image Dec 22, 2025, 03_41_04 PM" src="https://github.com/user-attachments/assets/ca85e0a6-7092-4c01-8b6a-2031152952b5" />
