### PR TITLE
chore: auto-format staged files using Husky + pretty-quick

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx pretty-quick --staged

--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -6,7 +6,7 @@
   "main": "index.ts",
   "scripts": {
     "storybook": "storybook dev -p 6006",
-    "check": "tsc --types 'vite/client'",
+    "check": "tsc --types vite/client",
     "lint": "eslint src"
   },
   "dependencies": {

--- a/modules/editor/package.json
+++ b/modules/editor/package.json
@@ -5,7 +5,7 @@
   "private": "true",
   "main": "src/index.ts",
   "scripts": {
-    "check": "tsc --types 'vite/client'",
+    "check": "tsc --types vite/client",
     "lint": "eslint src"
   },
   "peerDependencies": {

--- a/modules/menu/package.json
+++ b/modules/menu/package.json
@@ -6,7 +6,7 @@
   "main": "src/index.ts",
   "scripts": {
     "storybook": "storybook dev -p 6006",
-    "check": "tsc --types 'vite/client'",
+    "check": "tsc --types vite/client",
     "lint": "eslint src"
   },
   "peerDependencies": {

--- a/modules/painter/package.json
+++ b/modules/painter/package.json
@@ -5,7 +5,7 @@
   "private": "true",
   "main": "src/index.ts",
   "scripts": {
-    "check": "tsc --types 'vite/client'",
+    "check": "tsc --types vite/client",
     "lint": "eslint src"
   },
   "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,12 +55,14 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.1",
         "http-server": "^14.1.1",
+        "husky": "^9.1.7",
         "lerna": "^8.2.2",
         "markdownlint": "^0.38.0",
         "markdownlint-cli": "^0.45.0",
         "nodemon": "^3.0.0",
         "nyc": "^17.1.0",
         "prettier": "^3.5.3",
+        "pretty-quick": "^4.2.2",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-router-dom": "^6.14.0",
@@ -13041,6 +13043,22 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -17165,6 +17183,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -19015,6 +19043,57 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-quick": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-4.2.2.tgz",
+      "integrity": "sha512-uAh96tBW1SsD34VhhDmWuEmqbpfYc/B3j++5MC/6b3Cb8Ow7NJsvKFhg0eoGu2xXX+o9RkahkTK6sUdd8E7g5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.7",
+        "ignore": "^7.0.5",
+        "mri": "^1.2.0",
+        "picocolors": "^1.1.1",
+        "picomatch": "^4.0.2",
+        "tinyexec": "^0.3.2",
+        "tslib": "^2.8.1"
+      },
+      "bin": {
+        "pretty-quick": "lib/cli.mjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pretty-quick"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0"
+      }
+    },
+    "node_modules/pretty-quick/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/pretty-quick/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/proc-log": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "check": "lerna run check",
     "lint": "lerna run lint && markdownlint -i '**/node_modules/**' . && textlint '**/*.md'",
     "test": "lerna run test",
-    "coverage": "./coverage.sh"
+    "coverage": "./coverage.sh",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^8.6.14",
@@ -51,12 +52,14 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.1",
     "http-server": "^14.1.1",
+    "husky": "^9.1.7",
     "lerna": "^8.2.2",
     "markdownlint": "^0.38.0",
     "markdownlint-cli": "^0.45.0",
     "nodemon": "^3.0.0",
     "nyc": "^17.1.0",
     "prettier": "^3.5.3",
+    "pretty-quick": "^4.2.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.14.0",


### PR DESCRIPTION
### Summary
This PR adds a pre-commit hook using Husky + pretty-quick to automatically
format only staged files. This helps maintain consistent formatting across
contributors without requiring manual formatting.

### Changes
• added Husky pre-commit hook
• configured pretty-quick to format staged files only
• resolved TypeScript check errors related to vite/client types
• ensured `npm run check` and `npm run build` pass

### Notes
• The hook does not reformat the entire repository
• Only staged files are affected, keeping commits clean
• CI still passes successfully

### Checklist
✔ npm run check passes
✔ npm run lint passes
✔ npm run build succeeds
✔ no unrelated files changed
