### PR TITLE
feat(editor): [UI] add hover text to editor button (fixes #509)

### DIFF
--- a/modules/editor/src/view/components/button/index.scss
+++ b/modules/editor/src/view/components/button/index.scss
@@ -2,25 +2,66 @@
 
 #editor-toolbar-btn {
   padding: 0.25rem;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
-  svg {
+  .editor-btn-label {
+    position: absolute;
+    z-index: 100;
+    left: calc(100% + 0.25rem);
+    display: none;
+    margin: 0;
+    padding: 0 0.375rem 0.125rem 0.25rem;
+    border-radius: 0 0.25rem 0.25rem 0;
+    background-color: $mb-accent-light;
+
+    &::before {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      display: block;
+      content: '';
+      width: 0.25rem;
+      transform: translateX(-100%);
+      clip-path: polygon(0 50%, 100% 0%, 100% 100%);
+      background-color: $mb-accent-light;
+    }
+
+    span {
+      font-size: 0.75rem;
+      font-weight: bold;
+      color: $text-light;
+    }
+  }
+
+  .editor-btn-img {
     width: 100%;
     height: 100%;
 
-    &.editor-toolbar-btn-img-hidden {
-      display: none;
-    }
+    svg {
+      width: 100%;
+      height: 100%;
 
-    .path-fill {
-      fill: $mb-accent;
-      transition: all 0.25s ease;
+      .path-fill {
+        fill: $mb-accent;
+        transition: all 0.25s ease;
+      }
     }
   }
 
   &:hover {
-    svg {
-      .path-fill {
-        fill: $mb-accent-light;
+    .editor-btn-label {
+      display: block;
+    }
+
+    .editor-btn-img {
+      svg {
+        .path-fill {
+          fill: $mb-accent-light;
+        }
       }
     }
   }

--- a/modules/editor/src/view/components/button/index.tsx
+++ b/modules/editor/src/view/components/button/index.tsx
@@ -18,6 +18,7 @@ let _svgClose: string;
  */
 export function setup(container: HTMLElement): void {
   container.id = 'editor-toolbar-btn';
+  container.classList.add('editor-btn-wrapper');
   _container = container;
 
   _svgCode = injected.assets['image.icon.code'].data;
@@ -31,5 +32,12 @@ export function setup(container: HTMLElement): void {
  * @param icon icon name
  */
 export function setButtonImg(icon: 'code' | 'cross'): void {
-  _container.innerHTML = icon === 'code' ? _svgCode : _svgClose;
+  _container.innerHTML = `
+    <p class="editor-btn-label">
+      <span>Editor</span>
+    </p>
+    <div class="editor-btn-img">
+      ${icon === 'code' ? _svgCode : _svgClose}
+    </div>
+  `;
 }


### PR DESCRIPTION
## Description
This PR adds a hover text label "Editor" to the editor toggle button in the sidebar toolbar.

Previously, the "Run", and "Reset" buttons displayed text labels on hover, but the "Editor" button did not. This change makes the UI consistent across all toolbar actions.

## Context
Fixes #509

## Type of Change
- [x] New feature (non-breaking change which adds functionality)


## Verification
- [x] Verified manual testing: Hovering over the Editor button now displays the "Editor" label.
- [x] `npm run build` passed successfully.
- [x] `npm run lint` passed (ran `prettier` on modified files).
- [x] `npm run check` passed for the editor module.
  > **Note:** `npm run check` fails globally with `TS2688` (missing `vite/client` types) for multiple modules in the current environment. This seems unrelated to this specific feature branch.

## Screenshots
<img width="1919" height="964" alt="image" src="https://github.com/user-attachments/assets/83e790cd-d578-4704-a859-ac124f99a18d" />
