### PR TITLE
Implement Sidebar Auto-Scroll and Fix Dependency

### DIFF
--- a/modules/masonry/package.json
+++ b/modules/masonry/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@react-aria/dnd": "^3.10.1",
     "@react-stately/dnd": "^3.6.0",
+    "lodash.clonedeep": "^4.5.0",
     "recoil": "^0.7.7",
     "uuid": "^10.0.0"
   },

--- a/modules/masonry/src/palette/components/brickListPanel.tsx
+++ b/modules/masonry/src/palette/components/brickListPanel.tsx
@@ -20,6 +20,7 @@ interface BrickListPanelProps {
   onModeChange: (mode: PaletteMode) => void;
   onClose: () => void;
   onCategoryInView?: (categoryId: string) => void;
+  containerRef?: React.RefObject<HTMLDivElement | null>;
 }
 
 const bricks: BrickConfig[] = (bricksData as BrickConfig[]).map((b) => ({
@@ -104,9 +105,11 @@ const BrickListPanel: React.FC<BrickListPanelProps> = ({
   onModeChange,
   onClose,
   onCategoryInView,
+  containerRef,
 }) => {
   const [searchQuery, setSearchQuery] = useState(query);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const localContainerRef = useRef<HTMLDivElement>(null);
+  const effectiveContainerRef = containerRef || localContainerRef;
   const observerRef = useRef<IntersectionObserver | null>(null);
   const [selectedBrick, setSelectedBrick] = useState<BrickConfig | null>(null);
   const [isDetailView, setIsDetailView] = useState(false);
@@ -129,13 +132,13 @@ const BrickListPanel: React.FC<BrickListPanelProps> = ({
 
   const handleScroll = useCallback(() => {}, []);
   useEffect(() => {
-    const container = containerRef.current;
+    const container = effectiveContainerRef.current;
     if (!container) return;
     return () => {};
   }, []);
 
   useEffect(() => {
-    const container = containerRef.current;
+    const container = effectiveContainerRef.current;
     if (!container) return;
 
     const observer = new IntersectionObserver(
@@ -170,7 +173,7 @@ const BrickListPanel: React.FC<BrickListPanelProps> = ({
   }, [categoryId, onCategoryInView]);
 
   useEffect(() => {
-    const container = containerRef.current;
+    const container = effectiveContainerRef.current;
     const observer = observerRef.current;
     if (!container || !observer) return;
 
@@ -329,7 +332,7 @@ const BrickListPanel: React.FC<BrickListPanelProps> = ({
           aria-label="Search bricks"
         />
       </div>
-      <div className="brick-list" ref={containerRef}>
+      <div className="brick-list" ref={effectiveContainerRef}>
         {Object.entries(groupedBricks).map(
           ([category, categoryBricks]: [string, BrickConfig[]]) => (
             <div key={category} className="brick-category" data-category={category}>

--- a/modules/masonry/src/palette/components/paletteWrapper.tsx
+++ b/modules/masonry/src/palette/components/paletteWrapper.tsx
@@ -10,17 +10,39 @@ const PaletteWrapper: React.FC = () => {
   const [query, setQuery] = useState<string>('');
   const prevSelectedCategory = useRef<string>('RHYTHM');
   const isCategoryChangeFromScroll = useRef(false);
+  const brickListContainerRef = useRef<HTMLDivElement>(null);
 
   const handleCategorySelect = useCallback((categoryId: string) => {
-    if (!isCategoryChangeFromScroll.current) {
-      setSelectedCategory(categoryId);
+    // Always update the selected category
+    setSelectedCategory(categoryId);
+    
+    // Set flag to true BEFORE scrolling to ignore IntersectionObserver events
+    isCategoryChangeFromScroll.current = true;
+    
+    // Scroll to the selected category section
+    if (brickListContainerRef.current) {
+      const categoryElement = brickListContainerRef.current.querySelector(
+        `[data-category="${categoryId}"]`
+      );
+      if (categoryElement) {
+        categoryElement.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start',
+        });
+      }
     }
-    isCategoryChangeFromScroll.current = false;
+    
+    // Reset flag after scroll animation completes (smooth scroll takes ~500ms)
+    setTimeout(() => {
+      isCategoryChangeFromScroll.current = false;
+    }, 600);
   }, []);
 
   const handleCategoryInView = useCallback((categoryId: string) => {
-    isCategoryChangeFromScroll.current = true;
-    setSelectedCategory(categoryId);
+    // Only update if this is a real scroll event (not from our programmatic scroll)
+    if (!isCategoryChangeFromScroll.current) {
+      setSelectedCategory(categoryId);
+    }
   }, []);
 
   const handleModeChange = useCallback((mode: PaletteMode) => {
@@ -70,6 +92,7 @@ const PaletteWrapper: React.FC = () => {
           onModeChange={handleModeChange}
           onClose={() => {}}
           onCategoryInView={handleCategoryInView}
+          containerRef={brickListContainerRef}
         />
       </div>
     </>

--- a/package-lock.json
+++ b/package-lock.json
@@ -181,6 +181,7 @@
       "dependencies": {
         "@react-aria/dnd": "^3.10.1",
         "@react-stately/dnd": "^3.6.0",
+        "lodash.clonedeep": "^4.5.0",
         "recoil": "^0.7.7",
         "uuid": "^10.0.0"
       },


### PR DESCRIPTION
### Overview

This PR improves navigation UX in the brick selector panel by adding auto-scroll functionality and resolves a critical dependency issue to ensure project stability.

### Changes

* **Auto-Scroll Logic:** Clicking a sidebar category (e.g., **Rhythm**, **Meter**, **Pitch**) now automatically scrolls the brick list panel to the corresponding section.
* **UI/UX Improvement:** Reduced manual scrolling time, allowing for faster access to specific musical blocks like "Intervals" or "Tone."
* **Dependency Fix:** Updated and resolved issues with `lodash.clonedeep": "^4.5.0"` to ensure the project compiles and runs correctly across environments.

Improvement Video: 

https://github.com/user-attachments/assets/94387724-058b-4103-988f-eb5bc918a21b

