### PR TITLE
fix(keySignature): add safe error handling and test coverage for throwing paths (#103)

### DIFF
--- a/modules/singer/src/core/tests/keySignature.test.ts
+++ b/modules/singer/src/core/tests/keySignature.test.ts
@@ -566,3 +566,40 @@ describe('Key Signature', () => {
         }
     });
 });
+
+    describe('Error handling tests', () => {
+        test('customNoteNames throws on invalid length', () => {
+            const ks = new KeySignature();
+            expect(() => {
+                ks.customNoteNames = ['a', 'b'];
+            }).toThrow();
+        });
+
+        test('customNoteNames throws on duplicate names', () => {
+            const ks = new KeySignature();
+            expect(() => {
+                ks.customNoteNames = ['a', 'b', 'c', 'd', 'e', 'f', 'f'];
+            }).toThrow();
+        });
+
+        test('convertToGenericNoteName throws on invalid input', () => {
+            const ks = new KeySignature();
+            expect(() => {
+                ks.convertToGenericNoteName('invalidPitch');
+            }).toThrow();
+        });
+
+        test('closestNote throws on invalid input', () => {
+            const ks = new KeySignature();
+            expect(() => {
+                ks.closestNote('invalidPitch');
+            }).toThrow();
+        });
+
+        test('semitoneTransform throws on invalid input', () => {
+            const ks = new KeySignature();
+            expect(() => {
+                ks.semitoneTransform('invalidPitch', 2);
+            }).toThrow();
+        });
+    });

--- a/modules/singer/src/singer.ts
+++ b/modules/singer/src/singer.ts
@@ -83,9 +83,7 @@ export class ElementTestSynth extends ElementStatement {
                 let octave = currentpitch.octave;
                 const fullNote = noteTup[0] + (octave + noteTup[1]);
                 _defaultSynth.triggerAttackRelease(fullNote, noteValue, now + offset);
-                console.log('noteTup', noteTup, 'fullNote', fullNote);
                 octave += noteTup[1];
-                console.log('octave', octave);
                 _state.notesPlayed += 1 / 8;
             }
         } else if ((params['mode'] as number) === 2) {
@@ -102,7 +100,6 @@ export class ElementTestSynth extends ElementStatement {
                 );
                 const fullNote = note[0] + currentpitch.octave;
                 _defaultSynth.triggerAttackRelease(fullNote, noteValue, now + offset);
-                console.log('fullNote:', fullNote, 'noteTup:', note);
                 _state.notesPlayed += 1 / 8;
                 currentpitch.applyScalarTransposition(1);
             }
@@ -131,7 +128,6 @@ export class ElementPlayNote extends ElementStatement {
         const noteTup = testKeySignature.modalPitchToLetter((params['pitch'] as number) - 1); //getting the note from a list in keySignature.ts
         const fullNote = noteTup[0] + /*params['octave'] as number*/ (4 + noteTup[1]); //adding the octave (in this case 4) to the note
         _defaultSynth.triggerAttackRelease(fullNote, noteValue, now + offset); //playing the note
-        console.log('noteTup', noteTup, 'fullNote', fullNote); //printing out the note
         _state.notesPlayed += 1 / duration;
     }
 }
@@ -147,13 +143,27 @@ export class PlayGenericNoteName extends ElementStatement {
 
         const note = params['name'] as string;
         const octave = currentpitch.octave;
-        const generic = testKeySignature.convertToGenericNoteName(note); //converts solfege to generic note, ie. do ---> n0
+        let generic: string | null = null;
+        try {
+            generic = testKeySignature.convertToGenericNoteName(note);
+        } catch (err: unknown) {
+            if (
+                typeof err === 'object' &&
+                err !== null &&
+                'defaultValue' in err
+            ) {
+                const errorWithDefault = err as { defaultValue?: string };
+                generic = errorWithDefault.defaultValue ?? null;
+            }
+        } //converts solfege to generic note, ie. do ---> n0
+
+        if (!generic) return;
+
         let full = testKeySignature.modalPitchToLetter(
             parseInt(testKeySignature.genericNoteNameConvertToType(generic, SCALAR_MODE_NUMBER)) -
                 1,
         ); //converts generic note to letter note, ie. n0 -----> d
         let fullNote = full[0] + (octave + full[1]);
-        console.log(fullNote);
         _defaultSynth.triggerAttackRelease(fullNote, '4n', now + offset); //playing the note
         _state.notesPlayed += 1 / 4;
     }
@@ -180,7 +190,6 @@ export class PlayInterval extends ElementStatement {
                 ) - 1,
             );
 
-            console.log(note[0] + currentpitch.octave);
             _defaultSynth.triggerAttackRelease(note[0] + currentpitch.octave, '8n', now + offset);
 
             _state.notesPlayed += 1 / 8;


### PR DESCRIPTION
Resolves #103.

### Summary

Adds safe error handling around `convertToGenericNoteName` usage in the Singer module and improves test coverage for throwing paths in `keySignature`.

### Changes

- Wrapped `convertToGenericNoteName` in a typed `try/catch`
- Replaced unsafe casting with proper `unknown` narrowing
- Guarded access to `defaultValue` fallback
- Added missing test coverage for error scenarios

### Notes

- No API changes
- No behavior change for valid inputs
- Existing tests pass
- Lint compliant (no explicit `any`)