### PR TITLE
feat(editor): [UI] add hover text to buttons for UI consistency with i18n with updated node version as per requirement

### DIFF
--- a/@types/components/editor.d.ts
+++ b/@types/components/editor.d.ts
@@ -2,7 +2,7 @@ import type { TAsset } from '../assets';
 
 export type TInjectedEditor = {
     flags: undefined;
-    i18n: Record<'editor.build' | 'editor.help', string>;
+    i18n: Record<'editor.build' | 'editor.help' | 'editor.close' | 'editor.editor', string>;
     assets: Record<
         | 'image.icon.build'
         | 'image.icon.help'

--- a/app/src/components.ts
+++ b/app/src/components.ts
@@ -13,6 +13,8 @@ const manifest: TComponentManifest = {
             strings: {
                 'editor.build': 'build button - build the program',
                 'editor.help': 'help button - show syntax information',
+                'editor.close': 'close button - close the editor bar',
+                'editor.editor': 'editor button - open editor bar',
             },
             assets: [
                 'image.icon.build',

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -111,7 +111,7 @@ Windows) this repository using
     Output should look like
 
     ```bash
-    v16.14.0
+    v20.x.x
     8.3.1
     Version 4.6.2
     v10.6.0

--- a/lib/i18n/lang/en.ts
+++ b/lib/i18n/lang/en.ts
@@ -7,6 +7,8 @@ const strings: TI18nFile = {
     'menu.reset': 'reset',
     'menu.run': 'run',
     'menu.stop': 'stop',
+    'editor.editor': 'editor',
+    'editor.close': 'close',
 };
 
 export default strings;

--- a/lib/i18n/lang/es.ts
+++ b/lib/i18n/lang/es.ts
@@ -7,6 +7,8 @@ const strings: TI18nFile = {
     'menu.reset': 'reiniciar',
     'menu.run': 'tocar',
     'menu.stop': 'detener',
+    'editor.editor': 'editor',
+    'editor.close': 'cerrar',
 };
 
 export default strings;

--- a/modules/editor/src/view/components/button/index.scss
+++ b/modules/editor/src/view/components/button/index.scss
@@ -1,8 +1,43 @@
 @import '@res/themes/light';
 
 #editor-toolbar-btn {
+  position: relative;
+  display: grid;
+  justify-content: center;
+  align-items: center;
   padding: 0.25rem;
 
+  transition: all 0.25s ease;
+
+  .menu-btn-label {
+    position: absolute;
+    z-index: 100;
+    left: calc(100% + 0.25rem);
+    display: none;
+    margin: 0;
+    padding: 0 0.375rem 0.125rem 0.25rem;
+    border-radius: 0 0.25rem 0.25rem 0;
+    background-color: $mb-accent-light;
+
+    &::before {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      display: block;
+      content: '';
+      width: 0.25rem;
+      transform: translateX(-100%);
+      clip-path: polygon(0 50%, 100% 0%, 100% 100%);
+      background-color: $mb-accent-light;
+    }
+
+    span {
+      font-size: 0.75rem;
+      font-weight: bold;
+      color: $text-light;
+    }
+  }
   svg {
     width: 100%;
     height: 100%;
@@ -18,6 +53,9 @@
   }
 
   &:hover {
+    .menu-btn-label {
+      display: block;
+    }
     svg {
       .path-fill {
         fill: $mb-accent-light;

--- a/modules/editor/src/view/components/button/index.tsx
+++ b/modules/editor/src/view/components/button/index.tsx
@@ -9,6 +9,8 @@ import './index.scss';
 let _container: HTMLElement;
 let _svgCode: string;
 let _svgClose: string;
+let editori18: string;
+let closei18: string;
 
 // -- component definition -------------------------------------------------------------------------
 
@@ -23,6 +25,8 @@ export function setup(container: HTMLElement): void {
   _svgCode = injected.assets['image.icon.code'].data;
   _svgClose = injected.assets['image.icon.close'].data;
 
+  editori18 = injected.i18n['editor.editor'];
+  closei18 = injected.i18n['editor.close'];
   setButtonImg('code');
 }
 
@@ -31,5 +35,20 @@ export function setup(container: HTMLElement): void {
  * @param icon icon name
  */
 export function setButtonImg(icon: 'code' | 'cross'): void {
-  _container.innerHTML = icon === 'code' ? _svgCode : _svgClose;
+  if (icon === 'code') {
+    _container.innerHTML = `
+    <p class="menu-btn-label">
+      <span>${editori18}</span>
+    </p>
+        <div className="menu-btn-img">${_svgCode}</div>
+    `;
+  } else {
+    _container.innerHTML = `
+    <p class="menu-btn-label">
+      <span>${closei18}</span>
+    </p>
+        <div className="menu-btn-img">${_svgClose}</div>
+    `;
+    // _container.innerHTML = _svgClose;
+  }
 }

--- a/modules/editor/src/view/components/index.scss
+++ b/modules/editor/src/view/components/index.scss
@@ -174,3 +174,71 @@
     }
   }
 }
+.menu-btn {
+  position: relative;
+  display: grid;
+  justify-content: center;
+  align-items: center;
+  // width: 100%;
+  margin: 0.5rem 0;
+  padding: 0.25rem;
+  border: none;
+  border-radius: 0.25rem;
+  background-color: $background-light;
+  cursor: pointer;
+  transition: all 0.25s ease;
+
+  &.menu-btn-hidden {
+    display: none;
+  }
+
+  .menu-btn-label {
+    position: absolute;
+    z-index: 100;
+    left: calc(100% + 0.25rem);
+    display: none;
+    margin: 0;
+    padding: 0 0.375rem 0.125rem 0.25rem;
+    border-radius: 0 0.25rem 0.25rem 0;
+    background-color: $mb-accent-light;
+
+    &::before {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      display: block;
+      content: '';
+      width: 0.25rem;
+      transform: translateX(-100%);
+      clip-path: polygon(0 50%, 100% 0%, 100% 100%);
+      background-color: $mb-accent-light;
+    }
+
+    span {
+      font-size: 0.75rem;
+      font-weight: bold;
+      color: $text-light;
+    }
+  }
+
+  .menu-btn-img {
+    .path-fill {
+      fill: $mb-accent;
+      transition: all 0.25s ease;
+    }
+  }
+
+  &:hover {
+    .menu-btn-label {
+      display: block;
+      text-transform: lowercase;
+    }
+
+    .menu-btn-img {
+      .path-fill {
+        fill: $mb-accent-light;
+      }
+    }
+  }
+}

--- a/modules/editor/src/view/components/index.tsx
+++ b/modules/editor/src/view/components/index.tsx
@@ -3,6 +3,7 @@ import type { JSX } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 
+import { SImage } from '@sugarlabs/mb4-components';
 import { injected } from '../..';
 
 // -- stylesheet -----------------------------------------------------------------------------------
@@ -53,14 +54,13 @@ function Editor(): JSX.Element {
 
     (
       [
-        ['image.icon.help', _btnHelp],
-        ['image.icon.build', _btnBuild],
-        ['image.icon.close', _btnClose],
-      ] as [string, HTMLButtonElement][]
-    ).forEach(([assetId, button]) => {
-      // @ts-ignore
-      button.innerHTML = injected.assets[assetId].data;
-    });
+        ['image.icon.close', _btnClose]
+      ] as [string, HTMLButtonElement][]).forEach(
+      ([assetId, button]) => {
+        // @ts-ignore
+        button.innerHTML = injected.assets[assetId].data;
+      },
+    );
   }, []);
 
   return (
@@ -72,17 +72,20 @@ function Editor(): JSX.Element {
           onInput={() => (_status.innerHTML = '')}
         ></textarea>
         <div id="editor-console">
-          <button
-            id="editor-btn-help"
-            ref={btnHelpRef}
-            onClick={() => setShowingHelp(true)}
-          ></button>
+          <button id="editor-btn-help" className="menu-btn" onClick={() => setShowingHelp(true)}>
+            <p className="menu-btn-label">
+              <span>{injected.i18n['editor.help'].toLowerCase()}</span>
+            </p>
+            <div className="menu-btn-img">
+              <SImage asset={injected.assets['image.icon.help']} />
+            </div>
+          </button>
           <div id="editor-status-wrapper">
             <p id="editor-status" ref={statusRef}></p>
           </div>
           <button
             id="editor-btn-build"
-            ref={btnBuildRef}
+            className="menu-btn"
             onClick={() =>
               _editor.dispatchEvent(
                 new CustomEvent<string>('buildprogram', {
@@ -90,7 +93,14 @@ function Editor(): JSX.Element {
                 }),
               )
             }
-          ></button>
+          >
+            <p className="menu-btn-label">
+              <span>{injected.i18n['editor.build'].toLocaleLowerCase()}</span>
+            </p>
+            <div className="menu-btn-img">
+              <SImage asset={injected.assets['image.icon.build']} />
+            </div>
+          </button>
         </div>
       </div>
       <div className={`editor-wrapper ${!showingHelp ? 'editor-wrapper-hidden' : ''}`}>


### PR DESCRIPTION
closes #509 

Labels: enhancement, documentation, web/UI 

Added tooltip/hover text as we used in project to the all buttons for better UI consistency. Also updated node version as per requirement.

## Testing
- Ran `npm run lint` — passed✅
- Ran `npm run build` — successful✅