### PR TITLE
docs: fix redirected Git download link in DEV.md

### DIFF
--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -55,7 +55,7 @@ machine.
 
 2. Open a terminal and navigate to working directory (where the source code will reside).
 
-3. _Git Clone_ (additional [installation](https://git-scm.com/downloads) of _Git_ required on
+3. _Git Clone_ (additional [installation](https://git-scm.com/downloads/) of _Git_ required on
 Windows) this repository using
 
     ```bash


### PR DESCRIPTION
While running the lint checks locally, I noticed that the Git download link in docs/DEV.md redirects.

The link:
https://git-scm.com/downloads

redirects to:
https://git-scm.com/downloads/

I updated the URL to include the trailing slash so it points directly to the correct page and avoids the redirect reported by markdownlint.