### PR TITLE
docs: fix broken Music Blocks guide link in Masonry design document

### DIFF
--- a/modules/masonry/docs/functional-specification/Masonry_Design_Document.md
+++ b/modules/masonry/docs/functional-specification/Masonry_Design_Document.md
@@ -76,7 +76,7 @@
    - Non-functional requirements: Performance, scalability, maintainability.
 
 2. **Wiki Storages**
-   - [Link to project documentation](https://github.com/sugarlabs/musicblocks/blob/master/guide/README.md)
+   - [Link to project documentation](https://github.com/sugarlabs/musicblocks/blob/master/README.md)
 
 3. **Docs and Responsible Entities**
    - Documentation maintained by project contributors.


### PR DESCRIPTION
While running the lint checks locally, I noticed that one of the links in the Masonry design document was pointing to a page that no longer exists.

The link:
https://github.com/sugarlabs/musicblocks/blob/master/guide/README.md

returns a 404 error.

I updated it to the correct page:
https://github.com/sugarlabs/musicblocks/blob/master/README.md

So the documentation points to a valid reference.