### PR TITLE
feat(common): add WIconButton component

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@sugarlabs:registry=https://npm.pkg.github.com

--- a/lib/components/src/WIconButton/index.tsx
+++ b/lib/components/src/WIconButton/index.tsx
@@ -3,7 +3,7 @@ import type { TAsset } from '#/@types/assets';
 
 // -- ui items -------------------------------------------------------------------------------------
 
-import { SImage } from '../..';
+import SImage from '../SImage';
 
 import './index.scss';
 


### PR DESCRIPTION
Hi @meganindya,

I have implemented the `WIconButton` component as requested in the issue. It supports 'big' and 'small' sizes and uses the `SImage` component.

Closes #272