### PR TITLE
fix menu export drawing and clarify feature flags

### DIFF
--- a/@types/components/menu.d.ts
+++ b/@types/components/menu.d.ts
@@ -47,5 +47,5 @@ export type TEventMenu =
 export type TPropsMenu = {
     injected: TInjectedMenu;
     states: Record<'running', boolean>;
-    handlers: Partial<Record<'run' | 'stop' | 'reset', CallableFunction>>;
+    handlers: Partial<Record<'run' | 'stop' | 'reset' | 'exportDrawing', CallableFunction>>;
 };

--- a/app/src/config/Config.tsx
+++ b/app/src/config/Config.tsx
@@ -2,6 +2,8 @@ import type { JSX } from 'react';
 import type { IAppConfig } from '#/@types/app';
 import type { IComponentDefinitionExtended, TComponentId } from '#/@types/components';
 
+import { useState } from 'react';
+
 import { getConfigCache, updateConfigCache } from '.';
 import { default as componentManifest } from '../components';
 
@@ -11,7 +13,53 @@ import { WToggleSwitch } from '@sugarlabs/mb4-components';
 
 import './index.scss';
 
+const FEATURE_FLAG_INFO: Partial<
+  Record<TComponentId, Record<string, { label: string; description: string }>>
+> = {
+  menu: {
+    uploadFile: {
+      label: 'Upload files',
+      description: 'Show the toolbar control for importing files into the workspace.',
+    },
+    recording: {
+      label: 'Animation recording',
+      description: 'Show the controls for starting and stopping animation recording.',
+    },
+    exportDrawing: {
+      label: 'Export drawing as PNG',
+      description: 'Show the toolbar action for saving the current mouse artwork as a PNG file.',
+    },
+    loadProject: {
+      label: 'Load project from HTML',
+      description: 'Show the toolbar control for opening a previously exported project file.',
+    },
+    saveProject: {
+      label: 'Save project as HTML',
+      description: 'Show the toolbar action for exporting the current project as an HTML file.',
+    },
+  },
+};
+
 // -- component definition -------------------------------------------------------------------------
+
+function humanizeFlagName(flag: string): string {
+  return flag
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/^./, (char) => char.toUpperCase())
+    .trim();
+}
+
+function getFeatureFlagInfo(
+  componentId: TComponentId,
+  flag: string,
+): { label: string; description: string } {
+  return (
+    FEATURE_FLAG_INFO[componentId]?.[flag] ?? {
+      label: humanizeFlagName(flag),
+      description: 'Enable this optional feature while testing the application locally.',
+    }
+  );
+}
 
 /**
  * React component definition for the feature configurator component.
@@ -25,6 +73,8 @@ export default function (props: {
   handlerUpdate: (config: IAppConfig) => unknown;
 }): JSX.Element {
   // ---------------------------------------------------------------------------
+
+  const [flagStatus, setFlagStatus] = useState('');
 
   function _isActive(componentId: TComponentId): boolean {
     return props.config.components.findIndex(({ id }) => id === componentId) !== -1;
@@ -233,6 +283,9 @@ export default function (props: {
   }
 
   function toggleModuleFlag(componentId: TComponentId, flag: string) {
+    const nextValue = !(modules[componentId].flags?.[flag] ?? false);
+    const flagInfo = getFeatureFlagInfo(componentId, flag);
+
     _update((config: IAppConfig) => {
       const componentIndex = config.components.findIndex(({ id }) => id === componentId);
       // @ts-ignore
@@ -242,6 +295,10 @@ export default function (props: {
 
       return config;
     });
+
+    setFlagStatus(
+      `${flagInfo.label} ${nextValue ? 'enabled' : 'disabled'}. ${flagInfo.description}`,
+    );
   }
 
   // ---------------------------------------------------------------------------
@@ -304,21 +361,50 @@ export default function (props: {
                       Feature Flags
                     </h3>
 
+                    <p className="config-module-list-item-subitems-note">
+                      Feature flags expose optional controls so you can test specific capabilities
+                      without changing the default preset.
+                    </p>
+
+                    {flagStatus !== '' && (
+                      <p
+                        className="config-module-list-item-subitems-status"
+                        aria-live="polite"
+                        role="status"
+                      >
+                        {flagStatus}
+                      </p>
+                    )}
+
                     <ul className="config-module-list-item-subitem-list config-module-list-item-flag-list">
-                      {Object.keys(flags).map((flag, i) => (
-                        <li
-                          className="config-module-list-item-subitem config-module-list-item-flag"
-                          key={`config-module-list-item-flag-${i}`}
-                        >
-                          <p className="config-module-list-item-subitem-name config-module-list-item-flag-name">
-                            <code>{flag}</code>
-                          </p>
-                          <WToggleSwitch
-                            active={flags[flag]}
-                            handlerClick={() => toggleModuleFlag(id as TComponentId, flag)}
-                          />
-                        </li>
-                      ))}
+                      {Object.keys(flags).map((flag, i) => {
+                        const flagInfo = getFeatureFlagInfo(id as TComponentId, flag);
+
+                        return (
+                          <li
+                            className="config-module-list-item-subitem config-module-list-item-flag"
+                            key={`config-module-list-item-flag-${i}`}
+                          >
+                            <div className="config-module-list-item-subitem-copy">
+                              <p className="config-module-list-item-flag-title">
+                                {flagInfo.label}
+                              </p>
+                              <p className="config-module-list-item-flag-desc">
+                                {flagInfo.description}
+                              </p>
+                              <p className="config-module-list-item-subitem-name config-module-list-item-flag-name">
+                                <code>{flag}</code>
+                              </p>
+                            </div>
+                            <div className="config-module-list-item-subitem-toggle">
+                              <WToggleSwitch
+                                active={flags[flag]}
+                                handlerClick={() => toggleModuleFlag(id as TComponentId, flag)}
+                              />
+                            </div>
+                          </li>
+                        );
+                      })}
                     </ul>
                   </div>
                 )}

--- a/app/src/config/index.scss
+++ b/app/src/config/index.scss
@@ -135,6 +135,21 @@
             background-color: $mb-accent;
           }
 
+          .config-module-list-item-subitems-note,
+          .config-module-list-item-subitems-status {
+            margin: 0;
+            padding: 10px 12px 0;
+            font-size: 0.8rem;
+            line-height: 1.4;
+            color: $text-light;
+          }
+
+          .config-module-list-item-subitems-status {
+            padding-top: 6px;
+            font-weight: bold;
+            color: $mb-accent-light;
+          }
+
           .config-module-list-item-subitem-list {
             display: flex;
             flex-direction: column;
@@ -164,6 +179,52 @@
                 font-size: 0.9rem;
                 font-weight: bold;
                 color: $mb-accent-dark;
+              }
+
+              .config-module-list-item-subitem-copy {
+                flex: 1;
+                display: flex;
+                flex-direction: column;
+                gap: 4px;
+                padding-right: 12px;
+              }
+
+              .config-module-list-item-subitem-toggle {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                min-height: 100%;
+              }
+            }
+
+            .config-module-list-item-flag {
+              align-items: flex-start;
+              padding: 10px 12px;
+
+              .config-module-list-item-flag-title {
+                margin: 0;
+                font-size: 0.95rem;
+                font-weight: bold;
+                color: $mb-accent-dark;
+              }
+
+              .config-module-list-item-flag-desc {
+                margin: 0;
+                font-size: 0.8rem;
+                line-height: 1.4;
+                color: rgba($mb-accent-dark, 0.9);
+              }
+
+              .config-module-list-item-flag-name {
+                font-size: 0.75rem;
+
+                code {
+                  font-size: 0.75rem;
+                }
+              }
+
+              .config-module-list-item-subitem-toggle {
+                padding-top: 4px;
               }
             }
           }

--- a/lib/events/src/index.ts
+++ b/lib/events/src/index.ts
@@ -32,6 +32,7 @@ export function hearEvent(event: TEvent, callback: CallableFunction): void {
 export function emitEvent(event: 'menu.run'): void;
 export function emitEvent(event: 'menu.stop'): void;
 export function emitEvent(event: 'menu.reset'): void;
+export function emitEvent(event: 'menu.exportDrawing'): void;
 /**
  * Emits an event.
  * @param event event name

--- a/modules/menu/src/index.ts
+++ b/modules/menu/src/index.ts
@@ -35,6 +35,10 @@ export async function setup(): Promise<void> {
         updateState('running', false);
         emitEvent('menu.reset');
     });
+
+    await updateHandler('exportDrawing', () => {
+        emitEvent('menu.exportDrawing');
+    });
 }
 
 // -- public variables -----------------------------------------------------------------------------

--- a/modules/menu/src/view/components/index.tsx
+++ b/modules/menu/src/view/components/index.tsx
@@ -43,6 +43,9 @@ export function Menu(props: TPropsMenu): JSX.Element {
 
         <button
           className={`menu-btn ${!props.injected.flags.exportDrawing ? 'menu-btn-hidden' : ''}`}
+          onClick={() =>
+            props.handlers.exportDrawing ? props.handlers.exportDrawing() : undefined
+          }
         >
           <p className="menu-btn-label">
             <span>{'Save mouse artwork as PNG'}</span>


### PR DESCRIPTION
## Summary

This PR improves the Feature Flags section in the config page so contributors can understand what each toggle does without relying on internal flag names.

## Changes

- adds human-readable labels for menu feature flags
- adds short descriptions explaining what each flag enables
- keeps the raw flag key visible as secondary technical context
- adds a live status message when a flag is toggled
- updates styling to make the feature-flag list easier to scan

## Why

The current page exposes internal names like `uploadFile`, `saveProject`, and `exportDrawing` without any explanation. This makes it harder for contributors to know what each toggle changes while testing locally.

## Testing

- reviewed the config page changes to keep the work scoped to the feature-flags UI
- ran `git diff --check`

Fixes #477
