### PR TITLE
feat(masonry): [brick] add outline-only path generator (newpath.ts)

### DIFF
--- a/modules/masonry/playground/App.tsx
+++ b/modules/masonry/playground/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import WorkspaceApp from './pages/Workspace/index';
+import WorkspaceApp from './pages/workspace/index';
 import CollisionDetection from '../src/collision-detection/CollisionDetection';
 
 export default function App() {

--- a/modules/masonry/src/@types/brick.d.ts
+++ b/modules/masonry/src/@types/brick.d.ts
@@ -65,7 +65,7 @@ export type TBrickRenderPropsCompound = TBrickRenderProps & {
     isFolded: boolean;
 };
 
-import { TConnectionPoints } from '../../tree/model/model';
+import { TConnectionPoints } from '../brick/view/utils/common';
 
 /**
  * @interface

--- a/modules/masonry/src/brick/model/model.ts
+++ b/modules/masonry/src/brick/model/model.ts
@@ -12,7 +12,7 @@ import type {
     IBrickCompound,
     TBrickRenderPropsCompound,
 } from '../../@types/brick';
-import type { TConnectionPoints as TCP } from '../../tree/model/model';
+import type { TConnectionPoints as TCP } from '../view/utils/common';
 import { generateBrickData } from '../utils/path';
 import type { TInputUnion } from '../utils/path';
 import { getLabelWidth } from '../utils/textMeasurement';

--- a/modules/masonry/src/brick/utils/newpath.ts
+++ b/modules/masonry/src/brick/utils/newpath.ts
@@ -1,0 +1,653 @@
+// newpath.ts — Brick SVG outline generation (geometry only, no rendering).
+// Mirrors generateBrickData from path.ts but takes an outline-only config:
+// properties that don't affect the SVG boundary (color, label text, tooltip,
+// icon, image, selector, addButton, variableArguments, etc.) are excluded.
+
+// -----------------Types------------------------
+
+export type Dimension = { w: number; h: number };
+export type Centroid = { x: number; y: number };
+
+// Argument count is derived from argumentDimensions.length (analogous to
+// bBoxArgs.length in path.ts) — there is no separate count property.
+export interface BrickOutlineConfig {
+    hasTopNotch: boolean;
+    hasBottomNotch: boolean;
+    // First-class outline property — NOT hard-coded to a particular brick type.
+    hasLeftNotch: boolean;
+    containsNesting: boolean;
+    nestingDimensions: Dimension[];
+    argumentDimensions: Dimension[];
+    labelWidth: number;
+    labelHeight: number;
+    secondaryLabel: boolean;
+    strokeWidth: number;
+}
+
+export interface BrickOutlineResult {
+    path: string;
+    boundingBox: Dimension;
+    connectionPoints: {
+        top?: Centroid;
+        right: Centroid[];
+        bottom?: Centroid;
+        left?: Centroid;
+        args?: Centroid[];
+        nested?: Centroid;
+    };
+}
+
+// -----------------Constants------------------------
+
+const CORNER_RADIUS = 4;
+const OFFSET_NOTCH_TOP = 4;
+const OFFSET_NOTCH_RIGHT = 4;
+const WIDTH_NOTCH_TOP = 10;
+const HEIGHT_NOTCH_RIGHT = 12;
+const OFFSET_NOTCH_BOTTOM = 4;
+const WIDTH_NOTCH_BOTTOM = 10;
+const OUTER_CORNER_RADIUS = 5;
+const CONN_NOTCH_WIDTH = 12;
+const MIN_NESTED_HEIGHT = 40;
+const MIN_LABEL_WIDTH = 40;
+const MIN_LABEL_HEIGHT = 20;
+
+// ------------------Notch generations-----------------------------
+
+// function for Top Notch generation
+function _generateNotchTop(): string[] {
+    return [
+        //
+        'v 2',
+        'h 10',
+        'v -2',
+    ];
+}
+
+// function for Bottom Notch generation
+function _generateNotchBottom(): string[] {
+    return [
+        //
+        'h -1',
+        'v 2',
+        'h -8',
+        'v -2',
+        'h -1',
+    ];
+}
+
+// function for Left Notch generation
+function _generateNotchLeft(): string[] {
+    return ['v -5', 'h -6', 'v 3', 'h -2', 'v -8', 'h 2', 'v 3', 'h 6', 'v -5'];
+}
+
+// function for Right Notch generation
+function _generateNotchRight(): string[] {
+    return ['v 4', 'h -4', 'v -3', 'h -4', 'v 10', 'h 4', 'v -3', 'h 4', 'v 4'];
+}
+
+// -----------------------Path Generation------------------------------
+
+// function to generate the top part of the svg
+function _generateTop(config: {
+    hasNotch: boolean;
+    hasArgs: boolean;
+    strokeWidth: number;
+    effectiveLabelWidth: number;
+}): string[] {
+    const { hasNotch, hasArgs, strokeWidth, effectiveLabelWidth } = config;
+
+    const variableTopWidth =
+        strokeWidth / 2 +
+        effectiveLabelWidth +
+        strokeWidth / 2 -
+        CORNER_RADIUS -
+        WIDTH_NOTCH_TOP -
+        OFFSET_NOTCH_TOP -
+        CORNER_RADIUS;
+
+    return [
+        `a ${CORNER_RADIUS} ${CORNER_RADIUS} 90 0 1 ${CORNER_RADIUS} -${CORNER_RADIUS}`,
+        `h ${OFFSET_NOTCH_TOP}`,
+        ...(hasNotch ? _generateNotchTop() : [`h ${WIDTH_NOTCH_TOP}`]),
+        `h ${variableTopWidth}`,
+        ...(hasArgs ? [`h ${OFFSET_NOTCH_RIGHT}`] : []),
+    ];
+}
+
+// function to generate the right part of the svg. Returns the path segments and
+// the total vertical distance traversed (needed by the left-edge generator).
+function _generateRight(config: {
+    hasArgs: boolean;
+    strokeWidth: number;
+    effectiveLabelHeight: number;
+    argumentDimensions: Dimension[];
+}): { path: string[]; vertical: number } {
+    const { hasArgs, strokeWidth, effectiveLabelHeight, argumentDimensions } = config;
+
+    const path: string[] = [];
+    let vertical = 0;
+
+    path.push(`a ${CORNER_RADIUS} ${CORNER_RADIUS} 90 0 1 ${CORNER_RADIUS} ${CORNER_RADIUS}`);
+    vertical += CORNER_RADIUS;
+
+    if (hasArgs) {
+        const requiredMinimum = strokeWidth / 2 + effectiveLabelHeight + strokeWidth / 2;
+        const argHeightsSum =
+            argumentDimensions.length > 0
+                ? argumentDimensions.reduce((sum, arg) => sum + arg.h, 0)
+                : 0;
+        const extra = Math.max(0, requiredMinimum - argHeightsSum);
+
+        for (let i = 0; i < argumentDimensions.length; i++) {
+            const argBox = argumentDimensions[i];
+
+            const fixedNotchHeight =
+                strokeWidth / 2 +
+                CORNER_RADIUS +
+                HEIGHT_NOTCH_RIGHT +
+                CORNER_RADIUS +
+                strokeWidth / 2;
+            const connectingBrickTransitions = CORNER_RADIUS + strokeWidth + CORNER_RADIUS;
+            const totalFixedHeight = fixedNotchHeight + connectingBrickTransitions;
+
+            const extraPerArg = extra / argumentDimensions.length;
+            const totalRequiredForThisArg = argBox.h + extraPerArg;
+            const variableLength = Math.max(0, totalRequiredForThisArg - totalFixedHeight);
+
+            path.push(..._generateNotchRight());
+            vertical += 4 + -3 + 10 + -3 + 4; // net 12 from notch path
+
+            if (variableLength > 0) {
+                path.push(`v ${variableLength.toFixed(2)}`);
+                vertical += variableLength;
+            }
+
+            if (i < argumentDimensions.length - 1) {
+                path.push(`v ${CORNER_RADIUS}`);
+                path.push(`v ${strokeWidth}`);
+                path.push(`v ${CORNER_RADIUS}`);
+                vertical += CORNER_RADIUS + strokeWidth + CORNER_RADIUS;
+            }
+        }
+    } else {
+        const totalHeight = strokeWidth / 2 + effectiveLabelHeight + strokeWidth / 2;
+        const rightEdge = Math.max(totalHeight - CORNER_RADIUS * 2, HEIGHT_NOTCH_RIGHT);
+        path.push(`v ${rightEdge.toFixed(2)}`);
+        vertical += rightEdge;
+    }
+
+    return { path, vertical };
+}
+
+// function to generate the nested path for compound (clamp) bricks
+function _generateNestedPath(config: {
+    nestingDimensions: Dimension[];
+    strokeWidth: number;
+    effectiveLabelWidth: number;
+    effectiveLabelHeight: number;
+    hasSecondaryLabel: boolean;
+}): string[] {
+    const {
+        nestingDimensions,
+        strokeWidth,
+        effectiveLabelWidth: _effectiveLabelWidth,
+        effectiveLabelHeight,
+        hasSecondaryLabel,
+    } = config;
+
+    let totalNestedHeight = 0;
+    for (let i = 0; i < nestingDimensions.length; i++) {
+        totalNestedHeight += nestingDimensions[i].h;
+    }
+    totalNestedHeight = Math.max(MIN_NESTED_HEIGHT, totalNestedHeight);
+
+    function _generateInnerLeft(): string[] {
+        const variableLength =
+            totalNestedHeight -
+            (strokeWidth / 2 + OUTER_CORNER_RADIUS + OUTER_CORNER_RADIUS + strokeWidth / 2);
+
+        return [
+            `a ${OUTER_CORNER_RADIUS} ${OUTER_CORNER_RADIUS} 90 0 0 -${OUTER_CORNER_RADIUS} ${CORNER_RADIUS}`,
+            `v ${Math.max(0, +variableLength.toFixed(2))}`,
+        ];
+    }
+
+    // Clamp bricks use a NARROW bottom foot (just wide enough to carry the
+    // connector notch for the brick below), not a full-width arm that closes the
+    // cavity. See the v3 "note value" clamp: wide top bar, short bottom foot.
+    // path.ts produces this with a local variableBottomWidth that stays 0.
+    const variableBottomWidth = 0;
+
+    let labelAreaHeight = 0;
+
+    // function to generate the nested bottom part of the svg
+    function _generateNestedBottom(): string[] {
+        const hasNotch = true; // nested bottom always has a notch
+
+        const variableWidth = variableBottomWidth + OFFSET_NOTCH_BOTTOM;
+
+        labelAreaHeight =
+            strokeWidth / 2 + effectiveLabelHeight + strokeWidth / 2 - CORNER_RADIUS * 2;
+
+        const variableOuterWidth = variableWidth + WIDTH_NOTCH_TOP - strokeWidth / 2;
+
+        return [
+            `a ${OUTER_CORNER_RADIUS} ${OUTER_CORNER_RADIUS} 90 0 0 ${OUTER_CORNER_RADIUS} ${OUTER_CORNER_RADIUS}`,
+            `h ${OFFSET_NOTCH_TOP}`,
+            ...(hasNotch ? _generateNotchTop() : [`h ${WIDTH_NOTCH_TOP}`]),
+            `h ${variableWidth}`,
+            `a ${CORNER_RADIUS} ${CORNER_RADIUS} 90 0 1 ${CORNER_RADIUS} ${CORNER_RADIUS}`,
+            ...(hasSecondaryLabel ? [`v ${labelAreaHeight}`] : ['v 4']),
+            `a ${CORNER_RADIUS} ${CORNER_RADIUS} 90 0 1 -${CORNER_RADIUS} ${CORNER_RADIUS}`,
+            `h -${variableOuterWidth - 2 * strokeWidth}`,
+            ...(hasNotch ? _generateNotchBottom() : [`h -${WIDTH_NOTCH_BOTTOM}`]),
+            `h -${OFFSET_NOTCH_BOTTOM}`,
+        ];
+    }
+
+    // function to generate the nested outer left part of the svg
+    function _generateNestedOuterLeft(): string[] {
+        const variableLength =
+            totalNestedHeight -
+            (strokeWidth / 2 + OUTER_CORNER_RADIUS + OUTER_CORNER_RADIUS + strokeWidth / 2);
+        return [
+            `a ${CORNER_RADIUS} ${CORNER_RADIUS} 90 0 1 -${CORNER_RADIUS} -${CORNER_RADIUS}`,
+            ...(hasSecondaryLabel ? [`v -${labelAreaHeight}`] : ['v -4']),
+            `v -${CORNER_RADIUS}`,
+            `v -${OUTER_CORNER_RADIUS}`,
+            `v -${Math.max(0, +variableLength.toFixed(2))}`,
+            `v -${CORNER_RADIUS}`,
+            `v -${CORNER_RADIUS}`,
+        ];
+    }
+
+    return [..._generateInnerLeft(), ..._generateNestedBottom(), ..._generateNestedOuterLeft()];
+}
+
+// function to generate the bottom part of the svg
+function _generateBottom(config: {
+    containsNesting: boolean;
+    hasNotch: boolean;
+    hasArgs: boolean;
+    strokeWidth: number;
+    effectiveLabelWidth: number;
+    effectiveLabelHeight: number;
+    hasSecondaryLabel: boolean;
+    nestingDimensions: Dimension[];
+}): string[] {
+    const {
+        containsNesting,
+        hasNotch,
+        hasArgs,
+        strokeWidth,
+        effectiveLabelWidth,
+        effectiveLabelHeight,
+        hasSecondaryLabel,
+        nestingDimensions,
+    } = config;
+
+    let variableBottomWidth: number;
+
+    if (containsNesting) {
+        variableBottomWidth =
+            Math.max(MIN_LABEL_WIDTH, effectiveLabelWidth) -
+            CORNER_RADIUS -
+            OFFSET_NOTCH_TOP -
+            WIDTH_NOTCH_TOP -
+            WIDTH_NOTCH_BOTTOM -
+            strokeWidth / 2;
+    } else {
+        variableBottomWidth =
+            strokeWidth / 2 +
+            Math.max(MIN_LABEL_WIDTH, effectiveLabelWidth) +
+            strokeWidth / 2 -
+            CORNER_RADIUS -
+            WIDTH_NOTCH_BOTTOM -
+            OFFSET_NOTCH_BOTTOM -
+            CORNER_RADIUS;
+    }
+
+    return [
+        `a ${CORNER_RADIUS} ${CORNER_RADIUS} 90 0 1 -${CORNER_RADIUS} ${CORNER_RADIUS}`,
+        ...(hasArgs ? ['h -4'] : ['h -0']),
+        `h -${variableBottomWidth}`,
+        ...(hasNotch ? _generateNotchBottom() : [`h -${WIDTH_NOTCH_BOTTOM}`]),
+        `h -${OFFSET_NOTCH_RIGHT}`,
+        ...(!containsNesting
+            ? [`a ${CORNER_RADIUS} ${CORNER_RADIUS} 90 0 1 -${CORNER_RADIUS} -${CORNER_RADIUS}`]
+            : _generateNestedPath({
+                  nestingDimensions,
+                  strokeWidth,
+                  effectiveLabelWidth,
+                  effectiveLabelHeight,
+                  hasSecondaryLabel,
+              })),
+    ];
+}
+
+// function to generate the left part of the svg
+function _generateLeft(config: { hasLeftNotch: boolean; rightVertical: number }): {
+    path: string[];
+    leftEdge: number;
+} {
+    const { hasLeftNotch, rightVertical } = config;
+
+    const path: string[] = [];
+
+    let leftEdge = rightVertical;
+
+    if (hasLeftNotch) {
+        leftEdge -= CONN_NOTCH_WIDTH + CORNER_RADIUS;
+        path.push(`v -${leftEdge}`);
+        path.push(..._generateNotchLeft());
+    } else {
+        leftEdge -= CORNER_RADIUS;
+        path.push(`v -${leftEdge.toFixed(2)}`);
+    }
+
+    return { path, leftEdge };
+}
+
+// -----------------------------------------------------------
+
+// function to generate the path based on the configuration
+function _generatePath(config: BrickOutlineConfig): {
+    path: string;
+    leftEdge: number;
+} {
+    const {
+        hasTopNotch,
+        hasBottomNotch,
+        hasLeftNotch,
+        containsNesting,
+        nestingDimensions,
+        argumentDimensions,
+        labelWidth,
+        labelHeight,
+        secondaryLabel,
+        strokeWidth,
+    } = config;
+
+    const effectiveLabelWidth = Math.max(MIN_LABEL_WIDTH, labelWidth);
+    const effectiveLabelHeight = Math.max(MIN_LABEL_HEIGHT, labelHeight);
+    const hasArgs = argumentDimensions.length > 0;
+
+    const top = _generateTop({
+        hasNotch: hasTopNotch,
+        hasArgs,
+        strokeWidth,
+        effectiveLabelWidth,
+    });
+
+    const rightResult = _generateRight({
+        hasArgs,
+        strokeWidth,
+        effectiveLabelHeight,
+        argumentDimensions,
+    });
+    const right = rightResult.path;
+    const rightVertical = rightResult.vertical;
+
+    const bottom = _generateBottom({
+        containsNesting,
+        hasNotch: hasBottomNotch,
+        hasArgs,
+        strokeWidth,
+        effectiveLabelWidth,
+        effectiveLabelHeight,
+        hasSecondaryLabel: secondaryLabel,
+        nestingDimensions: containsNesting ? nestingDimensions : [],
+    });
+
+    const leftResult = _generateLeft({
+        hasLeftNotch,
+        rightVertical,
+    });
+    const left = leftResult.path;
+    const leftEdge = leftResult.leftEdge;
+
+    const segments = [...top, ...right, ...bottom, ...left];
+
+    return {
+        path: ['m 0,0', ...segments].join(' '),
+        leftEdge,
+    };
+}
+
+// function to calculate the bounding box values
+function _getBoundingBox(config: BrickOutlineConfig): Dimension {
+    const {
+        hasLeftNotch,
+        containsNesting,
+        nestingDimensions,
+        argumentDimensions,
+        labelWidth,
+        labelHeight,
+        secondaryLabel,
+        strokeWidth,
+    } = config;
+
+    const hasArgs = argumentDimensions.length > 0;
+    const effectiveLabelWidth = Math.max(MIN_LABEL_WIDTH, labelWidth);
+    const effectiveLabelHeight = Math.max(MIN_LABEL_HEIGHT, labelHeight);
+
+    // Match variableTopWidth logic from _generateTop
+    const variableTopWidth =
+        strokeWidth / 2 +
+        effectiveLabelWidth +
+        strokeWidth / 2 -
+        CORNER_RADIUS -
+        WIDTH_NOTCH_TOP -
+        OFFSET_NOTCH_TOP -
+        CORNER_RADIUS;
+
+    const baseWidth = CORNER_RADIUS + OFFSET_NOTCH_TOP + WIDTH_NOTCH_TOP + variableTopWidth;
+
+    const width = hasArgs
+        ? baseWidth + OFFSET_NOTCH_RIGHT + CORNER_RADIUS + strokeWidth / 2 + (hasLeftNotch ? 7 : 0)
+        : baseWidth + CORNER_RADIUS + strokeWidth / 2;
+
+    const { vertical: rightVertical } = _generateRight({
+        hasArgs,
+        strokeWidth,
+        effectiveLabelHeight,
+        argumentDimensions,
+    });
+
+    let height =
+        rightVertical + CORNER_RADIUS + (hasLeftNotch ? strokeWidth / 2 - 1 : strokeWidth / 2);
+
+    if (containsNesting) {
+        const nestDims = nestingDimensions || [];
+        let nestingHeight =
+            nestDims.length > 0
+                ? nestDims.reduce((sum: number, box: Dimension) => sum + box.h, 0)
+                : 0;
+        nestingHeight = Math.max(nestingHeight, MIN_NESTED_HEIGHT);
+
+        const labelAreaHeight = secondaryLabel
+            ? strokeWidth / 2 + effectiveLabelHeight + strokeWidth / 2 - CORNER_RADIUS * 2
+            : 4;
+
+        const nestedTotal =
+            OUTER_CORNER_RADIUS +
+            (nestingHeight - (strokeWidth / 2 + OUTER_CORNER_RADIUS * 2 + strokeWidth / 2)) +
+            OUTER_CORNER_RADIUS +
+            CORNER_RADIUS +
+            labelAreaHeight +
+            CORNER_RADIUS;
+
+        height += nestedTotal;
+    }
+
+    return { w: width, h: height };
+}
+
+// functions to calculate coordinates of the connection points
+
+// Centroid calculation for Top Notch
+function _getTopCentroid(config: BrickOutlineConfig): Centroid | undefined {
+    if (!config.hasTopNotch) return undefined;
+    return {
+        x: CORNER_RADIUS + OFFSET_NOTCH_TOP + WIDTH_NOTCH_TOP / 2,
+        y: 1,
+    };
+}
+
+// Centroid calculation for Bottom Notch
+function _getBottomCentroid(
+    config: BrickOutlineConfig,
+    boundingBox: Dimension,
+): Centroid | undefined {
+    if (!config.hasBottomNotch) return undefined;
+
+    if (!config.containsNesting) {
+        return {
+            x: CORNER_RADIUS + OFFSET_NOTCH_BOTTOM + WIDTH_NOTCH_BOTTOM / 2,
+            y: boundingBox.h - 1,
+        };
+    }
+
+    return {
+        x:
+            CORNER_RADIUS +
+            OFFSET_NOTCH_TOP +
+            WIDTH_NOTCH_TOP / 2 +
+            OFFSET_NOTCH_BOTTOM +
+            WIDTH_NOTCH_BOTTOM / 2,
+        y: boundingBox.h - 1,
+    };
+}
+
+// Calculate centroids for right connector notches (one per argument)
+function _getRightCentroids(config: BrickOutlineConfig, boundingBox: Dimension): Centroid[] {
+    const { argumentDimensions, strokeWidth, labelHeight } = config;
+    if (argumentDimensions.length === 0) return [];
+
+    const centroids: Centroid[] = [];
+    const effectiveLabelHeight = Math.max(MIN_LABEL_HEIGHT, labelHeight);
+    const requiredMinimum = strokeWidth / 2 + effectiveLabelHeight + strokeWidth / 2;
+    const argHeightsSum =
+        argumentDimensions.length > 0 ? argumentDimensions.reduce((sum, arg) => sum + arg.h, 0) : 0;
+    const extra = Math.max(0, requiredMinimum - argHeightsSum);
+
+    let verticalOffset = CORNER_RADIUS; // top-right corner arc
+
+    for (let i = 0; i < argumentDimensions.length; i++) {
+        const extraPerArg = extra / argumentDimensions.length;
+        const argBox = argumentDimensions[i];
+
+        const fixedNotchHeight = 12; // v4 + v-3 + v10 + v-3 + v4
+
+        const variableLength = Math.max(
+            0,
+            argBox.h +
+                extraPerArg -
+                (strokeWidth / 2 +
+                    CORNER_RADIUS +
+                    HEIGHT_NOTCH_RIGHT +
+                    CORNER_RADIUS +
+                    strokeWidth / 2 +
+                    CORNER_RADIUS +
+                    strokeWidth +
+                    CORNER_RADIUS),
+        );
+
+        const centroidY = verticalOffset + 6; // middle of the v10 segment
+
+        centroids.push({
+            x: boundingBox.w - 5,
+            y: centroidY,
+        });
+
+        verticalOffset += fixedNotchHeight;
+
+        if (variableLength > 0) {
+            verticalOffset += variableLength;
+        }
+
+        if (i < argumentDimensions.length - 1) {
+            verticalOffset += CORNER_RADIUS + strokeWidth + CORNER_RADIUS;
+        }
+    }
+
+    return centroids;
+}
+
+// Calculate centroid for left connector notch
+function _getLeftCentroid(config: BrickOutlineConfig): Centroid | undefined {
+    if (!config.hasLeftNotch) return undefined;
+    return {
+        x: -7, // notch is made of h -6, h -2 → centre = -7
+        y: CORNER_RADIUS + CONN_NOTCH_WIDTH / 2,
+    };
+}
+
+function _getConnectionPoints(
+    config: BrickOutlineConfig,
+    boundingBox: Dimension,
+): {
+    top?: Centroid;
+    right: Centroid[];
+    bottom?: Centroid;
+    left?: Centroid;
+} {
+    return {
+        top: _getTopCentroid(config),
+        right: _getRightCentroids(config, boundingBox),
+        bottom: _getBottomCentroid(config, boundingBox),
+        left: _getLeftCentroid(config),
+    };
+}
+
+// single export function to return brick outline data
+export function generateBrickOutline(config: BrickOutlineConfig): BrickOutlineResult {
+    const { path } = _generatePath(config);
+    const boundingBox = _getBoundingBox(config);
+    const connectionPoints = _getConnectionPoints(config, boundingBox);
+
+    // Argument slot origins (for all configs with args)
+    let args: Centroid[] | undefined = undefined;
+    if (connectionPoints.right.length > 0) {
+        args = connectionPoints.right.map((pt) => ({
+            x: pt.x + OFFSET_NOTCH_RIGHT / 2 + CORNER_RADIUS,
+            y: pt.y - CORNER_RADIUS - HEIGHT_NOTCH_RIGHT / 2,
+        }));
+    }
+
+    // Nested region origin (for compound/clamp bricks)
+    let nested: Centroid | undefined = undefined;
+    if (config.containsNesting && connectionPoints.bottom) {
+        const nestDims = config.nestingDimensions || [];
+        let nestingHeight =
+            nestDims.length > 0
+                ? nestDims.reduce((sum: number, box: Dimension) => sum + box.h, 0)
+                : 0;
+        nestingHeight = Math.max(nestingHeight, MIN_NESTED_HEIGHT);
+        nestingHeight += CORNER_RADIUS + 2;
+
+        nested = {
+            x:
+                connectionPoints.bottom.x -
+                WIDTH_NOTCH_BOTTOM / 2 -
+                OFFSET_NOTCH_BOTTOM -
+                CORNER_RADIUS -
+                2, // strokeWidth offset
+            y: connectionPoints.bottom.y - CORNER_RADIUS * 2 - 4 - nestingHeight,
+        };
+    }
+
+    return {
+        path,
+        boundingBox,
+        connectionPoints: {
+            top: connectionPoints.top,
+            right: connectionPoints.right,
+            bottom: connectionPoints.bottom,
+            left: connectionPoints.left,
+            args,
+            nested,
+        },
+    };
+}

--- a/modules/masonry/src/brick/utils/spec/newpath.spec.ts
+++ b/modules/masonry/src/brick/utils/spec/newpath.spec.ts
@@ -1,0 +1,543 @@
+import { generateBrickOutline } from '../newpath';
+import type { BrickOutlineConfig, Dimension } from '../newpath';
+import { generateBrickData } from '../path';
+import type { TInputUnion } from '../path';
+
+// ---------------------------------------------------------------------------
+// Helper: parse an SVG path string and compute a bounding box from it.
+// (Copied from path.spec.ts for consistency.)
+// ---------------------------------------------------------------------------
+function calculatePathBoundingBox(pathString: string): { w: number; h: number } {
+    const pathData = pathString.trim().replace(/,/g, ' ').replace(/\s+/g, ' ');
+    const tokens = pathData.split(' ');
+
+    let currentX = 0;
+    let currentY = 0;
+    let minX = 0;
+    let minY = 0;
+    let maxX = 0;
+    let maxY = 0;
+
+    let i = 0;
+    while (i < tokens.length) {
+        const command = tokens[i];
+        if (command === 'm') {
+            currentX += parseFloat(tokens[i + 1]);
+            currentY += parseFloat(tokens[i + 2]);
+            i += 3;
+        } else if (command === 'M') {
+            currentX = parseFloat(tokens[i + 1]);
+            currentY = parseFloat(tokens[i + 2]);
+            i += 3;
+        } else if (command === 'h') {
+            currentX += parseFloat(tokens[i + 1]);
+            i += 2;
+        } else if (command === 'H') {
+            currentX = parseFloat(tokens[i + 1]);
+            i += 2;
+        } else if (command === 'v') {
+            currentY += parseFloat(tokens[i + 1]);
+            i += 2;
+        } else if (command === 'V') {
+            currentY = parseFloat(tokens[i + 1]);
+            i += 2;
+        } else if (command === 'a') {
+            if (i + 7 < tokens.length) {
+                currentX += parseFloat(tokens[i + 6]);
+                currentY += parseFloat(tokens[i + 7]);
+                i += 8;
+            } else {
+                i += 1;
+            }
+        } else if (command === 'A') {
+            if (i + 7 < tokens.length) {
+                currentX = parseFloat(tokens[i + 6]);
+                currentY = parseFloat(tokens[i + 7]);
+                i += 8;
+            } else {
+                i += 1;
+            }
+        } else if (command === 'z' || command === 'Z') {
+            i += 1;
+        } else if (!isNaN(parseFloat(command))) {
+            i += 1;
+        } else {
+            i += 1;
+        }
+        minX = Math.min(minX, currentX);
+        minY = Math.min(minY, currentY);
+        maxX = Math.max(maxX, currentX);
+        maxY = Math.max(maxY, currentY);
+    }
+
+    return { w: Math.abs(maxX - minX), h: Math.abs(maxY - minY) };
+}
+
+// ---------------------------------------------------------------------------
+// Equivalence test cases — same inputs expressed in both APIs.
+// ---------------------------------------------------------------------------
+
+type EquivalencePair = {
+    name: string;
+    oldInput: TInputUnion;
+    newInput: BrickOutlineConfig;
+};
+
+const equivalenceCases: EquivalencePair[] = [
+    {
+        name: 'Type1 – with top/bottom notch, one arg',
+        oldInput: {
+            type: 'type1',
+            strokeWidth: 2,
+            scaleFactor: 1,
+            bBoxLabel: { w: 20, h: 35 },
+            bBoxArgs: [{ w: 40, h: 35 }],
+            hasNotchAbove: true,
+            hasNotchBelow: true,
+        },
+        newInput: {
+            hasTopNotch: true,
+            hasBottomNotch: true,
+            hasLeftNotch: false,
+            containsNesting: false,
+            nestingDimensions: [],
+            argumentDimensions: [{ w: 40, h: 35 }],
+            labelWidth: 20,
+            labelHeight: 35,
+            secondaryLabel: false,
+            strokeWidth: 2,
+        },
+    },
+    {
+        name: 'Type1 – no args, large label',
+        oldInput: {
+            type: 'type1',
+            strokeWidth: 2,
+            scaleFactor: 1,
+            bBoxLabel: { w: 100, h: 0 },
+            bBoxArgs: [],
+            hasNotchAbove: true,
+            hasNotchBelow: true,
+        },
+        newInput: {
+            hasTopNotch: true,
+            hasBottomNotch: true,
+            hasLeftNotch: false,
+            containsNesting: false,
+            nestingDimensions: [],
+            argumentDimensions: [],
+            labelWidth: 100,
+            labelHeight: 0,
+            secondaryLabel: false,
+            strokeWidth: 2,
+        },
+    },
+    {
+        name: 'Type2 – left notch, one arg',
+        oldInput: {
+            type: 'type2',
+            strokeWidth: 2,
+            scaleFactor: 1,
+            bBoxLabel: { w: 150, h: 90 },
+            bBoxArgs: [{ w: 70, h: 45 }],
+        },
+        newInput: {
+            hasTopNotch: false,
+            hasBottomNotch: false,
+            hasLeftNotch: true,
+            containsNesting: false,
+            nestingDimensions: [],
+            argumentDimensions: [{ w: 70, h: 45 }],
+            labelWidth: 150,
+            labelHeight: 90,
+            secondaryLabel: false,
+            strokeWidth: 2,
+        },
+    },
+    {
+        name: 'Type2 – left notch, two args',
+        oldInput: {
+            type: 'type2',
+            strokeWidth: 2,
+            scaleFactor: 1,
+            bBoxLabel: { w: 60, h: 20 },
+            bBoxArgs: [
+                { w: 20, h: 40 },
+                { w: 20, h: 40 },
+            ],
+        },
+        newInput: {
+            hasTopNotch: false,
+            hasBottomNotch: false,
+            hasLeftNotch: true,
+            containsNesting: false,
+            nestingDimensions: [],
+            argumentDimensions: [
+                { w: 20, h: 40 },
+                { w: 20, h: 40 },
+            ],
+            labelWidth: 60,
+            labelHeight: 20,
+            secondaryLabel: false,
+            strokeWidth: 2,
+        },
+    },
+    {
+        name: 'Type3 – nesting, secondary label off',
+        oldInput: {
+            type: 'type3',
+            strokeWidth: 2,
+            scaleFactor: 1,
+            bBoxLabel: { w: 140, h: 50 },
+            bBoxArgs: [
+                { w: 50, h: 20 },
+                { w: 60, h: 15 },
+            ],
+            hasNotchAbove: true,
+            hasNotchBelow: false,
+            bBoxNesting: [
+                { w: 80, h: 40 },
+                { w: 100, h: 30 },
+            ],
+            secondaryLabel: false,
+        },
+        newInput: {
+            hasTopNotch: true,
+            hasBottomNotch: false,
+            hasLeftNotch: false,
+            containsNesting: true,
+            nestingDimensions: [
+                { w: 80, h: 40 },
+                { w: 100, h: 30 },
+            ],
+            argumentDimensions: [
+                { w: 50, h: 20 },
+                { w: 60, h: 15 },
+            ],
+            labelWidth: 140,
+            labelHeight: 50,
+            secondaryLabel: false,
+            strokeWidth: 2,
+        },
+    },
+    {
+        name: 'Type3 – nesting empty, secondary label on',
+        oldInput: {
+            type: 'type3',
+            strokeWidth: 2,
+            scaleFactor: 1,
+            bBoxLabel: { w: 100, h: 20 },
+            bBoxArgs: [
+                { w: 60, h: 40 },
+                { w: 60, h: 50 },
+            ],
+            hasNotchAbove: false,
+            hasNotchBelow: true,
+            bBoxNesting: [],
+            secondaryLabel: true,
+        },
+        newInput: {
+            hasTopNotch: false,
+            hasBottomNotch: true,
+            hasLeftNotch: false,
+            containsNesting: true,
+            nestingDimensions: [],
+            argumentDimensions: [
+                { w: 60, h: 40 },
+                { w: 60, h: 50 },
+            ],
+            labelWidth: 100,
+            labelHeight: 20,
+            secondaryLabel: true,
+            strokeWidth: 2,
+        },
+    },
+    {
+        name: 'Type3 – minimal sizes',
+        oldInput: {
+            type: 'type3',
+            strokeWidth: 2,
+            scaleFactor: 1,
+            bBoxLabel: { w: 0, h: 0 },
+            bBoxArgs: [{ w: 0, h: 20 }],
+            hasNotchAbove: true,
+            hasNotchBelow: true,
+            bBoxNesting: [{ w: 10, h: 10 }],
+            secondaryLabel: false,
+        },
+        newInput: {
+            hasTopNotch: true,
+            hasBottomNotch: true,
+            hasLeftNotch: false,
+            containsNesting: true,
+            nestingDimensions: [{ w: 10, h: 10 }],
+            argumentDimensions: [{ w: 0, h: 20 }],
+            labelWidth: 0,
+            labelHeight: 0,
+            secondaryLabel: false,
+            strokeWidth: 2,
+        },
+    },
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('newpath.ts — Brick Outline Generation', () => {
+    describe('Path equivalence with path.ts', () => {
+        equivalenceCases.forEach(({ name, oldInput, newInput }) => {
+            it(`produces identical SVG path: ${name}`, () => {
+                const oldResult = generateBrickData(oldInput);
+                const newResult = generateBrickOutline(newInput);
+                expect(newResult.path).toBe(oldResult.path);
+            });
+
+            it(`produces identical bounding box: ${name}`, () => {
+                const oldResult = generateBrickData(oldInput);
+                const newResult = generateBrickOutline(newInput);
+                expect(newResult.boundingBox.w).toBeCloseTo(oldResult.boundingBox.w, 2);
+                expect(newResult.boundingBox.h).toBeCloseTo(oldResult.boundingBox.h, 2);
+            });
+
+            it(`produces matching connection points: ${name}`, () => {
+                const oldResult = generateBrickData(oldInput);
+                const newResult = generateBrickOutline(newInput);
+
+                // top
+                if (oldResult.connectionPoints.top) {
+                    expect(newResult.connectionPoints.top).toBeDefined();
+                    expect(newResult.connectionPoints.top!.x).toBeCloseTo(
+                        oldResult.connectionPoints.top.x,
+                        2,
+                    );
+                    expect(newResult.connectionPoints.top!.y).toBeCloseTo(
+                        oldResult.connectionPoints.top.y,
+                        2,
+                    );
+                } else {
+                    expect(newResult.connectionPoints.top).toBeUndefined();
+                }
+
+                // bottom
+                if (oldResult.connectionPoints.bottom) {
+                    expect(newResult.connectionPoints.bottom).toBeDefined();
+                    expect(newResult.connectionPoints.bottom!.x).toBeCloseTo(
+                        oldResult.connectionPoints.bottom.x,
+                        2,
+                    );
+                    expect(newResult.connectionPoints.bottom!.y).toBeCloseTo(
+                        oldResult.connectionPoints.bottom.y,
+                        2,
+                    );
+                } else {
+                    expect(newResult.connectionPoints.bottom).toBeUndefined();
+                }
+
+                // left
+                if (oldResult.connectionPoints.left) {
+                    expect(newResult.connectionPoints.left).toBeDefined();
+                    expect(newResult.connectionPoints.left!.x).toBeCloseTo(
+                        oldResult.connectionPoints.left.x,
+                        2,
+                    );
+                    expect(newResult.connectionPoints.left!.y).toBeCloseTo(
+                        oldResult.connectionPoints.left.y,
+                        2,
+                    );
+                } else {
+                    expect(newResult.connectionPoints.left).toBeUndefined();
+                }
+
+                // right
+                expect(newResult.connectionPoints.right.length).toBe(
+                    oldResult.connectionPoints.right.length,
+                );
+                for (let i = 0; i < oldResult.connectionPoints.right.length; i++) {
+                    expect(newResult.connectionPoints.right[i].x).toBeCloseTo(
+                        oldResult.connectionPoints.right[i].x,
+                        2,
+                    );
+                    expect(newResult.connectionPoints.right[i].y).toBeCloseTo(
+                        oldResult.connectionPoints.right[i].y,
+                        2,
+                    );
+                }
+
+                // args
+                if (oldResult.connectionPoints.args) {
+                    expect(newResult.connectionPoints.args).toBeDefined();
+                    expect(newResult.connectionPoints.args!.length).toBe(
+                        oldResult.connectionPoints.args.length,
+                    );
+                    for (let i = 0; i < oldResult.connectionPoints.args.length; i++) {
+                        expect(newResult.connectionPoints.args![i].x).toBeCloseTo(
+                            oldResult.connectionPoints.args[i].x,
+                            2,
+                        );
+                        expect(newResult.connectionPoints.args![i].y).toBeCloseTo(
+                            oldResult.connectionPoints.args[i].y,
+                            2,
+                        );
+                    }
+                }
+
+                // nested
+                if (oldResult.connectionPoints.nested) {
+                    expect(newResult.connectionPoints.nested).toBeDefined();
+                    expect(newResult.connectionPoints.nested!.x).toBeCloseTo(
+                        oldResult.connectionPoints.nested.x,
+                        2,
+                    );
+                    expect(newResult.connectionPoints.nested!.y).toBeCloseTo(
+                        oldResult.connectionPoints.nested.y,
+                        2,
+                    );
+                }
+            });
+        });
+    });
+
+    describe('Bounding box matches actual path dimensions', () => {
+        equivalenceCases.forEach(({ name, newInput }) => {
+            it(`bbox ≈ path extent: ${name}`, () => {
+                const { path, boundingBox } = generateBrickOutline(newInput);
+                const actualBounds = calculatePathBoundingBox(path);
+                expect(Math.abs(boundingBox.w - actualBounds.w)).toBeLessThanOrEqual(1);
+                expect(Math.abs(boundingBox.h - actualBounds.h)).toBeLessThanOrEqual(1);
+            });
+        });
+    });
+
+    describe('Connection points within bounding box', () => {
+        equivalenceCases.forEach(({ name, newInput }) => {
+            it(`all points inside bbox: ${name}`, () => {
+                const { boundingBox, connectionPoints } = generateBrickOutline(newInput);
+
+                if (connectionPoints.top) {
+                    expect(connectionPoints.top.x).toBeGreaterThanOrEqual(0);
+                    expect(connectionPoints.top.x).toBeLessThanOrEqual(boundingBox.w);
+                    expect(connectionPoints.top.y).toBeGreaterThanOrEqual(0);
+                    expect(connectionPoints.top.y).toBeLessThanOrEqual(boundingBox.h);
+                }
+                if (connectionPoints.bottom) {
+                    expect(connectionPoints.bottom.x).toBeGreaterThanOrEqual(0);
+                    expect(connectionPoints.bottom.x).toBeLessThanOrEqual(boundingBox.w);
+                    expect(connectionPoints.bottom.y).toBeGreaterThanOrEqual(0);
+                    expect(connectionPoints.bottom.y).toBeLessThanOrEqual(boundingBox.h);
+                }
+                connectionPoints.right.forEach((pt) => {
+                    expect(pt.x).toBeGreaterThanOrEqual(0);
+                    expect(pt.x).toBeLessThanOrEqual(boundingBox.w);
+                    expect(pt.y).toBeGreaterThanOrEqual(0);
+                    expect(pt.y).toBeLessThanOrEqual(boundingBox.h);
+                });
+                if (connectionPoints.left) {
+                    expect(connectionPoints.left.y).toBeGreaterThanOrEqual(0);
+                    expect(connectionPoints.left.y).toBeLessThanOrEqual(boundingBox.h);
+                }
+            });
+        });
+    });
+
+    describe('Argument count derived from argumentDimensions.length', () => {
+        it('zero arguments → no right notches', () => {
+            const config: BrickOutlineConfig = {
+                hasTopNotch: true,
+                hasBottomNotch: true,
+                hasLeftNotch: false,
+                containsNesting: false,
+                nestingDimensions: [],
+                argumentDimensions: [],
+                labelWidth: 80,
+                labelHeight: 30,
+                secondaryLabel: false,
+                strokeWidth: 2,
+            };
+            const { connectionPoints } = generateBrickOutline(config);
+            expect(connectionPoints.right).toHaveLength(0);
+            expect(connectionPoints.args).toBeUndefined();
+        });
+
+        it('three arguments → three right notches', () => {
+            const config: BrickOutlineConfig = {
+                hasTopNotch: false,
+                hasBottomNotch: false,
+                hasLeftNotch: true,
+                containsNesting: false,
+                nestingDimensions: [],
+                argumentDimensions: [
+                    { w: 30, h: 25 },
+                    { w: 30, h: 25 },
+                    { w: 30, h: 25 },
+                ],
+                labelWidth: 120,
+                labelHeight: 60,
+                secondaryLabel: false,
+                strokeWidth: 2,
+            };
+            const { connectionPoints } = generateBrickOutline(config);
+            expect(connectionPoints.right).toHaveLength(3);
+            expect(connectionPoints.args).toHaveLength(3);
+        });
+    });
+
+    describe('Left notch is a first-class outline property', () => {
+        it('hasLeftNotch produces left centroid regardless of other flags', () => {
+            const config: BrickOutlineConfig = {
+                hasTopNotch: true,
+                hasBottomNotch: true,
+                hasLeftNotch: true,
+                containsNesting: false,
+                nestingDimensions: [],
+                argumentDimensions: [{ w: 40, h: 30 }],
+                labelWidth: 80,
+                labelHeight: 30,
+                secondaryLabel: false,
+                strokeWidth: 2,
+            };
+            const { connectionPoints } = generateBrickOutline(config);
+            expect(connectionPoints.left).toBeDefined();
+            expect(connectionPoints.left!.x).toBe(-7);
+        });
+
+        it('hasLeftNotch false → no left centroid', () => {
+            const config: BrickOutlineConfig = {
+                hasTopNotch: true,
+                hasBottomNotch: true,
+                hasLeftNotch: false,
+                containsNesting: false,
+                nestingDimensions: [],
+                argumentDimensions: [{ w: 40, h: 30 }],
+                labelWidth: 80,
+                labelHeight: 30,
+                secondaryLabel: false,
+                strokeWidth: 2,
+            };
+            const { connectionPoints } = generateBrickOutline(config);
+            expect(connectionPoints.left).toBeUndefined();
+        });
+    });
+
+    describe('Consistency', () => {
+        it('identical inputs produce identical outputs', () => {
+            const config: BrickOutlineConfig = {
+                hasTopNotch: true,
+                hasBottomNotch: true,
+                hasLeftNotch: false,
+                containsNesting: true,
+                nestingDimensions: [{ w: 50, h: 30 }],
+                argumentDimensions: [{ w: 40, h: 20 }],
+                labelWidth: 100,
+                labelHeight: 40,
+                secondaryLabel: true,
+                strokeWidth: 2,
+            };
+            const r1 = generateBrickOutline(config);
+            const r2 = generateBrickOutline(config);
+            expect(r1.path).toBe(r2.path);
+            expect(r1.boundingBox).toEqual(r2.boundingBox);
+            expect(r1.connectionPoints).toEqual(r2.connectionPoints);
+        });
+    });
+});

--- a/modules/masonry/src/brick/view/utils/common.ts
+++ b/modules/masonry/src/brick/view/utils/common.ts
@@ -2,7 +2,7 @@
  * Common utilities for brick view components
  */
 
-import type { TColor } from '../../@types/brick';
+import type { TColor } from '../../../@types/brick';
 
 export const FONT_HEIGHT = 16;
 
@@ -30,4 +30,6 @@ export type TConnectionPoints = {
     right: { x: number; y: number }[];
     bottom?: { x: number; y: number };
     left?: { x: number; y: number };
+    args?: { x: number; y: number }[];
+    nested?: { x: number; y: number };
 };


### PR DESCRIPTION
## What this does

Adds a new file `newpath.ts` that generates the SVG outline of a brick. It takes the same geometry approach as the existing `path.ts` but only deals with the outline of the brick, nothing else. The old `path.ts` is not touched at all.

## Why a new file

`path.ts` mixes the outline geometry with a type1/type2/type3 system. I wanted a cleaner version that only handles the outline, so that later on labels, icons, colours, selectors and tooltips can be drawn on top of it without touching the
geometry. Doing it in a separate file means there is zero risk of breaking the current path generation while this is being built.

## What goes into the config

Only the things that actually change the shape:

- hasTopNotch, hasBottomNotch, hasLeftNotch
- containsNesting, nestingDimensions
- argumentDimensions
- labelWidth, labelHeight
- secondaryLabel
- strokeWidth (this one affects spacing in the geometry, so it stays)

Left out on purpose because they belong to rendering, not the outline:

- color, fill, stroke, tooltip, labelType, labelSource, argumentLabels, selector, addButton, icon, image, variableArguments

## A few decisions worth noting

- Number of argument notches comes from `argumentDimensions.length`. There is no separate count property, same idea as `bBoxArgs.length` in the old file.
- `hasLeftNotch` is now a proper flag of its own. In the old code the left notch was tied to type2, here it is independent.

## Testing

Added `newpath.spec.ts` with 40 tests, all passing:

- Runs the same inputs through the new file and the old `path.ts` and checks the path string, bounding box and    connection points all match.
- Checks the bounding box matches the actual drawn path.
- Checks connection points stay inside the box, arg count is right, and the left notch behaves as expected.

To run it:

`npx vitest run src/brick/utils/spec/newpath.spec.ts`

Lint is clean too.

## Not done yet (on purpose)

- This file is not wired into the app. `model.ts` still uses `path.ts`, so nothing in the running app changes. Connecting it up is a separate step for later.
- Since the notch flags are independent now, some flag combinations that the old  type1/2/3 could not make are possible. Those new combinations are not tested or rendered yet.
