### PR TITLE
feat(masonry): make brick path outline stroke-width aware

### DIFF
--- a/modules/masonry/src/brick/utils/newPath.ts
+++ b/modules/masonry/src/brick/utils/newPath.ts
@@ -18,6 +18,12 @@ export interface BrickOutlineInput {
 }
 
 export interface BrickOutlineInput2 {
+    /**
+     * Stroke width of the outline. The outline is drawn inset by `strokeWidth / 2`
+     * so the stroke stays inside the reported width/height instead of being clipped.
+     * Pass 0 for no inset (original geometry).
+     */
+    strokeWidth: number;
     /** Dimensions of the main label text area */
     labelMainDims: Size;
     /** One entry per argument slot; each pairs a parameter label with its argument */
@@ -181,20 +187,30 @@ export function computeDimensions2(input: BrickOutlineInput2): ComputedDimension
     const params = input.paramArgDims.map((p) => p.param ?? { w: 0, h: MIN_PARAM_H });
     const args = input.paramArgDims.map((p) => p.arg ?? { w: 0, h: MIN_ARG_H });
 
+    const strokeWidth = input.strokeWidth;
+
     // ── Width ──
+    // Each content box reserves s/2 of stroke clearance on its left and right edges
+    // (s/2 + s/2 per box) so the inset outline's stroke is not clipped.
     const maxParamWidth = params.length > 0 ? Math.max(...params.map((p) => p.w)) : 0;
     const labelParamGutter = maxParamWidth > 0 ? LABEL_PARAM_GUTTER_X : 0;
     const headWidth =
-        HEAD_PAD_X1 + HEAD_PAD_X2 + input.labelMainDims.w + labelParamGutter + maxParamWidth;
+        strokeWidth / 2 +
+        HEAD_PAD_X1 + HEAD_PAD_X2 + input.labelMainDims.w + labelParamGutter + maxParamWidth +
+        strokeWidth / 2;
 
-    const tailWidth = TAIL_INDENT_W + (input.nestingDims?.w ?? 0);
+    const tailWidth =
+        strokeWidth / 2 + TAIL_INDENT_W + (input.nestingDims?.w ?? 0) + strokeWidth / 2;
 
     const width = Math.max(headWidth, tailWidth, MIN_WIDTH);
 
     // ── Height of head ──
     const paramsTotalHeight = params.reduce((sum, p) => sum + p.h, 0);
     const paramGutterTotal = PARAM_GUTTER_Y * Math.max(0, params.length - 1);
-    const argsTotalHeight = args.reduce((sum, a) => sum + a.h, 0);
+    // Reserve a strokeWidth gap between stacked args so adjacent arg bricks' strokes
+    // sit side by side without overlapping (mirrors the stroke spacing in path.ts).
+    const argGutterTotal = strokeWidth * Math.max(0, args.length - 1);
+    const argsTotalHeight = args.reduce((sum, a) => sum + a.h, 0) + argGutterTotal;
 
     const headHeight = Math.max(
         Math.max(input.labelMainDims.h, MIN_LABEL_MAIN_H) + HEAD_PAD_Y1 + HEAD_PAD_Y2,
@@ -207,9 +223,11 @@ export function computeDimensions2(input: BrickOutlineInput2): ComputedDimension
     const nestHeight = hasNesting ? Math.max(input.nestingDims?.h ?? 0, MIN_NEST_HEIGHT) : 0;
     const tailHeight = hasNesting ? nestHeight + TAIL_FOOT_H : 0;
 
-    const height = headHeight + tailHeight;
+    // Only the outer perimeter gains clearance: the head↔tail seam is interior, so
+    // strokeWidth is added once to the total (s/2 top + s/2 bottom), not to headHeight.
+    const height = headHeight + tailHeight + strokeWidth;
 
-    return { width, height, headHeight, nestHeight };
+    return { width, height, headHeight, nestHeight};
 }
 
 // ────────────────────────── Outline Generation ──────────────────────────
@@ -306,40 +324,47 @@ export function generateBrickOutline(input: BrickOutlineInput): BrickOutlineOutp
 
 // ────────────────────────── Path Segments ──────────────────────────
 
-function segTopEdge(width: number): string[] {
-    return [`m 0 0`, `h ${width}`];
+// The whole outline is inset by s/2: it starts at (s/2, s/2) and every full-span
+// edge is shortened by s (s/2 of clearance at each end).
+function segTopEdge(width: number, strokeWidth: number): string[] {
+    return [`m ${strokeWidth / 2} ${strokeWidth / 2}`, `h ${width - strokeWidth}`];
 }
 
+// The head's right edge runs from the top inset down to the cavity-roof seam.
+// Both ends shift down by s/2, so its length equals headHeight unchanged.
 function segHeadRight(headHeight: number): string[] {
     return [`v ${headHeight}`];
 }
 
-function segHeadBottom(width: number): string[] {
-    return [`h ${-width}`];
+function segHeadBottom(width: number, strokeWidth: number): string[] {
+    return [`h ${-(width - strokeWidth)}`];
 }
 
-function segLeftEdge(height: number): string[] {
-    return [`v ${-height}`];
+function segLeftEdge(height: number, strokeWidth: number): string[] {
+    return [`v ${-(height - strokeWidth)}`];
 }
 
-function segTailCavityRoof(width: number): string[] {
-    return [`h ${-(width - TAIL_INDENT_W)}`];
+// Tail edges keep their nominal feature sizes, but the concave cavity shrinks by
+// s/2 per wall (insetting the solid pushes its notch walls into the cavity): the
+// roof, spine and floor each move inward, and the freed s is absorbed by the foot.
+function segTailCavityRoof(width: number, strokeWidth: number): string[] {
+    return [`h ${-(width - TAIL_INDENT_W - strokeWidth)}`];
 }
 
-function segTailCavityLeft(nestHeight: number): string[] {
-    return [`v ${nestHeight}`];
+function segTailCavityLeft(nestHeight: number, strokeWidth: number): string[] {
+    return [`v ${nestHeight - strokeWidth}`];
 }
 
-function segTailFootStep(): string[] {
-    return [`h ${TAIL_FOOT_W - TAIL_INDENT_W}`];
+function segTailFootStep(strokeWidth: number): string[] {
+    return [`h ${TAIL_FOOT_W - TAIL_INDENT_W - strokeWidth}`];
 }
 
-function segTailFootRight(): string[] {
-    return [`v ${TAIL_FOOT_H}`];
+function segTailFootRight(strokeWidth: number): string[] {
+    return [`v ${TAIL_FOOT_H + strokeWidth}`];
 }
 
-function segTailBottom(): string[] {
-    return [`h ${-TAIL_FOOT_W}`];
+function segTailBottom(strokeWidth: number): string[] {
+    return [`h ${-(TAIL_FOOT_W - strokeWidth)}`];
 }
 
 function generateMarkers(
@@ -349,8 +374,11 @@ function generateMarkers(
     nestHeight: number,
     hasNesting: boolean,
 ): BrickOutlineOutput2['markers'] {
+    // Anchors are positioned relative to the now-inset outline: distances from the
+    // top/left edges gain s/2, and the right edge sits at (width - s/2).
+    const s = input.strokeWidth;
     const mainLabelRect = [
-        `M ${HEAD_PAD_X1} ${HEAD_PAD_Y1}`,
+        `M ${HEAD_PAD_X1 + s / 2} ${HEAD_PAD_Y1 + s / 2}`,
         `h ${input.labelMainDims.w}`,
         `v ${input.labelMainDims.h}`,
         `h ${-input.labelMainDims.w}`,
@@ -360,11 +388,14 @@ function generateMarkers(
     let nestingRect: string | undefined;
     if (hasNesting) {
         const nestingW = input.nestingDims?.w ?? 0;
+        // The nested child is its own brick with stroke s. Inset its outline a full s
+        // inside the parent's cavity outline (s/2 for the parent stroke + s/2 for the
+        // child stroke) so the two strokes sit adjacent without ever overlapping.
         nestingRect = [
-            `M ${TAIL_INDENT_W} ${headHeight}`,
-            `h ${nestingW}`,
-            `v ${nestHeight}`,
-            `h ${-nestingW}`,
+            `M ${TAIL_INDENT_W + 1.5 * s} ${headHeight + 1.5 * s}`,
+            `h ${nestingW - s}`,
+            `v ${nestHeight - 3 * s}`,
+            `h ${-(nestingW - s)}`,
             'Z',
         ].join(' ');
     }
@@ -377,20 +408,27 @@ function generateMarkers(
         const rowH = arg?.h ?? MIN_ARG_H;
 
         if (arg !== null) {
+            // Each arg is its own brick with stroke s, sitting to the right of the
+            // parent. Place its outline at width + s/2 so the arg's stroke edge meets
+            // the parent's outer stroke edge (x = width) — adjacent, never overlapping.
             argRectList.push(
-                [`M ${width} ${y}`, `h ${arg.w}`, `v ${arg.h}`, `h ${-arg.w}`, 'Z'].join(' '),
+                [`M ${width + s / 2} ${y + s / 2}`, `h ${arg.w}`, `v ${arg.h}`, `h ${-arg.w}`, 'Z'].join(
+                    ' ',
+                ),
             );
         }
 
         if (param !== null) {
-            const paramY = y + (rowH - param.h) / 2;
-            const x = width - HEAD_PAD_X2 - param.w;
+            const paramY = y + (rowH - param.h) / 2 + s / 2;
+            const x = width - s / 2 - HEAD_PAD_X2 - param.w;
             paramRects.push(
                 [`M ${x} ${paramY}`, `h ${param.w}`, `v ${param.h}`, `h ${-param.w}`, 'Z'].join(' '),
             );
         }
 
-        y += rowH;
+        // Advance past this row plus the strokeWidth gap reserved between arg bricks
+        // (matches argGutterTotal in computeDimensions2).
+        y += rowH + s;
     }
 
     return {
@@ -414,24 +452,25 @@ export function generateBrickOutline2(
 ): BrickOutlineOutput2 {
     const { width, height, headHeight, nestHeight } = computeDimensions2(input);
     const hasNesting = input.nestingDims !== undefined;
+    const s = input.strokeWidth;
 
     const segments = !hasNesting
         ? [
-              ...segTopEdge(width),
+              ...segTopEdge(width, s),
               ...segHeadRight(headHeight),
-              ...segHeadBottom(width),
-              ...segLeftEdge(headHeight),
+              ...segHeadBottom(width, s),
+              ...segLeftEdge(height, s),
               'z',
           ]
         : [
-              ...segTopEdge(width),
+              ...segTopEdge(width, s),
               ...segHeadRight(headHeight),
-              ...segTailCavityRoof(width),
-              ...segTailCavityLeft(nestHeight),
-              ...segTailFootStep(),
-              ...segTailFootRight(),
-              ...segTailBottom(),
-              ...segLeftEdge(height),
+              ...segTailCavityRoof(width, s),
+              ...segTailCavityLeft(nestHeight, s),
+              ...segTailFootStep(s),
+              ...segTailFootRight(s),
+              ...segTailBottom(s),
+              ...segLeftEdge(height, s),
               'z',
           ];
 

--- a/modules/masonry/src/brick/utils/spec/newPath.spec.ts
+++ b/modules/masonry/src/brick/utils/spec/newPath.spec.ts
@@ -1,5 +1,10 @@
-import { generateBrickOutline, computeDimensions } from '../newPath';
-import type { BrickOutlineInput } from '../newPath';
+import {
+    generateBrickOutline,
+    computeDimensions,
+    generateBrickOutline2,
+    computeDimensions2,
+} from '../newPath';
+import type { BrickOutlineInput, BrickOutlineInput2 } from '../newPath';
 
 // ────────────────────────── Helpers ──────────────────────────
 
@@ -433,5 +438,390 @@ describe('newPath: computeDimensions', () => {
         // topBarWidth = 8 + 20 + 8 = 36
         // width = max(100, 36, 224) = 224
         expect(dims.width).toBe(224);
+    });
+});
+
+// ══════════════════════ V2: stroke-width-aware path ══════════════════════
+
+// ────────────────────────── Helpers ──────────────────────────
+
+interface RelSeg {
+    cmd: 'm' | 'h' | 'v' | 'z';
+    /** signed length for h/v; undefined for m/z */
+    len?: number;
+}
+
+/**
+ * Parse a relative SVG path (lowercase m/h/v + z) into its segments.
+ * The leading `m dx dy` only positions the start, so it is recorded as a single
+ * `m` with no length; `h`/`v` carry their signed relative displacement.
+ */
+function parseRelPath(path: string): RelSeg[] {
+    const tokens = path.trim().split(/\s+/);
+    const segs: RelSeg[] = [];
+    let i = 0;
+    while (i < tokens.length) {
+        const cmd = tokens[i];
+        if (cmd === 'm') {
+            segs.push({ cmd: 'm' });
+            i += 3; // m dx dy
+        } else if (cmd === 'h' || cmd === 'v') {
+            segs.push({ cmd, len: parseFloat(tokens[i + 1]) });
+            i += 2;
+        } else if (cmd === 'z' || cmd === 'Z') {
+            segs.push({ cmd: 'z' });
+            i += 1;
+        } else {
+            i += 1;
+        }
+    }
+    return segs;
+}
+
+/** Net horizontal / vertical displacement of all h/v segments (should be 0 for a closed loop). */
+function netDisplacement(path: string): { dx: number; dy: number } {
+    let dx = 0;
+    let dy = 0;
+    for (const seg of parseRelPath(path)) {
+        if (seg.cmd === 'h') dx += seg.len!;
+        if (seg.cmd === 'v') dy += seg.len!;
+    }
+    return { dx, dy };
+}
+
+// ────────────────────────── Constants (mirrored for assertions) ──────────────────────────
+
+const MIN_LABEL_MAIN_H = 20;
+const MIN_NEST_HEIGHT = 40;
+const MIN_ARG_H = 40;
+const HEAD_PAD = 10; // X1/X2/Y1/Y2 all 10
+const LABEL_PARAM_GUTTER_X = 10;
+const PARAM_GUTTER_Y = 10;
+const TAIL_INDENT_W = 10;
+const TAIL_FOOT_H = 10;
+const TAIL_FOOT_W = 40;
+
+// ────────────────────────── computeDimensions2 ──────────────────────────
+
+describe('path V2: computeDimensions2', () => {
+    describe('width', () => {
+        it('main label dominates (no stroke)', () => {
+            const dims = computeDimensions2({
+                strokeWidth: 0,
+                labelMainDims: { w: 200, h: 30 },
+                paramArgDims: [],
+            });
+            // headWidth = 0 + 20 + 200 = 220 ; tailWidth = 10 ; width = max(220,10,100)
+            expect(dims.width).toBe(220);
+        });
+
+        it('MIN_WIDTH dominates a small brick (no stroke)', () => {
+            const dims = computeDimensions2({
+                strokeWidth: 0,
+                labelMainDims: { w: 30, h: 10 },
+                paramArgDims: [],
+            });
+            // headWidth = 20 + 30 = 50 ; width = max(50,10,100) = 100
+            expect(dims.width).toBe(MIN_WIDTH);
+        });
+
+        it('adds s/2 + s/2 of stroke clearance to the head when the head dominates', () => {
+            const s = 4;
+            const dims = computeDimensions2({
+                strokeWidth: s,
+                labelMainDims: { w: 200, h: 30 },
+                paramArgDims: [],
+            });
+            // headWidth = s + 20 + 200 = 224
+            expect(dims.width).toBe(224);
+        });
+
+        it('does NOT add stroke clearance when MIN_WIDTH wins (documents the s-smaller edge case)', () => {
+            const s = 4;
+            const dims = computeDimensions2({
+                strokeWidth: s,
+                labelMainDims: { w: 30, h: 10 },
+                paramArgDims: [],
+            });
+            // headWidth = s + 20 + 30 = 54 ; tailWidth = s + 10 = 14 ; width = max(54,14,100) = 100
+            // NOTE: the original `max(...) + s` formula would give 104. MIN_WIDTH never gets +s.
+            expect(dims.width).toBe(MIN_WIDTH);
+        });
+
+        it('widens for the widest param plus the label gutter', () => {
+            const dims = computeDimensions2({
+                strokeWidth: 0,
+                labelMainDims: { w: 60, h: 20 },
+                paramArgDims: [
+                    { param: { w: 40, h: 15 }, arg: null },
+                    { param: { w: 30, h: 25 }, arg: null },
+                ],
+            });
+            // headWidth = 0 + 20 + 60 + 10(gutter) + 40(maxParam) = 130
+            expect(dims.width).toBe(130);
+        });
+
+        it('tail (nesting) can drive the width', () => {
+            const dims = computeDimensions2({
+                strokeWidth: 0,
+                labelMainDims: { w: 20, h: 10 },
+                paramArgDims: [],
+                nestingDims: { w: 200, h: 50 },
+            });
+            // tailWidth = 0 + 10 + 200 = 210 ; width = max(30,210,100) = 210
+            expect(dims.width).toBe(210);
+        });
+    });
+
+    describe('height', () => {
+        it('falls back to the main-label minimum height', () => {
+            const dims = computeDimensions2({
+                strokeWidth: 0,
+                labelMainDims: { w: 60, h: 10 },
+                paramArgDims: [],
+            });
+            // headHeight = max(max(10,20)+20, 20, 0) = 40 ; no tail ; +s = 0
+            expect(dims.headHeight).toBe(40);
+            expect(dims.height).toBe(40);
+            expect(dims.nestHeight).toBe(0);
+        });
+
+        it('stacked null-arg rows drive head height via MIN_ARG_H', () => {
+            const dims = computeDimensions2({
+                strokeWidth: 0,
+                labelMainDims: { w: 60, h: 20 },
+                paramArgDims: [
+                    { param: { w: 40, h: 15 }, arg: null },
+                    { param: { w: 30, h: 25 }, arg: null },
+                ],
+            });
+            // argsTotalHeight = MIN_ARG_H + MIN_ARG_H + 0(gutter, s=0) = 80
+            expect(dims.headHeight).toBe(2 * MIN_ARG_H);
+        });
+
+        it('adds strokeWidth once to the total height (top + bottom margin)', () => {
+            const s = 6;
+            const dims = computeDimensions2({
+                strokeWidth: s,
+                labelMainDims: { w: 60, h: 30 },
+                paramArgDims: [],
+            });
+            // headHeight = max(30,20)+20 = 50 ; height = 50 + 0 + s
+            expect(dims.headHeight).toBe(50);
+            expect(dims.height).toBe(50 + s);
+        });
+
+        it('compound brick height = headHeight + nestHeight + foot + s', () => {
+            const s = 4;
+            const dims = computeDimensions2({
+                strokeWidth: s,
+                labelMainDims: { w: 80, h: 20 },
+                paramArgDims: [],
+                nestingDims: { w: 50, h: 50 },
+            });
+            expect(dims.headHeight).toBe(40); // max(20,20)+20
+            expect(dims.nestHeight).toBe(50); // max(50,40)
+            // height = 40 + (50 + 10) + 4
+            expect(dims.height).toBe(40 + 50 + TAIL_FOOT_H + s);
+        });
+
+        it('enforces the minimum nesting height', () => {
+            const dims = computeDimensions2({
+                strokeWidth: 0,
+                labelMainDims: { w: 80, h: 20 },
+                paramArgDims: [],
+                nestingDims: { w: 50, h: 5 },
+            });
+            expect(dims.nestHeight).toBe(MIN_NEST_HEIGHT);
+        });
+
+        it('reserves a strokeWidth gutter between stacked arg bricks', () => {
+            const s = 4;
+            const dims = computeDimensions2({
+                strokeWidth: s,
+                labelMainDims: { w: 60, h: 20 },
+                paramArgDims: [
+                    { param: null, arg: { w: 50, h: 30 } },
+                    { param: null, arg: { w: 50, h: 30 } },
+                ],
+            });
+            // argsTotalHeight = 30 + 30 + s*(2-1) = 64 ; headHeight = max(40, 20, 64) = 64
+            expect(dims.headHeight).toBe(30 + 30 + s);
+        });
+    });
+});
+
+// ────────────────────────── generateBrickOutline2 ──────────────────────────
+
+describe('path V2: generateBrickOutline2', () => {
+    it('simple brick path with no stroke', () => {
+        const result = generateBrickOutline2({
+            strokeWidth: 0,
+            labelMainDims: { w: 60, h: 20 },
+            paramArgDims: [],
+        });
+        // width = 100 (MIN_WIDTH), headHeight = 40, height = 40
+        expect(result.path).toBe('m 0 0 h 100 v 40 h -100 v -40 z');
+        expect(result.width).toBe(100);
+        expect(result.height).toBe(40);
+    });
+
+    it('simple brick path inset by s/2 with stroke', () => {
+        const result = generateBrickOutline2({
+            strokeWidth: 4,
+            labelMainDims: { w: 200, h: 30 },
+            paramArgDims: [],
+        });
+        // width = 224, headHeight = 50, height = 54
+        // top edge: m 2 2, h (224-4)=220 ; right v 50 ; bottom h -220 ; left v -(54-4)=-50
+        expect(result.path).toBe('m 2 2 h 220 v 50 h -220 v -50 z');
+        expect(result.width).toBe(224);
+        expect(result.height).toBe(54);
+    });
+
+    it('compound brick path with no stroke', () => {
+        const result = generateBrickOutline2({
+            strokeWidth: 0,
+            labelMainDims: { w: 80, h: 20 },
+            paramArgDims: [],
+            nestingDims: { w: 50, h: 50 },
+        });
+        // width=100, headHeight=40, nestHeight=50, height=100
+        expect(result.path).toBe('m 0 0 h 100 v 40 h -90 v 50 h 30 v 10 h -40 v -100 z');
+    });
+
+    it('compound brick path with stroke (cavity −s, foot +s)', () => {
+        const result = generateBrickOutline2({
+            strokeWidth: 4,
+            labelMainDims: { w: 80, h: 20 },
+            paramArgDims: [],
+            nestingDims: { w: 50, h: 50 },
+        });
+        // width=104, headHeight=40, nestHeight=50, height=104
+        // roof: -(104-10-4)=-90 ; spine: 50-4=46 ; footStep: 40-10-4=26 ; footRight: 10+4=14 ; bottom: -(40-4)=-36
+        expect(result.path).toBe('m 2 2 h 100 v 40 h -90 v 46 h 26 v 14 h -36 v -100 z');
+    });
+
+    describe('well-formedness: the outline is a closed loop (net displacement = 0)', () => {
+        const inputs: { name: string; input: BrickOutlineInput2 }[] = [
+            {
+                name: 'simple, s=0',
+                input: { strokeWidth: 0, labelMainDims: { w: 60, h: 20 }, paramArgDims: [] },
+            },
+            {
+                name: 'simple, s=4',
+                input: { strokeWidth: 4, labelMainDims: { w: 200, h: 30 }, paramArgDims: [] },
+            },
+            {
+                name: 'compound, s=0',
+                input: {
+                    strokeWidth: 0,
+                    labelMainDims: { w: 80, h: 20 },
+                    paramArgDims: [],
+                    nestingDims: { w: 50, h: 50 },
+                },
+            },
+            {
+                name: 'compound, s=4',
+                input: {
+                    strokeWidth: 4,
+                    labelMainDims: { w: 80, h: 20 },
+                    paramArgDims: [],
+                    nestingDims: { w: 50, h: 50 },
+                },
+            },
+        ];
+
+        inputs.forEach(({ name, input }) => {
+            it(`closes for ${name}`, () => {
+                const { dx, dy } = netDisplacement(generateBrickOutline2(input).path);
+                expect(dx).toBe(0);
+                expect(dy).toBe(0);
+            });
+        });
+    });
+
+    describe('s = 0 reduces to the original (stroke terms vanish)', () => {
+        it('width has no stroke contribution at s=0', () => {
+            const input: BrickOutlineInput2 = {
+                strokeWidth: 0,
+                labelMainDims: { w: 120, h: 30 },
+                paramArgDims: [{ param: { w: 40, h: 18 }, arg: null }],
+            };
+            const dims = computeDimensions2(input);
+            const headWidth = 2 * HEAD_PAD + 120 + LABEL_PARAM_GUTTER_X + 40;
+            expect(dims.width).toBe(Math.max(headWidth, TAIL_INDENT_W, MIN_WIDTH));
+        });
+
+        it('path starts at the origin (no inset) when s=0', () => {
+            const { path } = generateBrickOutline2({
+                strokeWidth: 0,
+                labelMainDims: { w: 60, h: 20 },
+                paramArgDims: [],
+            });
+            expect(path.startsWith('m 0 0')).toBe(true);
+        });
+    });
+
+    describe('markers', () => {
+        it('omits markers unless requested', () => {
+            const result = generateBrickOutline2({
+                strokeWidth: 0,
+                labelMainDims: { w: 60, h: 20 },
+                paramArgDims: [],
+            });
+            expect(result.markers).toBeUndefined();
+        });
+
+        it('emits the requested marker regions', () => {
+            const result = generateBrickOutline2(
+                {
+                    strokeWidth: 0,
+                    labelMainDims: { w: 60, h: 20 },
+                    paramArgDims: [{ param: { w: 40, h: 15 }, arg: { w: 50, h: 30 } }],
+                    nestingDims: { w: 50, h: 50 },
+                },
+                true,
+            );
+            expect(result.markers).toBeDefined();
+            expect(result.markers!.labelMain).toBeTruthy();
+            expect(result.markers!.labelParams).toHaveLength(1);
+            expect(result.markers!.args).toHaveLength(1);
+            expect(result.markers!.nesting).toBeTruthy();
+        });
+    });
+});
+
+// ────────────────────────── Validity boundary (geometric fit / well-formedness) ──────────────────────────
+
+describe('path V2: validity boundaries (documented, not yet enforced)', () => {
+    /**
+     * The fixed-size tail features invert once the stroke exceeds them. The foot step
+     * (TAIL_FOOT_W - TAIL_INDENT_W = 30) is the first to go negative, so the outline
+     * stops being well-formed at s >= 30.
+     */
+    it('the foot-step segment goes negative once s exceeds TAIL_FOOT_W - TAIL_INDENT_W', () => {
+        const footStepLen = (s: number) => TAIL_FOOT_W - TAIL_INDENT_W - s;
+        expect(footStepLen(29)).toBeGreaterThan(0);
+        expect(footStepLen(30)).toBe(0);
+        expect(footStepLen(31)).toBeLessThan(0);
+    });
+
+    /**
+     * The stroke inset shrinks the cavity interior to (nestHeight - s), so nested
+     * content of height h only fits while nestHeight - s >= h.
+     */
+    it('cavity interior shrinks by s below the computed nestHeight', () => {
+        const s = 4;
+        const dims = computeDimensions2({
+            strokeWidth: s,
+            labelMainDims: { w: 80, h: 20 },
+            paramArgDims: [],
+            nestingDims: { w: 50, h: 50 },
+        });
+        const cavityInterior = dims.nestHeight - s;
+        expect(cavityInterior).toBe(50 - s);
+        // Content of height 50 no longer fits inside the inset cavity (50 - 4 = 46 < 50).
+        expect(cavityInterior).toBeLessThan(50);
     });
 });

--- a/modules/masonry/src/brick/view/components/Path.tsx
+++ b/modules/masonry/src/brick/view/components/Path.tsx
@@ -3,28 +3,43 @@ import { generateBrickOutline2, type BrickOutlineInput2 } from '../../utils/newP
 export function PathBrickView({ input }: { input: BrickOutlineInput2 }) {
   const maxArgW = Math.max(0, ...input.paramArgDims.map((p) => p.arg?.w ?? 0));
   const { width, height, path, markers } = generateBrickOutline2(input, true);
+  const s = input.strokeWidth ?? 0;
 
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width={width + maxArgW}
+      width={width + maxArgW + s}
       height={height}
-      viewBox={`0 0 ${width + maxArgW} ${height}`}
+      viewBox={`0 0 ${width + maxArgW + s} ${height}`}
       style={{ backgroundColor: '#eee' }}
     >
-      <path d={path} fill="#aaa" />
+      {/* Outer brick: grey fill, grey stroke */}
+      <path d={path} fill="#bbb" stroke="#555" strokeWidth={s} />
 
       {markers && (
         <>
+          {/* Main label (interior content) */}
           <path d={markers?.labelMain} fill="#00f" />
 
+          {/* Param labels (interior content) */}
           {markers?.labelParams?.map((d, i) => <path key={i} d={d} fill="#ff0" />)}
 
+          {/* Each arg is its own brick: filled with its colour (inside reference) plus a
+              darker stroke, so it reads as a distinct brick not overlapping the parent. */}
           {markers?.args?.map((d, i) => (
-            <path key={i} d={d} fill={i % 2 === 0 ? '#f80' : '#f0f'} />
+            <path
+              key={i}
+              d={d}
+              fill={i % 2 === 0 ? '#f80' : '#f0f'}
+              stroke={i % 2 === 0 ? '#a50' : '#a0a'}
+              strokeWidth={s}
+            />
           ))}
 
-          <path d={markers?.nesting} fill="#0f0" />
+          {/* Nested child brick: green fill (inside reference) with a darker green stroke */}
+          {markers?.nesting && (
+            <path d={markers.nesting} fill="#0f0" stroke="#070" strokeWidth={s} />
+          )}
         </>
       )}
     </svg>

--- a/modules/masonry/src/brick/view/stories/Path.stories.tsx
+++ b/modules/masonry/src/brick/view/stories/Path.stories.tsx
@@ -18,6 +18,7 @@ type Story = StoryObj<typeof PathBrickView>;
 export const JustLabel: Story = {
   args: {
     input: {
+      strokeWidth: 4,
       labelMainDims: { w: 120, h: 20 },
       paramArgDims: [],
     },
@@ -27,6 +28,7 @@ export const JustLabel: Story = {
 export const LabelArgNoParam: Story = {
   args: {
     input: {
+      strokeWidth: 4,
       labelMainDims: { w: 120, h: 20 },
       paramArgDims: [{ param: null, arg: { w: 100, h: 40 } }],
     },
@@ -36,6 +38,7 @@ export const LabelArgNoParam: Story = {
 export const LabelArgWithParam: Story = {
   args: {
     input: {
+      strokeWidth: 4,
       labelMainDims: { w: 120, h: 20 },
       paramArgDims: [{ param: { w: 80, h: 15 }, arg: { w: 100, h: 40 } }],
     },
@@ -45,6 +48,7 @@ export const LabelArgWithParam: Story = {
 export const LabelMixedParamArgs: Story = {
   args: {
     input: {
+      strokeWidth: 4,
       labelMainDims: { w: 120, h: 20 },
       paramArgDims: [
         { param: { w: 100, h: 15 }, arg: { w: 100, h: 40 } },
@@ -58,7 +62,8 @@ export const LabelMixedParamArgs: Story = {
 
 // ── Nesting variants (label + 2 args each with their param) ──
 
-const nestingBase: Pick<BrickOutlineInput2, 'labelMainDims' | 'paramArgDims'> = {
+const nestingBase: Pick<BrickOutlineInput2, 'strokeWidth' | 'labelMainDims' | 'paramArgDims'> = {
+  strokeWidth: 4,
   labelMainDims: { w: 120, h: 20 },
   paramArgDims: [
     { param: { w: 80, h: 15 }, arg: { w: 100, h: 40 } },


### PR DESCRIPTION
Builds on the path generator from the previous PRs to handle stroke width properly so the outline's stroke isn't clipped at the edges.

What changed:
- Reserve `s/2` of clearance on the left and right of both the head and tail content boxes (`s/2 + s/2` per box) when computing width.
- Made `strokeWidth` a required input instead of optional (per maintainer).
- Removed a leftover `console.log` in `computeDimensions2`.
- Added tests for the V2 path (`computeDimensions2` / `generateBrickOutline2`), which had no coverage before: width/height formulas, the inset path strings at s=0 and s=4, closed-loop checks, and the validity boundaries.

Tests: 45 passing (19 existing + 26 new).
