### PR TITLE
feat(masonry): [brick] round the brick outline corners (corner radius)

### DIFF
--- a/modules/masonry/src/brick/utils/path2.ts
+++ b/modules/masonry/src/brick/utils/path2.ts
@@ -48,6 +48,11 @@ export const H_NOTCH_RADIUS = 3;
 /** y-offset from the top of an arg slot down to an H-notch centre. */
 export const NOTCH_OFFSET_Y = 9;
 
+// ── Corner geometry ──
+// Each edge pulled in by CORNER_RADIUS with a quarter-circle arc; cavity corners use CORNER_RADIUS + strokeWidth. Capped by the left tab: CORNER_RADIUS <= NOTCH_OFFSET_Y - H_NOTCH_RADIUS - (3*s)/2 - s/2.
+/** Radius of the brick's rounded outer (convex) corners. */
+export const CORNER_RADIUS = 3;
+
 // ────────────────────────── Dimension Calculation ────────────────────────────────────────────────
 
 interface ComputedDimensions {
@@ -155,6 +160,18 @@ function computeArgNotchCentreYs(
 
 // ────────────────────────── Arc Helpers ──────────────────────────────────────────────────────────
 
+/** A point relative to the arc's start (the current pen position). */
+type RelPoint = { x: number; y: number };
+
+/** Relative SVG arc (`a`) from `end` and `centre` (both relative to the start); radius and sweep derived. Limited to a quarter turn. */
+function arc(end: RelPoint, centre: RelPoint): string {
+    const radius = Math.hypot(centre.x, centre.y);
+    // Cross product of (start→centre) and (start→end), with start at the origin.
+    // Negative ⇒ the turn is clockwise ⇒ SVG sweep flag 1 (in y-down space).
+    const sweepFlag = centre.y * end.x - centre.x * end.y < 0 ? 1 : 0;
+    return `a ${radius} ${radius} 0 0 ${sweepFlag} ${end.x} ${end.y}`;
+}
+
 /** Inward U-shape groove arc (left → right). Used by top notch and nested bottom notch. */
 function buildVGroove(strokeWidth: number): string[] {
     const grooveR = V_NOTCH_RADIUS + strokeWidth;
@@ -162,26 +179,27 @@ function buildVGroove(strokeWidth: number): string[] {
     const R = grooveR - lip;
     return [
         // Quarter-arc: horizontal (left) → vertical (down). CW
-        `a ${lip} ${lip} 0 0 1 ${lip} ${lip}`,
+        arc({ x: lip, y: lip }, { x: lip, y: 0 }),
         // Semicircle: vertical (down) → vertical (up). CCW (U-shape)
-        `a ${R} ${R} 0 0 0 ${2 * R} 0`,
+        arc({ x: R, y: R }, { x: 0, y: R }),
+        arc({ x: R, y: -R }, { x: R, y: 0 }),
         // Quarter-arc: vertical (up) → horizontal (right). CW
-        `a ${lip} ${lip} 0 0 1 ${lip} ${-lip}`,
+        arc({ x: lip, y: -lip }, { x: 0, y: -lip }),
     ];
 }
 
 /** Outward U-shape tab arc (right → left). Used by bottom notch and nested top notch. */
 function buildVTab(strokeWidth: number): string[] {
-
     const lip = (3 * strokeWidth) / 2;
     const R = V_NOTCH_RADIUS - strokeWidth / 2;
     return [
         // Quarter-arc: horizontal (right) → vertical (down). CCW
-        `a ${lip} ${lip} 0 0 0 ${-lip} ${lip}`,
+        arc({ x: -lip, y: lip }, { x: -lip, y: 0 }),
         // Semicircle: vertical (down) → vertical (up). CW (U-shape)
-        `a ${R} ${R} 0 0 1 ${-2 * R} 0`,
+        arc({ x: -R, y: R }, { x: 0, y: R }),
+        arc({ x: -R, y: -R }, { x: -R, y: 0 }),
         // Quarter-arc: vertical (up) → horizontal (left). CCW
-        `a ${lip} ${lip} 0 0 0 ${-lip} ${-lip}`,
+        arc({ x: -lip, y: -lip }, { x: 0, y: -lip }),
     ];
 }
 
@@ -197,22 +215,28 @@ function buildVTab(strokeWidth: number): string[] {
  * @param hasTopNotch - Whether to draw the top notch groove
  */
 function segTopEdge(strokeWidth: number, width: number, hasTopNotch: boolean): string[] {
-    // No notch — single flat span, inset by strokeWidth/2 at each end.
+    // Start point sits after the rounded top-left corner: inset by strokeWidth/2 and CORNER_RADIUS.
+    const start = `M ${strokeWidth / 2 + CORNER_RADIUS} ${strokeWidth / 2}`;
+    // Convex top-right corner: end CR right + CR down, curving around a centre CR to the right.
+    const corner = arc({ x: CORNER_RADIUS, y: CORNER_RADIUS }, { x: CORNER_RADIUS, y: 0 });
+
+    // No notch — single flat span, inset by strokeWidth/2 + CORNER_RADIUS at each end.
     if (!hasTopNotch) {
-        return [`M ${strokeWidth / 2} ${strokeWidth / 2}`, `h ${width - strokeWidth}`];
+        return [start, `h ${width - strokeWidth - CORNER_RADIUS - CORNER_RADIUS}`, corner];
     }
 
     // flatBefore: horizontal run from the starting M position to the notch left edge
-    // flatAfter:  horizontal run from the notch right edge to the brick's right edge
+    // flatAfter:  horizontal run from the notch right edge to the rounded top-right corner
     const grooveR = V_NOTCH_RADIUS + strokeWidth;
-    const flatBefore = NOTCH_OFFSET_X - grooveR - strokeWidth / 2;
-    const flatAfter = width - NOTCH_OFFSET_X - grooveR - strokeWidth / 2;
+    const flatBefore = NOTCH_OFFSET_X - grooveR - strokeWidth / 2 - CORNER_RADIUS;
+    const flatAfter = width - NOTCH_OFFSET_X - grooveR - strokeWidth / 2 - CORNER_RADIUS;
 
     return [
-        `M ${strokeWidth / 2} ${strokeWidth / 2}`,
+        start,
         `h ${flatBefore}`, // flat run to groove left edge
         ...buildVGroove(strokeWidth),
         `h ${flatAfter}`, // flat run to brick right edge
+        corner,
     ];
 }
 
@@ -226,13 +250,16 @@ function segTopEdge(strokeWidth: number, width: number, hasTopNotch: boolean): s
  * @param notchCentres - Absolute y positions (top → bottom) of each groove centre
  */
 function segHeadRight(strokeWidth: number, headHeight: number, notchCentres: number[]): string[] {
-    // The edge runs between the two corners, each inset by strokeWidth/2 so the stroke isn't clipped.
-    const edgeStart = strokeWidth / 2; // top-right corner (pen arrives here)
-    const edgeEnd = headHeight - strokeWidth / 2; // bottom-right corner
+    // The edge runs between the two corners, each inset by strokeWidth/2 + CORNER_RADIUS.
+    const edgeStart = strokeWidth / 2 + CORNER_RADIUS; // below the rounded top-right corner
+    const edgeEnd = headHeight - strokeWidth / 2 - CORNER_RADIUS; // above the rounded bottom-right corner
+
+    // Convex bottom-right corner: end CR left + CR down, curving around a centre CR below.
+    const corner = arc({ x: -CORNER_RADIUS, y: CORNER_RADIUS }, { x: 0, y: CORNER_RADIUS });
 
     // No notches — single straight run.
     if (notchCentres.length === 0) {
-        return [`v ${edgeEnd - edgeStart}`];
+        return [`v ${edgeEnd - edgeStart}`, corner];
     }
 
     const grooveR = H_NOTCH_RADIUS + strokeWidth / 2;
@@ -262,17 +289,19 @@ function segHeadRight(strokeWidth: number, headHeight: number, notchCentres: num
         const flatBefore = notchTop - pen;
         segs.push(`v ${flatBefore}`);
         // 2. lip arc: peel the edge inwards (−x)
-        segs.push(`a ${lip} ${lip} 0 0 1 ${-lip} ${lip}`);
+        segs.push(arc({ x: -lip, y: lip }, { x: 0, y: lip }));
         // 3. semicircle: the concave groove dipping into the brick (−x)
-        segs.push(`a ${grooveR} ${grooveR} 0 0 0 0 ${2 * grooveR}`);
+        segs.push(arc({ x: -grooveR, y: grooveR }, { x: -grooveR, y: 0 }));
+        segs.push(arc({ x: grooveR, y: grooveR }, { x: 0, y: grooveR }));
         // 4. lip arc: bring the edge back out
-        segs.push(`a ${lip} ${lip} 0 0 1 ${lip} ${lip}`);
+        segs.push(arc({ x: lip, y: lip }, { x: lip, y: 0 }));
 
         pen = notchBottom;
     }
 
     // 5. remaining flat run down to the bottom corner
     segs.push(`v ${edgeEnd - pen}`);
+    segs.push(corner);
     return segs;
 }
 
@@ -286,22 +315,29 @@ function segHeadRight(strokeWidth: number, headHeight: number, notchCentres: num
  * @param hasBottomNotch - Whether to draw the bottom notch tab
  */
 function segHeadBottom(strokeWidth: number, width: number, hasBottomNotch: boolean): string[] {
+    const span = width - strokeWidth - CORNER_RADIUS - CORNER_RADIUS;
+
+    // Convex bottom-left corner: end CR left + CR up, curving around a centre CR to the left.
+    const corner = arc({ x: -CORNER_RADIUS, y: -CORNER_RADIUS }, { x: -CORNER_RADIUS, y: 0 });
+
     // No notch — single flat span going left.
     if (!hasBottomNotch) {
-        return [`h ${-(width - strokeWidth)}`];
+        return [`h ${-span}`, corner];
     }
 
     if (strokeWidth >= 2 * V_NOTCH_RADIUS) {
-        return [`h ${-(width - strokeWidth)}`];
+        return [`h ${-span}`, corner];
     }
 
-    const flatBefore = width - NOTCH_OFFSET_X - V_NOTCH_RADIUS - (3 * strokeWidth) / 2;
-    const flatAfter = NOTCH_OFFSET_X - V_NOTCH_RADIUS - (3 * strokeWidth) / 2;
+    const flatBefore =
+        width - NOTCH_OFFSET_X - V_NOTCH_RADIUS - (3 * strokeWidth) / 2 - CORNER_RADIUS;
+    const flatAfter = NOTCH_OFFSET_X - V_NOTCH_RADIUS - (3 * strokeWidth) / 2 - CORNER_RADIUS;
 
     return [
         `h ${-flatBefore}`, // flat run to tab right edge
         ...buildVTab(strokeWidth),
         `h ${-flatAfter}`, // flat run to brick left edge
+        corner,
     ];
 }
 
@@ -315,15 +351,18 @@ function segHeadBottom(strokeWidth: number, width: number, hasBottomNotch: boole
  * @param hasLeftNotch  - Whether to draw the left tab
  */
 function segLeftEdge(strokeWidth: number, height: number, hasLeftNotch: boolean): string[] {
-    // The edge runs between the two corners, each inset by strokeWidth/2; travelled upward.
-    const edgeStart = height - strokeWidth / 2; // bottom-left corner (pen arrives here)
-    const edgeEnd = strokeWidth / 2; // top-left corner
+    // The edge runs between the two corners, each inset by strokeWidth/2 + CORNER_RADIUS; travelled upward.
+    const edgeStart = height - strokeWidth / 2 - CORNER_RADIUS; // above the rounded bottom-left corner
+    const edgeEnd = strokeWidth / 2 + CORNER_RADIUS; // below the rounded top-left corner
 
     const tabR = H_NOTCH_RADIUS - strokeWidth / 2;
     const lip = (3 * strokeWidth) / 2;
 
+    // Convex top-left corner: end CR right + CR up, curving around a centre CR above.
+    const corner = arc({ x: CORNER_RADIUS, y: -CORNER_RADIUS }, { x: 0, y: -CORNER_RADIUS });
+
     if (!hasLeftNotch) {
-        return [`v ${-(edgeStart - edgeEnd)}`];
+        return [`v ${-(edgeStart - edgeEnd)}`, corner];
     }
 
     const notchBottom = NOTCH_OFFSET_Y + tabR + lip;
@@ -331,15 +370,17 @@ function segLeftEdge(strokeWidth: number, height: number, hasLeftNotch: boolean)
 
     // Fall back to a straight edge if the tab wouldn't fit between the two corners.
     if (notchBottom > edgeStart || notchTop < edgeEnd) {
-        return [`v ${-(edgeStart - edgeEnd)}`];
+        return [`v ${-(edgeStart - edgeEnd)}`, corner];
     }
 
     return [
         `v ${-(edgeStart - notchBottom)}`, // 1. flat run up to where the tab begins
-        `a ${lip} ${lip} 0 0 0 ${-lip} ${-lip}`, // 2. lip arc: peel the edge outwards (−x)
-        `a ${tabR} ${tabR} 0 0 1 0 ${-2 * tabR}`, // 3. semicircle: the convex tab bulging out (−x)
-        `a ${lip} ${lip} 0 0 0 ${lip} ${-lip}`, // 4. lip arc: bring the edge back in
+        arc({ x: -lip, y: -lip }, { x: 0, y: -lip }), // 2. lip arc: peel the edge outwards (−x)
+        arc({ x: -tabR, y: -tabR }, { x: -tabR, y: 0 }), // 3. semicircle: the convex tab bulging out (−x)
+        arc({ x: tabR, y: -tabR }, { x: 0, y: -tabR }),
+        arc({ x: lip, y: -lip }, { x: lip, y: 0 }), // 4. lip arc: bring the edge back in
         `v ${-(notchTop - edgeEnd)}`, // 5. remaining flat run up to the top-left corner
+        corner,
     ];
 }
 
@@ -352,27 +393,55 @@ function segLeftEdge(strokeWidth: number, height: number, hasLeftNotch: boolean)
  * @param width              - Total outer width of the brick
  */
 function segTailCavityRoof(strokeWidth: number, width: number): string[] {
-    const span = width - TAIL_INDENT_W - strokeWidth;
+    // The two cavity corners run a stroke-width larger so a nested brick's rounded convex
+    // corner seats flush inside them (same idea as groove = tab + strokeWidth).
+    const cavityCornerRadius = CORNER_RADIUS + strokeWidth;
+
+    const span = width - TAIL_INDENT_W - strokeWidth - CORNER_RADIUS - cavityCornerRadius;
+
+    // Concave roof → spine corner: end crc left + crc down, curving around a centre crc to the left.
+    const corner = arc(
+        { x: -cavityCornerRadius, y: cavityCornerRadius },
+        { x: -cavityCornerRadius, y: 0 },
+    );
 
     if (strokeWidth >= 2 * V_NOTCH_RADIUS) {
-        return [`h ${-span}`];
+        return [`h ${-span}`, corner];
     }
 
     // Tab centre aligns with the inner brick's top/bottom notch centre.
     const flatBefore =
-        width - TAIL_INDENT_W - NOTCH_OFFSET_X - V_NOTCH_RADIUS - (5 * strokeWidth) / 2;
-    const flatAfter = NOTCH_OFFSET_X - V_NOTCH_RADIUS - strokeWidth / 2;
+        width -
+        TAIL_INDENT_W -
+        NOTCH_OFFSET_X -
+        V_NOTCH_RADIUS -
+        (5 * strokeWidth) / 2 -
+        CORNER_RADIUS;
+    const flatAfter = NOTCH_OFFSET_X - V_NOTCH_RADIUS - strokeWidth / 2 - cavityCornerRadius;
 
     return [
         `h ${-flatBefore}`, // flat run to tab right edge
         ...buildVTab(strokeWidth),
         `h ${-flatAfter}`, // flat run to cavity left wall
+        corner,
     ];
 }
 
 function segTailCavityLeft(strokeWidth: number, nestHeight: number): string[] {
+    const cavityCornerRadius = CORNER_RADIUS + strokeWidth;
+
     // Grows s/2 per seam: starts s/2 below the inset roof, ends s/2 above the inset floor.
-    return [`v ${nestHeight + strokeWidth / 2 + strokeWidth / 2}`];
+    // Both ends meet concave cavity corners, so each is pulled in by cavityCornerRadius.
+    const span =
+        nestHeight + strokeWidth / 2 + strokeWidth / 2 - cavityCornerRadius - cavityCornerRadius;
+
+    // Concave spine → foot corner: end crc right + crc down, curving around a centre crc below.
+    const corner = arc(
+        { x: cavityCornerRadius, y: cavityCornerRadius },
+        { x: 0, y: cavityCornerRadius },
+    );
+
+    return [`v ${span}`, corner];
 }
 
 /**
@@ -383,20 +452,29 @@ function segTailCavityLeft(strokeWidth: number, nestHeight: number): string[] {
  * @param strokeWidth          - Stroke width in SVG units
  */
 function segTailFoot(strokeWidth: number): string[] {
+    const cavityCornerRadius = CORNER_RADIUS + strokeWidth;
+
     const span = TAIL_STEP_W - TAIL_INDENT_W;
 
-    const flatBefore = NOTCH_OFFSET_X - V_NOTCH_RADIUS - strokeWidth / 2;
-    const flatAfter = span - NOTCH_OFFSET_X - V_NOTCH_RADIUS - (3 * strokeWidth) / 2;
+    const flatBefore = NOTCH_OFFSET_X - V_NOTCH_RADIUS - strokeWidth / 2 - cavityCornerRadius;
+    const flatAfter =
+        span - NOTCH_OFFSET_X - V_NOTCH_RADIUS - (3 * strokeWidth) / 2 - CORNER_RADIUS;
+
+    // Convex foot → step-right corner: end CR right + CR down, curving around a centre CR to the right.
+    const corner = arc({ x: CORNER_RADIUS, y: CORNER_RADIUS }, { x: CORNER_RADIUS, y: 0 });
 
     return [
         `h ${flatBefore}`, // flat run to groove left edge
         ...buildVGroove(strokeWidth),
         `h ${flatAfter}`, // flat run to step right wall
+        corner,
     ];
 }
 
 function segTailStepRight(): string[] {
-    return [`v ${TAIL_STEP_H}`];
+    // Convex step-right → step-bottom corner: end CR left + CR down, curving around a centre CR below.
+    const corner = arc({ x: -CORNER_RADIUS, y: CORNER_RADIUS }, { x: 0, y: CORNER_RADIUS });
+    return [`v ${TAIL_STEP_H - CORNER_RADIUS - CORNER_RADIUS}`, corner];
 }
 
 /**
@@ -407,22 +485,29 @@ function segTailStepRight(): string[] {
  * @param hasBottomNotch - Whether to draw the bottom notch tab
  */
 function segTailStepBottom(strokeWidth: number, hasBottomNotch: boolean): string[] {
+    const span = TAIL_STEP_W - CORNER_RADIUS - CORNER_RADIUS;
+
+    // Convex step-bottom → left corner: end CR left + CR up, curving around a centre CR to the left.
+    const corner = arc({ x: -CORNER_RADIUS, y: -CORNER_RADIUS }, { x: -CORNER_RADIUS, y: 0 });
+
     // No notch — single flat span going left.
     if (!hasBottomNotch) {
-        return [`h ${-TAIL_STEP_W}`];
+        return [`h ${-span}`, corner];
     }
 
     if (strokeWidth >= 2 * V_NOTCH_RADIUS) {
-        return [`h ${-TAIL_STEP_W}`];
+        return [`h ${-span}`, corner];
     }
 
-    const flatBefore = TAIL_STEP_W - NOTCH_OFFSET_X - V_NOTCH_RADIUS - strokeWidth / 2;
-    const flatAfter = NOTCH_OFFSET_X - V_NOTCH_RADIUS - (3 * strokeWidth) / 2;
+    const flatBefore =
+        TAIL_STEP_W - NOTCH_OFFSET_X - V_NOTCH_RADIUS - strokeWidth / 2 - CORNER_RADIUS;
+    const flatAfter = NOTCH_OFFSET_X - V_NOTCH_RADIUS - (3 * strokeWidth) / 2 - CORNER_RADIUS;
 
     return [
         `h ${-flatBefore}`, // flat run to tab right edge
         ...buildVTab(strokeWidth),
         `h ${-flatAfter}`, // flat run to step left wall
+        corner,
     ];
 }
 

--- a/modules/masonry/src/brick/utils/spec/path2.spec.ts
+++ b/modules/masonry/src/brick/utils/spec/path2.spec.ts
@@ -7,6 +7,7 @@ import {
     H_NOTCH_RADIUS,
     V_NOTCH_RADIUS,
     NOTCH_OFFSET_Y,
+    CORNER_RADIUS,
     TAIL_INDENT_W,
     TAIL_STEP_H,
     TAIL_STEP_W,
@@ -217,8 +218,10 @@ describe('path V2: generateBrickOutline', () => {
             labelDims: { w: 60, h: 20 },
             paramArgDims: [],
         });
-        // width = 120 (minWidth), headHeight = 28, height = 28
-        expect(result.path).toBe('M 0 0 h 120 v 28 h -120 v -28 Z');
+        // width = 120 (minWidth), headHeight = 28, height = 28; corners rounded by CORNER_RADIUS.
+        expect(result.path).toBe(
+            'M 3 0 h 114 a 3 3 0 0 1 3 3 v 22 a 3 3 0 0 1 -3 3 h -114 a 3 3 0 0 1 -3 -3 v -22 a 3 3 0 0 1 3 -3 Z',
+        );
         expect(result.width).toBe(120);
         expect(result.height).toBe(28);
     });
@@ -229,9 +232,11 @@ describe('path V2: generateBrickOutline', () => {
             labelDims: { w: 200, h: 30 },
             paramArgDims: [],
         });
-        // width = 218, headHeight = 42, height = 42
-        // M s/2 s/2 ; h (218-4)=214 ; v headHeight-4=38 ; h -214 ; v -38
-        expect(result.path).toBe('M 2 2 h 214 v 38 h -214 v -38 Z');
+        // width = 218, headHeight = 42, height = 42; inset by s/2, corners rounded by CORNER_RADIUS.
+        // M (s/2+cr) s/2 ; h (218-4-2*3)=208 ; corner ; v (42-4-2*3)=32 ; ...
+        expect(result.path).toBe(
+            'M 5 2 h 208 a 3 3 0 0 1 3 3 v 32 a 3 3 0 0 1 -3 3 h -208 a 3 3 0 0 1 -3 -3 v -32 a 3 3 0 0 1 3 -3 Z',
+        );
         expect(result.width).toBe(218);
         expect(result.height).toBe(42);
     });
@@ -244,9 +249,10 @@ describe('path V2: generateBrickOutline', () => {
             nestingDims: { w: 50, h: 50 },
         });
         // width=120, headHeight=28, nestHeight=50, height=84
-        // cavity roof and foot now always include V-notch arcs (tab + groove)
+        // cavity roof and foot always include V-notch arcs (tab + groove); corners rounded,
+        // with the two concave cavity corners a stroke-width larger.
         expect(result.path).toBe(
-            'M 0 0 h 120 v 28 h -99 a 0 0 0 0 0 0 0 a 3 3 0 0 1 -6 0 a 0 0 0 0 0 0 0 h -9 v 50 h 9 a 0 0 0 0 1 0 0 a 3 3 0 0 0 6 0 a 0 0 0 0 1 0 0 h 9 v 6 h -30 v -84 Z',
+            'M 3 0 h 114 a 3 3 0 0 1 3 3 v 22 a 3 3 0 0 1 -3 3 h -96 a 0 0 0 0 0 0 0 a 3 3 0 0 1 -3 3 a 3 3 0 0 1 -3 -3 a 0 0 0 0 0 0 0 h -6 a 3 3 0 0 0 -3 3 v 44 a 3 3 0 0 0 3 3 h 6 a 0 0 0 0 0 0 0 a 3 3 0 0 0 3 3 a 3 3 0 0 0 3 -3 a 0 0 0 0 0 0 0 h 6 a 3 3 0 0 1 3 3 v 0 a 3 3 0 0 1 -3 3 h -24 a 3 3 0 0 1 -3 -3 v -78 a 3 3 0 0 1 3 -3 Z',
         );
     });
 
@@ -258,9 +264,10 @@ describe('path V2: generateBrickOutline', () => {
             nestingDims: { w: 50, h: 50 },
         });
         // width=120, headHeight=32, nestHeight=50, height=92
-        // cavity roof and foot now always include V-notch arcs (tab + groove)
+        // cavity roof and foot always include V-notch arcs (tab + groove); corners rounded,
+        // with the two concave cavity corners a stroke-width larger.
         expect(result.path).toBe(
-            'M 2 2 h 116 v 28 h -89 a 6 6 0 0 0 -6 6 a 1 1 0 0 1 -2 0 a 6 6 0 0 0 -6 -6 h -7 v 54 h 7 a 2 2 0 0 1 2 2 a 5 5 0 0 0 10 0 a 2 2 0 0 1 2 -2 h 3 v 6 h -30 v -88 Z',
+            'M 5 2 h 110 a 3 3 0 0 1 3 3 v 22 a 3 3 0 0 1 -3 3 h -86 a 6 6 0 0 0 -6 6 a 1 1 0 0 1 -1 1 a 1 1 0 0 1 -1 -1 a 6 6 0 0 0 -6 -6 h 0 a 7 7 0 0 0 -7 7 v 40 a 7 7 0 0 0 7 7 h 0 a 2 2 0 0 1 2 2 a 5 5 0 0 0 5 5 a 5 5 0 0 0 5 -5 a 2 2 0 0 1 2 -2 h 0 a 3 3 0 0 1 3 3 v 0 a 3 3 0 0 1 -3 3 h -24 a 3 3 0 0 1 -3 -3 v -82 a 3 3 0 0 1 3 -3 Z',
         );
     });
 
@@ -315,13 +322,14 @@ describe('path V2: generateBrickOutline', () => {
             expect(dims.width).toBe(Math.max(headWidth, TAIL_STEP_W, MINIMUMS.minWidth));
         });
 
-        it('path starts at the origin (no inset) when s=0', () => {
+        it('path top edge has no stroke inset when s=0 (only the corner inset remains)', () => {
             const { path } = generateBrickOutline({
                 strokeWidth: 0,
                 labelDims: { w: 60, h: 20 },
                 paramArgDims: [],
             });
-            expect(path.startsWith('M 0 0')).toBe(true);
+            // y = 0 (no stroke inset); x = CORNER_RADIUS, the start of the top edge after the corner.
+            expect(path.startsWith(`M ${CORNER_RADIUS} 0`)).toBe(true);
         });
     });
 
@@ -401,8 +409,32 @@ interface ArcSeg {
     dy: number;
 }
 
-/** Extract every elliptical-arc (`a rx ry rot large sweep dx dy`) segment from a path. */
+/**
+ * Extract every elliptical-arc (`a rx ry rot large sweep dx dy`) segment from a path. Each notch
+ * semicircle is drawn as two equal-radius quarter arcs; this merges that pair back into one arc.
+ */
 function parseArcs(path: string): ArcSeg[] {
+    const tokens = path.trim().split(/\s+/);
+    const arcs: ArcSeg[] = [];
+    for (let i = 0; i < tokens.length; i++) {
+        if (tokens[i] === 'a') {
+            const rx = parseFloat(tokens[i + 1]);
+            const sweep = parseFloat(tokens[i + 5]);
+            let dx = parseFloat(tokens[i + 6]);
+            let dy = parseFloat(tokens[i + 7]);
+            if (tokens[i + 8] === 'a' && Math.abs(parseFloat(tokens[i + 9]) - rx) < 1e-9) {
+                dx += parseFloat(tokens[i + 14]);
+                dy += parseFloat(tokens[i + 15]);
+                i += 8;
+            }
+            arcs.push({ rx, sweep, dx, dy });
+        }
+    }
+    return arcs;
+}
+
+/** Like parseArcs but WITHOUT merging a notch's two halves — exposes each individual quarter arc. */
+function parseArcsRaw(path: string): ArcSeg[] {
     const tokens = path.trim().split(/\s+/);
     const arcs: ArcSeg[] = [];
     for (let i = 0; i < tokens.length; i++) {
@@ -451,7 +483,12 @@ function semicircleCentresY(path: string, radius: number): number[] {
             y += parseFloat(tokens[i + 1]);
         } else if (cmd === 'a') {
             const rx = parseFloat(tokens[i + 1]);
-            const dy = parseFloat(tokens[i + 7]);
+            let dy = parseFloat(tokens[i + 7]);
+            // merge the two quarter-arcs of a notch back into one semicircle
+            if (tokens[i + 8] === 'a' && Math.abs(parseFloat(tokens[i + 9]) - rx) < 1e-9) {
+                dy += parseFloat(tokens[i + 15]);
+                i += 8;
+            }
             if (Math.abs(rx - radius) < 1e-9) centres.push(y + dy / 2);
             y += dy;
         }
@@ -471,8 +508,15 @@ function leftTabCentreY(path: string): number | undefined {
         if (cmd === 'M' || cmd === 'm') y = parseFloat(tokens[i + 2]);
         else if (cmd === 'v') y += parseFloat(tokens[i + 1]);
         else if (cmd === 'a') {
-            const dx = parseFloat(tokens[i + 6]);
-            const dy = parseFloat(tokens[i + 7]);
+            const rx = parseFloat(tokens[i + 1]);
+            let dx = parseFloat(tokens[i + 6]);
+            let dy = parseFloat(tokens[i + 7]);
+            // merge the two quarter-arcs of a notch back into one semicircle
+            if (tokens[i + 8] === 'a' && Math.abs(parseFloat(tokens[i + 9]) - rx) < 1e-9) {
+                dx += parseFloat(tokens[i + 14]);
+                dy += parseFloat(tokens[i + 15]);
+                i += 8;
+            }
             if (dx === 0 && dy < 0) return y + dy / 2;
             y += dy;
         }
@@ -483,13 +527,15 @@ function leftTabCentreY(path: string): number | undefined {
 const oneArg = { param: null, arg: { w: 50, h: 40 } };
 
 describe('path V2: notches', () => {
-    it('draws no arcs when there are no args and no left tab', () => {
+    it('draws no notch arcs when there are no args and no left tab', () => {
         const r = generateBrickOutline({
             strokeWidth: 2,
             labelDims: { w: 60, h: 20 },
             paramArgDims: [],
         });
-        expect(parseArcs(r.path)).toHaveLength(0);
+        // The only arcs are the four rounded corners; there are no notch arcs.
+        const notchArcs = parseArcs(r.path).filter((a) => a.rx !== CORNER_RADIUS);
+        expect(notchArcs).toHaveLength(0);
     });
 
     it('right grooves follow the args: one groove per argument slot, no flag needed', () => {
@@ -596,6 +642,111 @@ describe('path V2: notches', () => {
             paramArgDims: [oneArg],
             hasLeftNotch: true,
         });
-        expect(parseArcs(noTab.path)).toHaveLength(0);
+        // Only the rounded corners remain; no notch (tab/groove) arcs are drawn.
+        const notchArcs = parseArcs(noTab.path).filter((a) => a.rx !== CORNER_RADIUS);
+        expect(notchArcs).toHaveLength(0);
+    });
+
+    it('right groove is split into two equal quarter-arcs, both concave (sweep 0)', () => {
+        const s = 2;
+        const grooveR = H_NOTCH_RADIUS + s / 2;
+        const r = generateBrickOutline({
+            strokeWidth: s,
+            labelDims: { w: 60, h: 20 },
+            paramArgDims: [oneArg],
+        });
+        // One arg → one groove, drawn as two 90° arcs of radius grooveR that each dip inward (−x).
+        const halves = parseArcsRaw(r.path).filter((a) => a.rx === grooveR);
+        expect(halves).toHaveLength(2);
+        expect(halves.every((a) => a.sweep === 0)).toBe(true);
+        expect(halves.every((a) => Math.abs(a.dy) === grooveR)).toBe(true);
+    });
+
+    it('left tab is split into two equal quarter-arcs, both convex (sweep 1)', () => {
+        const s = 2;
+        const tabR = H_NOTCH_RADIUS - s / 2;
+        const r = generateBrickOutline({
+            strokeWidth: s,
+            labelDims: { w: 60, h: 20 },
+            paramArgDims: [oneArg],
+            hasLeftNotch: true,
+        });
+        // The left tab is drawn as two 90° arcs of radius tabR that each bulge outward (−x).
+        const halves = parseArcsRaw(r.path).filter((a) => a.rx === tabR);
+        expect(halves).toHaveLength(2);
+        expect(halves.every((a) => a.sweep === 1)).toBe(true);
+        expect(halves.every((a) => Math.abs(a.dy) === tabR)).toBe(true);
+    });
+});
+
+// ────────────────────────── Corner Radius ──────────────────────────────────────────────────────────
+
+describe('path V2: corner radius', () => {
+    it('rounds all four corners of a simple brick with one convex arc each', () => {
+        const r = generateBrickOutline({
+            strokeWidth: 2,
+            labelDims: { w: 60, h: 20 },
+            paramArgDims: [],
+        });
+        // A simple brick has no notches, so its only arcs are the four corners.
+        const corners = parseArcs(r.path).filter((a) => a.rx === CORNER_RADIUS);
+        expect(corners).toHaveLength(4);
+        // Every outer corner is convex (sweep 1).
+        expect(corners.every((a) => a.sweep === 1)).toBe(true);
+    });
+
+    it('a compound brick rounds the two cavity corners concavely, a stroke-width larger', () => {
+        const s = 2;
+        const r = generateBrickOutline({
+            strokeWidth: s,
+            labelDims: { w: 80, h: 20 },
+            paramArgDims: [],
+            nestingDims: { w: 50, h: 50 },
+        });
+        // 8 corners around the C-shape: 6 convex outer corners at CORNER_RADIUS, plus the two
+        // concave cavity-mouth corners at CORNER_RADIUS + strokeWidth so a nested brick seats
+        // flush inside them.
+        const convex = parseArcs(r.path).filter((a) => a.rx === CORNER_RADIUS && a.sweep === 1);
+        const concave = parseArcs(r.path).filter(
+            (a) => a.rx === CORNER_RADIUS + s && a.sweep === 0,
+        );
+        expect(convex).toHaveLength(6);
+        expect(concave).toHaveLength(2);
+    });
+
+    it('corner radius does not change the reported width/height', () => {
+        const input: BrickOutlineInput = {
+            strokeWidth: 2,
+            labelDims: { w: 60, h: 20 },
+            paramArgDims: [],
+        };
+        const r = generateBrickOutline(input);
+        const dims = computeDimensions(input, MINIMUMS);
+        // Rounding only trims/curves the corners; the outer frame is unchanged.
+        expect(r.width).toBe(dims.width);
+        expect(r.height).toBe(dims.height);
+    });
+
+    it('the outline still closes with corner radius combined with every notch', () => {
+        const simple = generateBrickOutline({
+            strokeWidth: 2,
+            labelDims: { w: 60, h: 20 },
+            paramArgDims: [oneArg, oneArg, oneArg],
+            hasLeftNotch: true,
+        });
+        const compound = generateBrickOutline({
+            strokeWidth: 2,
+            labelDims: { w: 60, h: 20 },
+            paramArgDims: [oneArg, oneArg],
+            nestingDims: { w: 80, h: 80 },
+            hasTopNotch: true,
+            hasBottomNotch: true,
+            hasLeftNotch: true,
+        });
+        for (const r of [simple, compound]) {
+            const { dx, dy } = netDisplacementFull(r.path);
+            expect(dx).toBeCloseTo(0);
+            expect(dy).toBeCloseTo(0);
+        }
     });
 });


### PR DESCRIPTION
Adds a `cornerRadius` property to the brick outline, building on the stroke-width work. It rounds the corners of the parent brick's own outline using SVG arc (`a`) commands.

What it does:
- New required `cornerRadius: number` input, modelled the same way as `strokeWidth`  (pass 0 for sharp corners).
- Each edge is shortened by `cornerRadius` at both ends and a quarter-circle arc fills the corner. Outer corners are convex; the two back corners of the nestingvcavity are concave, so they use the opposite sweep flag.
- The starting point begins one radius past the top-left corner so the closing arc forms that corner cleanly.

What it does NOT change:
- `computeDimensions2` is untouched. Rounding curves inward from edges that already
  define the box, so width/height don't change.

Tests: added cases for the r=0 identity, the rounded path strings, arc count andvconvex/concave sweep flags, closure, and dimensions staying unchanged. 58 passing.

Known limit (not handled yet): on a compound brick the smallest feature is the step (`TAIL_STEP_H = 10`), so a radius above 5 makes that edge negative. Clamping/validation will come in a follow-up.
