### PR TITLE
GSoC 2026 Week 3 : feat(masonry): Add notches to the brick outline generator

### DIFF
--- a/modules/masonry/src/@types/brick.d.ts
+++ b/modules/masonry/src/@types/brick.d.ts
@@ -171,6 +171,10 @@ export interface BrickOutlineInput {
      * - `Size` — nesting exists with known content dimensions
      */
     nestingDims?: Size | null;
+    /** Whether to draw a top notch (downward groove). Defaults to false. */
+    topNotch?: boolean;
+    /** Whether to draw a bottom notch (protruding tab). Defaults to false. */
+    bottomNotch?: boolean;
 }
 
 export interface BrickOutlineOutput {
@@ -191,6 +195,10 @@ export interface BrickOutlineOutput {
         /** Bounds of the nesting cavity; absent when there is no nesting */
         nesting?: Bounds;
     };
+    /** Always 0 (top notch goes inward). */
+    topNotchDepth: number;
+    /** Downward protrusion distance of the bottom notch. */
+    bottomNotchDepth: number;
 }
 
 export interface BrickViewProps {
@@ -198,6 +206,10 @@ export interface BrickViewProps {
     label: string;
     /** Controls brick size and font scaling; defaults to 1 */
     scaleLevel?: 1 | 2 | 3;
+    /** Whether to draw a top notch (downward groove from top edge). Defaults to false. */
+    topNotch?: boolean;
+    /** Whether to draw a bottom notch (tab protruding below bottom edge). Defaults to false. */
+    bottomNotch?: boolean;
 }
 
 export interface BrickMinimums {

--- a/modules/masonry/src/@types/brick.d.ts
+++ b/modules/masonry/src/@types/brick.d.ts
@@ -175,6 +175,10 @@ export interface BrickOutlineInput {
     topNotch?: boolean;
     /** Whether to draw a bottom notch (protruding tab). Defaults to false. */
     bottomNotch?: boolean;
+    /** Whether to draw a nested-top notch (smaller tab on cavity roof). Only used with nesting. */
+    nestedTopNotch?: boolean;
+    /** Whether to draw a nested-bottom notch (full-size groove on cavity floor). Only used with nesting. */
+    nestedBottomNotch?: boolean;
 }
 
 export interface BrickOutlineOutput {
@@ -199,6 +203,10 @@ export interface BrickOutlineOutput {
     topNotchDepth: number;
     /** Downward protrusion distance of the bottom notch. */
     bottomNotchDepth: number;
+    /** Always 0 (nested-top tab goes inward into cavity). */
+    nestedTopNotchDepth: number;
+    /** Downward protrusion of nested-bottom groove into the foot. */
+    nestedBottomNotchDepth: number;
 }
 
 export interface BrickViewProps {

--- a/modules/masonry/src/brick/utils/path2.ts
+++ b/modules/masonry/src/brick/utils/path2.ts
@@ -41,7 +41,13 @@ export const NOTCH_WIDTH = 10;
 /** Base depth of the notch groove / tab in SVG units (must be <= HEAD_PAD_Y1) */
 export const NOTCH_DEPTH = 2;
 /** Left edge offset for the top notch (bottom notch aligns to this centre) */
+<<<<<<< HEAD:modules/masonry/src/brick/utils/path2.ts
 export const NOTCH_OFFSET_X = 8;
+=======
+const NOTCH_OFFSET_X = 8;
+/** Left edge offset for nested notches, measured from TAIL_INDENT_W */
+const NESTED_NOTCH_OFFSET_X = 8;
+>>>>>>> 5641eca (feat(masonry) : Add nestedTopNotch and  nestedBottomNotch):modules/masonry/src/brick/utils/newPath.ts
 
 // ────────────────────────── Dimension Calculation ──────────────────────────
 
@@ -168,7 +174,7 @@ function segHeadRight(headHeight: number, strokeWidth: number): string[] {
 }
 
 /**
- * Bottom edge of the head (used for simple / non-compound bricks), right → left.
+ * Bottom edge of the head (used for bricks without nesting), right → left.
  * Draws a downward tab (hasBottomNotch), reduced in width by 2*s to fit the top groove.
  *
  * @param width          - Total outer width of the brick
@@ -209,10 +215,44 @@ function segLeftEdge(height: number, strokeWidth: number): string[] {
     return [`v ${-(height - strokeWidth / 2 - strokeWidth / 2)}`];
 }
 
-function segTailCavityRoof(width: number, strokeWidth: number): string[] {
-    // Cavity walls each inset s/2 inward; the freed s is absorbed into the step height.
-    const span = width - TAIL_INDENT_W - strokeWidth / 2 - strokeWidth / 2;
-    return [`h ${-span}`];
+/**
+ * Cavity roof segment, right → left.
+ * Draws a smaller tab (hasNestedTopNotch) protruding DOWN into the cavity.
+ *
+ * @param width              - Total outer width of the brick
+ * @param strokeWidth        - Stroke width in SVG units
+ * @param hasNestedTopNotch  - Whether to draw the nested-top notch tab
+ */
+function segTailCavityRoof(width: number, strokeWidth: number, hasNestedTopNotch: boolean): string[] {
+    const s = strokeWidth;
+    const span = width - TAIL_INDENT_W - s / 2 - s / 2;
+
+    // No nested notch — single flat span
+    if (!hasNestedTopNotch) {
+        return [`h ${-span}`];
+    }
+
+    // Nested-top is the SMALLER tab: width reduced by 2*s for interlocking
+    const tabWidth = NOTCH_WIDTH - 2 * s;
+    const tabDepth = NOTCH_DEPTH;
+
+    // Guard: if strokeWidth makes the width non-positive, fall back to flat
+    if (tabWidth <= 0) {
+        return [`h ${-span}`];
+    }
+
+    // Going RIGHT → LEFT along the cavity roof
+    // Tab left edge at absolute x = TAIL_INDENT_W + NESTED_NOTCH_OFFSET_X + s
+    const flatBefore = span - (NESTED_NOTCH_OFFSET_X + NOTCH_WIDTH - s);
+    const flatAfter  = NESTED_NOTCH_OFFSET_X + s;
+
+    return [
+        `h ${-flatBefore}`,    // LEFT — flat run to tab right edge
+        `v ${tabDepth}`,       // DOWN — tab protrudes into cavity
+        `h ${-tabWidth}`,      // LEFT — across the tab
+        `v ${-tabDepth}`,      // UP   — back to roof level
+        `h ${-flatAfter}`,     // LEFT — flat run to cavity left wall
+    ];
 }
 
 function segTailCavityLeft(nestHeight: number, strokeWidth: number): string[] {
@@ -220,8 +260,38 @@ function segTailCavityLeft(nestHeight: number, strokeWidth: number): string[] {
     return [`v ${nestHeight + strokeWidth / 2 + strokeWidth / 2}`];
 }
 
-function segTailFoot(): string[] {
-    return [`h ${TAIL_STEP_W - TAIL_INDENT_W}`];
+/**
+ * Cavity foot segment, left → right.
+ * Draws a full-size groove (hasNestedBottomNotch) going DOWN into the foot.
+ *
+ * @param strokeWidth           - Stroke width in SVG units
+ * @param hasNestedBottomNotch  - Whether to draw the nested-bottom notch groove
+ */
+function segTailFoot(strokeWidth: number, hasNestedBottomNotch: boolean): string[] {
+    const s = strokeWidth;
+    const span = TAIL_STEP_W - TAIL_INDENT_W;
+
+    // No nested notch — single flat span
+    if (!hasNestedBottomNotch) {
+        return [`h ${span}`];
+    }
+
+    // Nested-bottom is the FULL-SIZE groove: NOTCH_WIDTH × NOTCH_DEPTH
+    const grooveWidth = NOTCH_WIDTH;
+    const grooveDepth = NOTCH_DEPTH;
+
+    // Going LEFT → RIGHT along the cavity floor
+    // Groove left edge at absolute x = TAIL_INDENT_W + NESTED_NOTCH_OFFSET_X
+    const flatBefore = NESTED_NOTCH_OFFSET_X;
+    const flatAfter  = span - NESTED_NOTCH_OFFSET_X - NOTCH_WIDTH;
+
+    return [
+        `h ${flatBefore}`,     // RIGHT — flat run to groove left edge
+        `v ${grooveDepth}`,    // DOWN  — groove into the foot
+        `h ${grooveWidth}`,    // RIGHT — across the groove
+        `v ${-grooveDepth}`,   // UP    — back to floor level
+        `h ${flatAfter}`,      // RIGHT — flat run to step right wall
+    ];
 }
 
 function segTailStepRight(): string[] {
@@ -229,7 +299,7 @@ function segTailStepRight(): string[] {
 }
 
 /**
- * Bottom of the tail step (compound bricks only), right → left.
+ * Bottom of the tail step (nesting bricks only), right → left.
  * Draws a downward tab similar to segHeadBottom.
  *
  * @param hasBottomNotch - Whether to draw the bottom notch tab
@@ -356,14 +426,19 @@ export function createBrickOutlineGenerator(
         // ── Resolve notch flags (default: no notches) ──
         const hasTopNotch = input.topNotch ?? false;
         const hasBottomNotch = input.bottomNotch ?? false;
+        // Nested notches only apply when there is nesting
+        const hasNestedTopNotch = hasNesting && (input.nestedTopNotch ?? false);
+        const hasNestedBottomNotch = hasNesting && (input.nestedBottomNotch ?? false);
 
         // ── Compute notch protrusion depths (for SVG viewBox sizing) ──
         const topNotchDepth = 0; // Inward groove; no extra top space needed
         const bottomNotchDepth = hasBottomNotch ? NOTCH_DEPTH : 0;
+        const nestedTopNotchDepth = 0; // Tab goes inward into cavity
+        const nestedBottomNotchDepth = 0; // Groove goes into foot (no external protrusion)
 
         // ── Build the SVG path segments ──
-        // Simple brick: top → right → bottom → left → close
-        // Compound brick: top → right → cavityRoof → cavityLeft → foot → stepRight → stepBottom → left → close
+        // Brick without nesting: top → right → bottom → left → close
+        // Nesting brick: top → right → cavityRoof → cavityLeft → foot → stepRight → stepBottom → left → close
         const segments = !hasNesting
             ? [
                 ...segTopEdge(width, strokeWidth, hasTopNotch),
@@ -375,9 +450,9 @@ export function createBrickOutlineGenerator(
             : [
                 ...segTopEdge(width, strokeWidth, hasTopNotch),
                 ...segHeadRight(headHeight, strokeWidth),
-                ...segTailCavityRoof(width, strokeWidth),
+                ...segTailCavityRoof(width, strokeWidth, hasNestedTopNotch),
                 ...segTailCavityLeft(nestHeight, strokeWidth),
-                ...segTailFoot(),
+                ...segTailFoot(strokeWidth, hasNestedBottomNotch),
                 ...segTailStepRight(),
                 ...segTailStepBottom(hasBottomNotch, strokeWidth),
                 ...segLeftEdge(height, strokeWidth),
@@ -388,6 +463,6 @@ export function createBrickOutlineGenerator(
 
         const bounds = generateBounds(input, width, headHeight, nestHeight, hasNesting, minimums);
 
-        return { path, width, height, bounds, topNotchDepth, bottomNotchDepth };
+        return { path, width, height, bounds, topNotchDepth, bottomNotchDepth, nestedTopNotchDepth, nestedBottomNotchDepth };
     };
 }

--- a/modules/masonry/src/brick/utils/path2.ts
+++ b/modules/masonry/src/brick/utils/path2.ts
@@ -37,20 +37,21 @@ export const TAIL_STEP_H = 6;
 // Groove (TopNotch / NestedBottomNotch) = full-size inward cut (width = NOTCH_WIDTH)
 // Tab    (BottomNotch / NestedTopNotch)  = smaller outward protrusion (width = NOTCH_WIDTH - 2*s)
 //
-// Both notch centres align at x = NOTCH_CENTER_X
+// Both notch centres align at x = NOTCH_OFFSET_X
 // Tab width shrinks by s on each side (2*s total) for interlocking
 // Groove uses the full NOTCH_WIDTH
-// Outer corner radius is NOTCH_CORNER_RADIUS, inner corner is sharp (0)
+// The lip is the small quarter-circle that flares each side into the semicircle
+// (radius NOTCH_LIP_RADIUS); the inner corner is sharp (0)
 // Sweep flags control convexity/concavity
 
 /** Base width of the notch opening in SVG units */
 export const NOTCH_WIDTH = 8;
-/** Corner radius for the quarter-circle transitions at each side of the notch */
-export const NOTCH_CORNER_RADIUS = 1;
-/** Absolute center for the top/bottom notch from the brick's left edge */
-export const NOTCH_CENTER_X = 12;
-/** Absolute center for nested notches, measured from TAIL_INDENT_W */
-export const NESTED_NOTCH_CENTER_X = 12;
+/** Radius of the small lip arc that flares each side of the notch into the semicircle */
+export const NOTCH_LIP_RADIUS = 1;
+/** Offset along x from the brick's left edge to the top/bottom notch centre */
+export const NOTCH_OFFSET_X = 12;
+/** Offset along x to nested notch centres, measured from TAIL_INDENT_W */
+export const NESTED_NOTCH_OFFSET_X = 12;
 
 // ────────────────────────── Dimension Calculation ──────────────────────────
 
@@ -206,13 +207,13 @@ function segTopEdge(width: number, strokeWidth: number, hasTopNotch: boolean): s
     // flatBefore: horizontal run from the starting M position to the notch left edge
     // flatAfter:  horizontal run from the notch right edge to the brick's right edge
     const r = NOTCH_WIDTH / 2;
-    const flatBefore = NOTCH_CENTER_X - r - s / 2;
-    const flatAfter = width - s / 2 - NOTCH_CENTER_X - r;
+    const flatBefore = NOTCH_OFFSET_X - r - s / 2;
+    const flatAfter = width - s / 2 - NOTCH_OFFSET_X - r;
 
     return [
         `M ${s / 2} ${s / 2}`,
         `h ${flatBefore}`, // RIGHT — flat run to groove left edge
-        ...arcGroove(NOTCH_WIDTH, NOTCH_CORNER_RADIUS), // Arc groove
+        ...arcGroove(NOTCH_WIDTH, NOTCH_LIP_RADIUS), // Arc groove
         `h ${flatAfter}`, // RIGHT — flat run to brick right edge
     ];
 }
@@ -251,12 +252,12 @@ function segHeadBottom(width: number, strokeWidth: number, hasBottomNotch: boole
     // flatBefore: from the brick's right edge to the tab's right edge
     // flatAfter:  from the tab's left edge to the brick's left edge
     const r = NOTCH_WIDTH / 2;
-    const flatBefore = width - NOTCH_CENTER_X - r + s / 2;
-    const flatAfter = NOTCH_CENTER_X - r + s / 2;
+    const flatBefore = width - NOTCH_OFFSET_X - r + s / 2;
+    const flatAfter = NOTCH_OFFSET_X - r + s / 2;
 
     return [
         `h ${-flatBefore}`, // LEFT — flat run to tab right edge
-        ...arcTab(tabWidth, NOTCH_CORNER_RADIUS), // Arc tab
+        ...arcTab(tabWidth, NOTCH_LIP_RADIUS), // Arc tab
         `h ${-flatAfter}`, // LEFT — flat run to brick left edge
     ];
 }
@@ -301,13 +302,13 @@ function segTailCavityRoof(
     // flatAfter:  from the tab's left edge to the cavity left wall
     // Add s/2 because the inner brick's visual offset starts at TAIL_INDENT_W + s, but the cavity wall path is at TAIL_INDENT_W + s/2
     const r = NOTCH_WIDTH / 2;
-    const offset = NESTED_NOTCH_CENTER_X - r + s / 2;
+    const offset = NESTED_NOTCH_OFFSET_X - r + s / 2;
     const flatBefore = span - (offset + NOTCH_WIDTH - s);
     const flatAfter = offset + s;
 
     return [
         `h ${-flatBefore}`, // LEFT — flat run to tab right edge
-        ...arcTab(tabWidth, NOTCH_CORNER_RADIUS), // Arc tab
+        ...arcTab(tabWidth, NOTCH_LIP_RADIUS), // Arc tab
         `h ${-flatAfter}`, // LEFT — flat run to cavity left wall
     ];
 }
@@ -337,13 +338,13 @@ function segTailFoot(strokeWidth: number, hasNestedBottomNotch: boolean): string
     // Left → Right along cavity floor.
     // +s/2 offsets the nested notch to align with the inserted inner brick.
     const r = NOTCH_WIDTH / 2;
-    const offset = NESTED_NOTCH_CENTER_X - r + s / 2;
+    const offset = NESTED_NOTCH_OFFSET_X - r + s / 2;
     const flatBefore = offset;
     const flatAfter = span - offset - NOTCH_WIDTH;
 
     return [
         `h ${flatBefore}`, // RIGHT — flat run to groove left edge
-        ...arcGroove(NOTCH_WIDTH, NOTCH_CORNER_RADIUS), // Arc groove
+        ...arcGroove(NOTCH_WIDTH, NOTCH_LIP_RADIUS), // Arc groove
         `h ${flatAfter}`, // RIGHT — flat run to step right wall
     ];
 }
@@ -376,14 +377,14 @@ function segTailStepBottom(hasBottomNotch: boolean, strokeWidth: number): string
     }
 
     // ── With bottom notch (Right → Left) ──
-    // Absolute center is NOTCH_CENTER_X, adjusting for the TAIL_STEP_W inward shift.
+    // Absolute center is NOTCH_OFFSET_X, adjusting for the TAIL_STEP_W inward shift.
     const r = NOTCH_WIDTH / 2;
-    const flatBefore = TAIL_STEP_W - NOTCH_CENTER_X - r + 1.5 * s;
-    const flatAfter = NOTCH_CENTER_X - r + s / 2;
+    const flatBefore = TAIL_STEP_W - NOTCH_OFFSET_X - r + 1.5 * s;
+    const flatAfter = NOTCH_OFFSET_X - r + s / 2;
 
     return [
         `h ${-flatBefore}`, // LEFT — flat run to tab right edge
-        ...arcTab(tabWidth, NOTCH_CORNER_RADIUS), // Arc tab
+        ...arcTab(tabWidth, NOTCH_LIP_RADIUS), // Arc tab
         `h ${-flatAfter}`, // LEFT — flat run to step left wall
     ];
 }

--- a/modules/masonry/src/brick/utils/path2.ts
+++ b/modules/masonry/src/brick/utils/path2.ts
@@ -41,13 +41,9 @@ export const NOTCH_WIDTH = 10;
 /** Base depth of the notch groove / tab in SVG units (must be <= HEAD_PAD_Y1) */
 export const NOTCH_DEPTH = 2;
 /** Left edge offset for the top notch (bottom notch aligns to this centre) */
-<<<<<<< HEAD:modules/masonry/src/brick/utils/path2.ts
 export const NOTCH_OFFSET_X = 8;
-=======
-const NOTCH_OFFSET_X = 8;
 /** Left edge offset for nested notches, measured from TAIL_INDENT_W */
-const NESTED_NOTCH_OFFSET_X = 8;
->>>>>>> 5641eca (feat(masonry) : Add nestedTopNotch and  nestedBottomNotch):modules/masonry/src/brick/utils/newPath.ts
+export const NESTED_NOTCH_OFFSET_X = 8;
 
 // ────────────────────────── Dimension Calculation ──────────────────────────
 
@@ -149,10 +145,7 @@ function segTopEdge(width: number, strokeWidth: number, hasTopNotch: boolean): s
 
     // ── No notch — single flat span, inset by s/2 at each end ──
     if (!hasTopNotch) {
-        return [
-            `M ${s / 2} ${s / 2}`,
-            `h ${width - s}`,
-        ];
+        return [`M ${s / 2} ${s / 2}`, `h ${width - s}`];
     }
 
     // ── Positioning ──
@@ -161,11 +154,11 @@ function segTopEdge(width: number, strokeWidth: number, hasTopNotch: boolean): s
 
     return [
         `M ${s / 2} ${s / 2}`,
-        `h ${flatBefore}`,        // flat run to notch left edge
-        `v ${NOTCH_DEPTH}`,       // DOWN — groove into the brick
-        `h ${NOTCH_WIDTH}`,       // RIGHT — across the groove
-        `v ${-NOTCH_DEPTH}`,      // UP   — back to top edge level
-        `h ${flatAfter}`,         // flat run to right end
+        `h ${flatBefore}`, // flat run to notch left edge
+        `v ${NOTCH_DEPTH}`, // DOWN — groove into the brick
+        `h ${NOTCH_WIDTH}`, // RIGHT — across the groove
+        `v ${-NOTCH_DEPTH}`, // UP   — back to top edge level
+        `h ${flatAfter}`, // flat run to right end
     ];
 }
 
@@ -203,11 +196,11 @@ function segHeadBottom(width: number, strokeWidth: number, hasBottomNotch: boole
     const flatAfter = NOTCH_OFFSET_X + s / 2;
 
     return [
-        `h ${-flatBefore}`,        // LEFT — flat run to notch right edge
-        `v ${botNotchDepth}`,      // DOWN — protrude below the bottom edge
-        `h ${-botNotchWidth}`,     // LEFT — across the notch tab
-        `v ${-botNotchDepth}`,     // UP   — back to bottom edge level
-        `h ${-flatAfter}`,         // LEFT — flat run to left end
+        `h ${-flatBefore}`, // LEFT — flat run to notch right edge
+        `v ${botNotchDepth}`, // DOWN — protrude below the bottom edge
+        `h ${-botNotchWidth}`, // LEFT — across the notch tab
+        `v ${-botNotchDepth}`, // UP   — back to bottom edge level
+        `h ${-flatAfter}`, // LEFT — flat run to left end
     ];
 }
 
@@ -223,7 +216,11 @@ function segLeftEdge(height: number, strokeWidth: number): string[] {
  * @param strokeWidth        - Stroke width in SVG units
  * @param hasNestedTopNotch  - Whether to draw the nested-top notch tab
  */
-function segTailCavityRoof(width: number, strokeWidth: number, hasNestedTopNotch: boolean): string[] {
+function segTailCavityRoof(
+    width: number,
+    strokeWidth: number,
+    hasNestedTopNotch: boolean,
+): string[] {
     const s = strokeWidth;
     const span = width - TAIL_INDENT_W - s / 2 - s / 2;
 
@@ -244,14 +241,14 @@ function segTailCavityRoof(width: number, strokeWidth: number, hasNestedTopNotch
     // Going RIGHT → LEFT along the cavity roof
     // Tab left edge at absolute x = TAIL_INDENT_W + NESTED_NOTCH_OFFSET_X + s
     const flatBefore = span - (NESTED_NOTCH_OFFSET_X + NOTCH_WIDTH - s);
-    const flatAfter  = NESTED_NOTCH_OFFSET_X + s;
+    const flatAfter = NESTED_NOTCH_OFFSET_X + s;
 
     return [
-        `h ${-flatBefore}`,    // LEFT — flat run to tab right edge
-        `v ${tabDepth}`,       // DOWN — tab protrudes into cavity
-        `h ${-tabWidth}`,      // LEFT — across the tab
-        `v ${-tabDepth}`,      // UP   — back to roof level
-        `h ${-flatAfter}`,     // LEFT — flat run to cavity left wall
+        `h ${-flatBefore}`, // LEFT — flat run to tab right edge
+        `v ${tabDepth}`, // DOWN — tab protrudes into cavity
+        `h ${-tabWidth}`, // LEFT — across the tab
+        `v ${-tabDepth}`, // UP   — back to roof level
+        `h ${-flatAfter}`, // LEFT — flat run to cavity left wall
     ];
 }
 
@@ -267,8 +264,7 @@ function segTailCavityLeft(nestHeight: number, strokeWidth: number): string[] {
  * @param strokeWidth           - Stroke width in SVG units
  * @param hasNestedBottomNotch  - Whether to draw the nested-bottom notch groove
  */
-function segTailFoot(strokeWidth: number, hasNestedBottomNotch: boolean): string[] {
-    const s = strokeWidth;
+function segTailFoot(_strokeWidth: number, hasNestedBottomNotch: boolean): string[] {
     const span = TAIL_STEP_W - TAIL_INDENT_W;
 
     // No nested notch — single flat span
@@ -283,14 +279,14 @@ function segTailFoot(strokeWidth: number, hasNestedBottomNotch: boolean): string
     // Going LEFT → RIGHT along the cavity floor
     // Groove left edge at absolute x = TAIL_INDENT_W + NESTED_NOTCH_OFFSET_X
     const flatBefore = NESTED_NOTCH_OFFSET_X;
-    const flatAfter  = span - NESTED_NOTCH_OFFSET_X - NOTCH_WIDTH;
+    const flatAfter = span - NESTED_NOTCH_OFFSET_X - NOTCH_WIDTH;
 
     return [
-        `h ${flatBefore}`,     // RIGHT — flat run to groove left edge
-        `v ${grooveDepth}`,    // DOWN  — groove into the foot
-        `h ${grooveWidth}`,    // RIGHT — across the groove
-        `v ${-grooveDepth}`,   // UP    — back to floor level
-        `h ${flatAfter}`,      // RIGHT — flat run to step right wall
+        `h ${flatBefore}`, // RIGHT — flat run to groove left edge
+        `v ${grooveDepth}`, // DOWN  — groove into the foot
+        `h ${grooveWidth}`, // RIGHT — across the groove
+        `v ${-grooveDepth}`, // UP    — back to floor level
+        `h ${flatAfter}`, // RIGHT — flat run to step right wall
     ];
 }
 
@@ -327,11 +323,11 @@ function segTailStepBottom(hasBottomNotch: boolean, strokeWidth: number): string
     const flatAfter = NOTCH_OFFSET_X + s / 2;
 
     return [
-        `h ${-flatBefore}`,        // LEFT — flat run to notch right edge
-        `v ${botNotchDepth}`,      // DOWN — protrude below the bottom edge
-        `h ${-botNotchWidth}`,     // LEFT — across the notch tab
-        `v ${-botNotchDepth}`,     // UP   — back to bottom edge level
-        `h ${-flatAfter}`,         // LEFT — flat run to left end
+        `h ${-flatBefore}`, // LEFT — flat run to notch right edge
+        `v ${botNotchDepth}`, // DOWN — protrude below the bottom edge
+        `h ${-botNotchWidth}`, // LEFT — across the notch tab
+        `v ${-botNotchDepth}`, // UP   — back to bottom edge level
+        `h ${-flatAfter}`, // LEFT — flat run to left end
     ];
 }
 
@@ -441,28 +437,37 @@ export function createBrickOutlineGenerator(
         // Nesting brick: top → right → cavityRoof → cavityLeft → foot → stepRight → stepBottom → left → close
         const segments = !hasNesting
             ? [
-                ...segTopEdge(width, strokeWidth, hasTopNotch),
-                ...segHeadRight(headHeight, strokeWidth),
-                ...segHeadBottom(width, strokeWidth, hasBottomNotch),
-                ...segLeftEdge(height, strokeWidth),
-                'z',
-            ]
+                  ...segTopEdge(width, strokeWidth, hasTopNotch),
+                  ...segHeadRight(headHeight, strokeWidth),
+                  ...segHeadBottom(width, strokeWidth, hasBottomNotch),
+                  ...segLeftEdge(height, strokeWidth),
+                  'z',
+              ]
             : [
-                ...segTopEdge(width, strokeWidth, hasTopNotch),
-                ...segHeadRight(headHeight, strokeWidth),
-                ...segTailCavityRoof(width, strokeWidth, hasNestedTopNotch),
-                ...segTailCavityLeft(nestHeight, strokeWidth),
-                ...segTailFoot(strokeWidth, hasNestedBottomNotch),
-                ...segTailStepRight(),
-                ...segTailStepBottom(hasBottomNotch, strokeWidth),
-                ...segLeftEdge(height, strokeWidth),
-                'z',
-            ];
+                  ...segTopEdge(width, strokeWidth, hasTopNotch),
+                  ...segHeadRight(headHeight, strokeWidth),
+                  ...segTailCavityRoof(width, strokeWidth, hasNestedTopNotch),
+                  ...segTailCavityLeft(nestHeight, strokeWidth),
+                  ...segTailFoot(strokeWidth, hasNestedBottomNotch),
+                  ...segTailStepRight(),
+                  ...segTailStepBottom(hasBottomNotch, strokeWidth),
+                  ...segLeftEdge(height, strokeWidth),
+                  'z',
+              ];
 
         const path = segments.join(' ');
 
         const bounds = generateBounds(input, width, headHeight, nestHeight, hasNesting, minimums);
 
-        return { path, width, height, bounds, topNotchDepth, bottomNotchDepth, nestedTopNotchDepth, nestedBottomNotchDepth };
+        return {
+            path,
+            width,
+            height,
+            bounds,
+            topNotchDepth,
+            bottomNotchDepth,
+            nestedTopNotchDepth,
+            nestedBottomNotchDepth,
+        };
     };
 }

--- a/modules/masonry/src/brick/utils/path2.ts
+++ b/modules/masonry/src/brick/utils/path2.ts
@@ -9,9 +9,9 @@ import type {
 
 // ── Head padding ──
 /** Distance from the top edge of the head to its inner content */
-export const HEAD_PAD_Y1 = 4;
+export const HEAD_PAD_Y1 = 5;
 /** Distance from the bottom edge of the head to its inner content */
-export const HEAD_PAD_Y2 = 4;
+export const HEAD_PAD_Y2 = 3;
 /** Distance from the left edge of the head to its inner content */
 export const HEAD_PAD_X1 = 7;
 /** Distance from the right edge of the head to its inner content */
@@ -32,18 +32,25 @@ export const TAIL_STEP_W = 30;
 export const TAIL_STEP_H = 6;
 
 // ── Notch geometry ──
-// Top notch is a full-size downward groove.
-// Bottom notch is a smaller downward tab (width reduced by 2*s for interlocking).
-// Both notch centres align at x = NOTCH_OFFSET_X + NOTCH_WIDTH / 2.
+// Each notch is a smooth semicircular arc.
+//
+// Groove (TopNotch / NestedBottomNotch) = full-size inward cut (width = NOTCH_WIDTH)
+// Tab    (BottomNotch / NestedTopNotch)  = smaller outward protrusion (width = NOTCH_WIDTH - 2*s)
+//
+// Both notch centres align at x = NOTCH_CENTER_X
+// Tab width shrinks by s on each side (2*s total) for interlocking
+// Groove uses the full NOTCH_WIDTH
+// Outer corner radius is NOTCH_CORNER_RADIUS, inner corner is sharp (0)
+// Sweep flags control convexity/concavity
 
-/** Base width of the top notch (full-size groove) in SVG units */
-export const NOTCH_WIDTH = 10;
-/** Base depth of the notch groove / tab in SVG units (must be <= HEAD_PAD_Y1) */
-export const NOTCH_DEPTH = 2;
-/** Left edge offset for the top notch (bottom notch aligns to this centre) */
-export const NOTCH_OFFSET_X = 8;
-/** Left edge offset for nested notches, measured from TAIL_INDENT_W */
-export const NESTED_NOTCH_OFFSET_X = 8;
+/** Base width of the notch opening in SVG units */
+export const NOTCH_WIDTH = 8;
+/** Corner radius for the quarter-circle transitions at each side of the notch */
+export const NOTCH_CORNER_RADIUS = 1;
+/** Absolute center for the top/bottom notch from the brick's left edge */
+export const NOTCH_CENTER_X = 12;
+/** Absolute center for nested notches, measured from TAIL_INDENT_W */
+export const NESTED_NOTCH_CENTER_X = 12;
 
 // ────────────────────────── Dimension Calculation ──────────────────────────
 
@@ -130,11 +137,58 @@ export function computeDimensions(
     return { width, height, headHeight, nestHeight };
 }
 
+// ────────────────────────── Arc Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Generates an arc for a GROOVE (inward U-shape cut).
+ * Used by TopNotch and NestedBottomNotch.
+ * Direction: positive horizontal (left → right).
+ *
+ * @param w - Full width of the groove opening
+ * @param r - Corner radius for the rounded transitions
+ * @returns Array with 3 SVG arc command strings
+ */
+function arcGroove(w: number, r: number): string[] {
+    const effectiveR = Math.min(r, w / 2);
+    const R = (w - 2 * effectiveR) / 2;
+    return [
+        // Quarter-arc: horizontal (left) → vertical (down). CW
+        `a ${effectiveR} ${effectiveR} 0 0 1 ${effectiveR} ${effectiveR}`,
+        // Semicircle: vertical (down) → vertical (up). CCW (U-shape)
+        `a ${R} ${R} 0 0 0 ${w - 2 * effectiveR} 0`,
+        // Quarter-arc: vertical (up) → horizontal (right). CW
+        `a ${effectiveR} ${effectiveR} 0 0 1 ${effectiveR} ${-effectiveR}`,
+    ];
+}
+
+/**
+ * Generates an arc for a TAB (outward U-shape protrusion).
+ * Used by BottomNotch and NestedTopNotch.
+ * Direction: negative horizontal (right → left).
+ *
+ * @param w - Width of the tab (NOTCH_WIDTH - 2*s)
+ * @param r - Corner radius for the rounded transitions
+ * @returns Array with 3 SVG arc command strings
+ */
+function arcTab(w: number, r: number): string[] {
+    const effectiveR = Math.min(r, w / 2);
+    const R = (w - 2 * effectiveR) / 2;
+    return [
+        // Quarter-arc: horizontal (right) → vertical (down). CCW
+        `a ${effectiveR} ${effectiveR} 0 0 0 ${-effectiveR} ${effectiveR}`,
+        // Semicircle: vertical (down) → vertical (up). CW (U-shape)
+        `a ${R} ${R} 0 0 1 ${-(w - 2 * effectiveR)} 0`,
+        // Quarter-arc: vertical (up) → horizontal (left). CCW
+        `a ${effectiveR} ${effectiveR} 0 0 0 ${-effectiveR} ${-effectiveR}`,
+    ];
+}
+
 // ────────────────────────── Path Segments ────────────────────────────────────────────────────────
 
 /**
  * Top edge of the brick, left → right.
- * Draws a downward groove (hasTopNotch) for interlocking with bricks above.
+ * Draws a full-size arc groove (hasTopNotch) for interlocking with bricks above.
+ * The groove cuts INWARD into the brick body.
  *
  * @param width       - Total outer width of the brick
  * @param strokeWidth - Stroke width in SVG units
@@ -149,16 +203,17 @@ function segTopEdge(width: number, strokeWidth: number, hasTopNotch: boolean): s
     }
 
     // ── Positioning ──
-    const flatBefore = NOTCH_OFFSET_X - s / 2;
-    const flatAfter = width - s / 2 - NOTCH_OFFSET_X - NOTCH_WIDTH;
+    // flatBefore: horizontal run from the starting M position to the notch left edge
+    // flatAfter:  horizontal run from the notch right edge to the brick's right edge
+    const r = NOTCH_WIDTH / 2;
+    const flatBefore = NOTCH_CENTER_X - r - s / 2;
+    const flatAfter = width - s / 2 - NOTCH_CENTER_X - r;
 
     return [
         `M ${s / 2} ${s / 2}`,
-        `h ${flatBefore}`, // flat run to notch left edge
-        `v ${NOTCH_DEPTH}`, // DOWN — groove into the brick
-        `h ${NOTCH_WIDTH}`, // RIGHT — across the groove
-        `v ${-NOTCH_DEPTH}`, // UP   — back to top edge level
-        `h ${flatAfter}`, // flat run to right end
+        `h ${flatBefore}`, // RIGHT — flat run to groove left edge
+        ...arcGroove(NOTCH_WIDTH, NOTCH_CORNER_RADIUS), // Arc groove
+        `h ${flatAfter}`, // RIGHT — flat run to brick right edge
     ];
 }
 
@@ -168,7 +223,8 @@ function segHeadRight(headHeight: number, strokeWidth: number): string[] {
 
 /**
  * Bottom edge of the head (used for bricks without nesting), right → left.
- * Draws a downward tab (hasBottomNotch), reduced in width by 2*s to fit the top groove.
+ * Draws a smaller arc tab (hasBottomNotch) protruding OUTWARD below the brick.
+ * Width is reduced by 2*s so it fits snugly inside the top groove when bricks stack.
  *
  * @param width          - Total outer width of the brick
  * @param strokeWidth    - Stroke width in SVG units
@@ -183,24 +239,25 @@ function segHeadBottom(width: number, strokeWidth: number, hasBottomNotch: boole
     }
 
     // ── Bottom notch dimensions ──
-    const botNotchWidth = NOTCH_WIDTH - 2 * s;
-    const botNotchDepth = NOTCH_DEPTH;
+    // Tab is narrower than the groove by s on each side for stroke interlocking
+    const tabWidth = NOTCH_WIDTH - 2 * s;
 
-    // Guard: if strokeWidth makes the width non-positive, fall back to flat
-    if (botNotchWidth <= 0) {
+    // Guard: tab must be valid
+    if (tabWidth <= 0) {
         return [`h ${-(width - s)}`];
     }
 
     // ── With bottom notch (going RIGHT → LEFT) ──
-    const flatBefore = width - NOTCH_OFFSET_X - NOTCH_WIDTH + s / 2;
-    const flatAfter = NOTCH_OFFSET_X + s / 2;
+    // flatBefore: from the brick's right edge to the tab's right edge
+    // flatAfter:  from the tab's left edge to the brick's left edge
+    const r = NOTCH_WIDTH / 2;
+    const flatBefore = width - NOTCH_CENTER_X - r + s / 2;
+    const flatAfter = NOTCH_CENTER_X - r + s / 2;
 
     return [
-        `h ${-flatBefore}`, // LEFT — flat run to notch right edge
-        `v ${botNotchDepth}`, // DOWN — protrude below the bottom edge
-        `h ${-botNotchWidth}`, // LEFT — across the notch tab
-        `v ${-botNotchDepth}`, // UP   — back to bottom edge level
-        `h ${-flatAfter}`, // LEFT — flat run to left end
+        `h ${-flatBefore}`, // LEFT — flat run to tab right edge
+        ...arcTab(tabWidth, NOTCH_CORNER_RADIUS), // Arc tab
+        `h ${-flatAfter}`, // LEFT — flat run to brick left edge
     ];
 }
 
@@ -210,7 +267,8 @@ function segLeftEdge(height: number, strokeWidth: number): string[] {
 
 /**
  * Cavity roof segment, right → left.
- * Draws a smaller tab (hasNestedTopNotch) protruding DOWN into the cavity.
+ * Draws a smaller arc tab (hasNestedTopNotch) protruding DOWN into the cavity.
+ * Width is reduced by 2*s so it fits inside the nested-bottom groove.
  *
  * @param width              - Total outer width of the brick
  * @param strokeWidth        - Stroke width in SVG units
@@ -231,23 +289,25 @@ function segTailCavityRoof(
 
     // Nested-top is the SMALLER tab: width reduced by 2*s for interlocking
     const tabWidth = NOTCH_WIDTH - 2 * s;
-    const tabDepth = NOTCH_DEPTH;
 
-    // Guard: if strokeWidth makes the width non-positive, fall back to flat
+    // Guard: tab must be valid
     if (tabWidth <= 0) {
         return [`h ${-span}`];
     }
 
     // Going RIGHT → LEFT along the cavity roof
     // Tab left edge at absolute x = TAIL_INDENT_W + NESTED_NOTCH_OFFSET_X + s
-    const flatBefore = span - (NESTED_NOTCH_OFFSET_X + NOTCH_WIDTH - s);
-    const flatAfter = NESTED_NOTCH_OFFSET_X + s;
+    // flatBefore: from the cavity right wall to the tab's right edge
+    // flatAfter:  from the tab's left edge to the cavity left wall
+    // Add s/2 because the inner brick's visual offset starts at TAIL_INDENT_W + s, but the cavity wall path is at TAIL_INDENT_W + s/2
+    const r = NOTCH_WIDTH / 2;
+    const offset = NESTED_NOTCH_CENTER_X - r + s / 2;
+    const flatBefore = span - (offset + NOTCH_WIDTH - s);
+    const flatAfter = offset + s;
 
     return [
         `h ${-flatBefore}`, // LEFT — flat run to tab right edge
-        `v ${tabDepth}`, // DOWN — tab protrudes into cavity
-        `h ${-tabWidth}`, // LEFT — across the tab
-        `v ${-tabDepth}`, // UP   — back to roof level
+        ...arcTab(tabWidth, NOTCH_CORNER_RADIUS), // Arc tab
         `h ${-flatAfter}`, // LEFT — flat run to cavity left wall
     ];
 }
@@ -259,12 +319,14 @@ function segTailCavityLeft(nestHeight: number, strokeWidth: number): string[] {
 
 /**
  * Cavity foot segment, left → right.
- * Draws a full-size groove (hasNestedBottomNotch) going DOWN into the foot.
+ * Draws a full-size arc groove (hasNestedBottomNotch) cutting DOWN into the foot.
+ * Full-size so it receives the inner brick's bottom tab.
  *
- * @param strokeWidth           - Stroke width in SVG units
+ * @param _strokeWidth          - Stroke width in SVG units (unused; groove is full-size)
  * @param hasNestedBottomNotch  - Whether to draw the nested-bottom notch groove
  */
-function segTailFoot(_strokeWidth: number, hasNestedBottomNotch: boolean): string[] {
+function segTailFoot(strokeWidth: number, hasNestedBottomNotch: boolean): string[] {
+    const s = strokeWidth;
     const span = TAIL_STEP_W - TAIL_INDENT_W;
 
     // No nested notch — single flat span
@@ -272,20 +334,16 @@ function segTailFoot(_strokeWidth: number, hasNestedBottomNotch: boolean): strin
         return [`h ${span}`];
     }
 
-    // Nested-bottom is the FULL-SIZE groove: NOTCH_WIDTH × NOTCH_DEPTH
-    const grooveWidth = NOTCH_WIDTH;
-    const grooveDepth = NOTCH_DEPTH;
-
-    // Going LEFT → RIGHT along the cavity floor
-    // Groove left edge at absolute x = TAIL_INDENT_W + NESTED_NOTCH_OFFSET_X
-    const flatBefore = NESTED_NOTCH_OFFSET_X;
-    const flatAfter = span - NESTED_NOTCH_OFFSET_X - NOTCH_WIDTH;
+    // Left → Right along cavity floor.
+    // +s/2 offsets the nested notch to align with the inserted inner brick.
+    const r = NOTCH_WIDTH / 2;
+    const offset = NESTED_NOTCH_CENTER_X - r + s / 2;
+    const flatBefore = offset;
+    const flatAfter = span - offset - NOTCH_WIDTH;
 
     return [
         `h ${flatBefore}`, // RIGHT — flat run to groove left edge
-        `v ${grooveDepth}`, // DOWN  — groove into the foot
-        `h ${grooveWidth}`, // RIGHT — across the groove
-        `v ${-grooveDepth}`, // UP    — back to floor level
+        ...arcGroove(NOTCH_WIDTH, NOTCH_CORNER_RADIUS), // Arc groove
         `h ${flatAfter}`, // RIGHT — flat run to step right wall
     ];
 }
@@ -296,7 +354,7 @@ function segTailStepRight(): string[] {
 
 /**
  * Bottom of the tail step (nesting bricks only), right → left.
- * Draws a downward tab similar to segHeadBottom.
+ * Draws a smaller arc tab protruding downward, same shape as segHeadBottom.
  *
  * @param hasBottomNotch - Whether to draw the bottom notch tab
  * @param strokeWidth    - Stroke width in SVG units
@@ -309,25 +367,24 @@ function segTailStepBottom(hasBottomNotch: boolean, strokeWidth: number): string
         return [`h ${-TAIL_STEP_W}`];
     }
 
-    // ── Bottom notch dimensions (strokeWidth narrower, same depth) ──
-    const botNotchWidth = NOTCH_WIDTH - 2 * s;
-    const botNotchDepth = NOTCH_DEPTH;
+    // ── Bottom notch dimensions (strokeWidth narrower for interlocking) ──
+    const tabWidth = NOTCH_WIDTH - 2 * s;
 
-    // Guard: if strokeWidth makes the width non-positive, fall back to flat
-    if (botNotchWidth <= 0) {
+    // Guard: tab must be valid
+    if (tabWidth <= 0) {
         return [`h ${-TAIL_STEP_W}`];
     }
 
-    // ── With bottom notch (going RIGHT → LEFT) ──
-    const flatBefore = TAIL_STEP_W - NOTCH_OFFSET_X - NOTCH_WIDTH + 1.5 * s;
-    const flatAfter = NOTCH_OFFSET_X + s / 2;
+    // ── With bottom notch (Right → Left) ──
+    // Absolute center is NOTCH_CENTER_X, adjusting for the TAIL_STEP_W inward shift.
+    const r = NOTCH_WIDTH / 2;
+    const flatBefore = TAIL_STEP_W - NOTCH_CENTER_X - r + 1.5 * s;
+    const flatAfter = NOTCH_CENTER_X - r + s / 2;
 
     return [
-        `h ${-flatBefore}`, // LEFT — flat run to notch right edge
-        `v ${botNotchDepth}`, // DOWN — protrude below the bottom edge
-        `h ${-botNotchWidth}`, // LEFT — across the notch tab
-        `v ${-botNotchDepth}`, // UP   — back to bottom edge level
-        `h ${-flatAfter}`, // LEFT — flat run to left end
+        `h ${-flatBefore}`, // LEFT — flat run to tab right edge
+        ...arcTab(tabWidth, NOTCH_CORNER_RADIUS), // Arc tab
+        `h ${-flatAfter}`, // LEFT — flat run to step left wall
     ];
 }
 
@@ -427,8 +484,10 @@ export function createBrickOutlineGenerator(
         const hasNestedBottomNotch = hasNesting && (input.nestedBottomNotch ?? false);
 
         // ── Compute notch protrusion depths (for SVG viewBox sizing) ──
+        const tabWidth = NOTCH_WIDTH - 2 * strokeWidth;
+        const canDrawTab = tabWidth > 0;
         const topNotchDepth = 0; // Inward groove; no extra top space needed
-        const bottomNotchDepth = hasBottomNotch ? NOTCH_DEPTH : 0;
+        const bottomNotchDepth = hasBottomNotch && canDrawTab ? tabWidth / 2 : 0;
         const nestedTopNotchDepth = 0; // Tab goes inward into cavity
         const nestedBottomNotchDepth = 0; // Groove goes into foot (no external protrusion)
 

--- a/modules/masonry/src/brick/utils/path2.ts
+++ b/modules/masonry/src/brick/utils/path2.ts
@@ -31,7 +31,19 @@ export const TAIL_STEP_W = 30;
 /** Height of the closing step at the bottom of the tail */
 export const TAIL_STEP_H = 6;
 
-// ────────────────────────── Dimension Calculation ────────────────────────────────────────────────
+// ── Notch geometry ──
+// Top notch is a full-size downward groove.
+// Bottom notch is a smaller downward tab (width reduced by 2*s for interlocking).
+// Both notch centres align at x = NOTCH_OFFSET_X + NOTCH_WIDTH / 2.
+
+/** Base width of the top notch (full-size groove) in SVG units */
+export const NOTCH_WIDTH = 10;
+/** Base depth of the notch groove / tab in SVG units (must be <= HEAD_PAD_Y1) */
+export const NOTCH_DEPTH = 2;
+/** Left edge offset for the top notch (bottom notch aligns to this centre) */
+export const NOTCH_OFFSET_X = 8;
+
+// ────────────────────────── Dimension Calculation ──────────────────────────
 
 interface ComputedDimensions {
     /** Total outer width of the brick */
@@ -118,11 +130,36 @@ export function computeDimensions(
 
 // ────────────────────────── Path Segments ────────────────────────────────────────────────────────
 
-function segTopEdge(width: number, strokeWidth: number): string[] {
-    // All segments inset by s/2: outline starts at (s/2, s/2); full-span edges lose s/2 at each end.
+/**
+ * Top edge of the brick, left → right.
+ * Draws a downward groove (hasTopNotch) for interlocking with bricks above.
+ *
+ * @param width       - Total outer width of the brick
+ * @param strokeWidth - Stroke width in SVG units
+ * @param hasTopNotch - Whether to draw the top notch groove
+ */
+function segTopEdge(width: number, strokeWidth: number, hasTopNotch: boolean): string[] {
+    const s = strokeWidth;
+
+    // ── No notch — single flat span, inset by s/2 at each end ──
+    if (!hasTopNotch) {
+        return [
+            `M ${s / 2} ${s / 2}`,
+            `h ${width - s}`,
+        ];
+    }
+
+    // ── Positioning ──
+    const flatBefore = NOTCH_OFFSET_X - s / 2;
+    const flatAfter = width - s / 2 - NOTCH_OFFSET_X - NOTCH_WIDTH;
+
     return [
-        `M ${strokeWidth / 2} ${strokeWidth / 2}`,
-        `h ${width - strokeWidth / 2 - strokeWidth / 2}`,
+        `M ${s / 2} ${s / 2}`,
+        `h ${flatBefore}`,        // flat run to notch left edge
+        `v ${NOTCH_DEPTH}`,       // DOWN — groove into the brick
+        `h ${NOTCH_WIDTH}`,       // RIGHT — across the groove
+        `v ${-NOTCH_DEPTH}`,      // UP   — back to top edge level
+        `h ${flatAfter}`,         // flat run to right end
     ];
 }
 
@@ -130,8 +167,42 @@ function segHeadRight(headHeight: number, strokeWidth: number): string[] {
     return [`v ${headHeight - strokeWidth / 2 - strokeWidth / 2}`];
 }
 
-function segHeadBottom(width: number, strokeWidth: number): string[] {
-    return [`h ${-(width - strokeWidth / 2 - strokeWidth / 2)}`];
+/**
+ * Bottom edge of the head (used for simple / non-compound bricks), right → left.
+ * Draws a downward tab (hasBottomNotch), reduced in width by 2*s to fit the top groove.
+ *
+ * @param width          - Total outer width of the brick
+ * @param strokeWidth    - Stroke width in SVG units
+ * @param hasBottomNotch - Whether to draw the bottom notch tab
+ */
+function segHeadBottom(width: number, strokeWidth: number, hasBottomNotch: boolean): string[] {
+    const s = strokeWidth;
+
+    // ── No notch — single flat span going left ──
+    if (!hasBottomNotch) {
+        return [`h ${-(width - s)}`];
+    }
+
+    // ── Bottom notch dimensions ──
+    const botNotchWidth = NOTCH_WIDTH - 2 * s;
+    const botNotchDepth = NOTCH_DEPTH;
+
+    // Guard: if strokeWidth makes the width non-positive, fall back to flat
+    if (botNotchWidth <= 0) {
+        return [`h ${-(width - s)}`];
+    }
+
+    // ── With bottom notch (going RIGHT → LEFT) ──
+    const flatBefore = width - NOTCH_OFFSET_X - NOTCH_WIDTH + s / 2;
+    const flatAfter = NOTCH_OFFSET_X + s / 2;
+
+    return [
+        `h ${-flatBefore}`,        // LEFT — flat run to notch right edge
+        `v ${botNotchDepth}`,      // DOWN — protrude below the bottom edge
+        `h ${-botNotchWidth}`,     // LEFT — across the notch tab
+        `v ${-botNotchDepth}`,     // UP   — back to bottom edge level
+        `h ${-flatAfter}`,         // LEFT — flat run to left end
+    ];
 }
 
 function segLeftEdge(height: number, strokeWidth: number): string[] {
@@ -157,8 +228,41 @@ function segTailStepRight(): string[] {
     return [`v ${TAIL_STEP_H}`];
 }
 
-function segTailStepBottom(): string[] {
-    return [`h ${-TAIL_STEP_W}`];
+/**
+ * Bottom of the tail step (compound bricks only), right → left.
+ * Draws a downward tab similar to segHeadBottom.
+ *
+ * @param hasBottomNotch - Whether to draw the bottom notch tab
+ * @param strokeWidth    - Stroke width in SVG units
+ */
+function segTailStepBottom(hasBottomNotch: boolean, strokeWidth: number): string[] {
+    const s = strokeWidth;
+
+    // ── No notch — single flat span going left ──
+    if (!hasBottomNotch) {
+        return [`h ${-TAIL_STEP_W}`];
+    }
+
+    // ── Bottom notch dimensions (strokeWidth narrower, same depth) ──
+    const botNotchWidth = NOTCH_WIDTH - 2 * s;
+    const botNotchDepth = NOTCH_DEPTH;
+
+    // Guard: if strokeWidth makes the width non-positive, fall back to flat
+    if (botNotchWidth <= 0) {
+        return [`h ${-TAIL_STEP_W}`];
+    }
+
+    // ── With bottom notch (going RIGHT → LEFT) ──
+    const flatBefore = TAIL_STEP_W - NOTCH_OFFSET_X - NOTCH_WIDTH + 1.5 * s;
+    const flatAfter = NOTCH_OFFSET_X + s / 2;
+
+    return [
+        `h ${-flatBefore}`,        // LEFT — flat run to notch right edge
+        `v ${botNotchDepth}`,      // DOWN — protrude below the bottom edge
+        `h ${-botNotchWidth}`,     // LEFT — across the notch tab
+        `v ${-botNotchDepth}`,     // UP   — back to bottom edge level
+        `h ${-flatAfter}`,         // LEFT — flat run to left end
+    ];
 }
 
 function generateBounds(
@@ -238,8 +342,10 @@ export function createBrickOutlineGenerator(
     /**
      * Computes the SVG path and layout bounds for a single brick frame.
      *
-     * @param input - Stroke width, label/param/arg dimensions, optional nesting.
-     * @returns SVG path string, outer frame dimensions, and content-region bounds.
+     * @param input - Stroke width, label/param/arg dimensions, optional nesting,
+     *               and optional topNotch / bottomNotch flags.
+     * @returns SVG path string, outer frame dimensions, content-region bounds,
+     *          and notch protrusion depths (for SVG viewBox sizing).
      */
     return (input: BrickOutlineInput): BrickOutlineOutput => {
         const { width, height, headHeight, nestHeight } = computeDimensions(input, minimums);
@@ -247,30 +353,41 @@ export function createBrickOutlineGenerator(
         const hasNesting = input.nestingDims !== undefined;
         const strokeWidth = input.strokeWidth;
 
+        // ── Resolve notch flags (default: no notches) ──
+        const hasTopNotch = input.topNotch ?? false;
+        const hasBottomNotch = input.bottomNotch ?? false;
+
+        // ── Compute notch protrusion depths (for SVG viewBox sizing) ──
+        const topNotchDepth = 0; // Inward groove; no extra top space needed
+        const bottomNotchDepth = hasBottomNotch ? NOTCH_DEPTH : 0;
+
+        // ── Build the SVG path segments ──
+        // Simple brick: top → right → bottom → left → close
+        // Compound brick: top → right → cavityRoof → cavityLeft → foot → stepRight → stepBottom → left → close
         const segments = !hasNesting
             ? [
-                  ...segTopEdge(width, strokeWidth),
-                  ...segHeadRight(headHeight, strokeWidth),
-                  ...segHeadBottom(width, strokeWidth),
-                  ...segLeftEdge(height, strokeWidth),
-                  'z',
-              ]
+                ...segTopEdge(width, strokeWidth, hasTopNotch),
+                ...segHeadRight(headHeight, strokeWidth),
+                ...segHeadBottom(width, strokeWidth, hasBottomNotch),
+                ...segLeftEdge(height, strokeWidth),
+                'z',
+            ]
             : [
-                  ...segTopEdge(width, strokeWidth),
-                  ...segHeadRight(headHeight, strokeWidth),
-                  ...segTailCavityRoof(width, strokeWidth),
-                  ...segTailCavityLeft(nestHeight, strokeWidth),
-                  ...segTailFoot(),
-                  ...segTailStepRight(),
-                  ...segTailStepBottom(),
-                  ...segLeftEdge(height, strokeWidth),
-                  'z',
-              ];
+                ...segTopEdge(width, strokeWidth, hasTopNotch),
+                ...segHeadRight(headHeight, strokeWidth),
+                ...segTailCavityRoof(width, strokeWidth),
+                ...segTailCavityLeft(nestHeight, strokeWidth),
+                ...segTailFoot(),
+                ...segTailStepRight(),
+                ...segTailStepBottom(hasBottomNotch, strokeWidth),
+                ...segLeftEdge(height, strokeWidth),
+                'z',
+            ];
 
         const path = segments.join(' ');
 
         const bounds = generateBounds(input, width, headHeight, nestHeight, hasNesting, minimums);
 
-        return { path, width, height, bounds };
+        return { path, width, height, bounds, topNotchDepth, bottomNotchDepth };
     };
 }

--- a/modules/masonry/src/brick/utils/spec/path2.spec.ts
+++ b/modules/masonry/src/brick/utils/spec/path2.spec.ts
@@ -394,6 +394,51 @@ describe('path V2: generateBrickOutline2', () => {
     });
 });
 
+// ────────────────────────── Notches ──────────────────────────────────────────────────────────────
+
+describe('path V2: notches', () => {
+    const baseInput: BrickOutlineInput = {
+        strokeWidth: 2,
+        labelDims: { w: 80, h: 20 },
+        paramArgDims: [],
+    };
+
+    it('outputs zero depths when no notches are specified', () => {
+        const result = generateBrickOutline2(baseInput);
+        expect(result.topNotchDepth).toBe(0);
+        expect(result.bottomNotchDepth).toBe(0);
+        expect(result.nestedTopNotchDepth).toBe(0);
+        expect(result.nestedBottomNotchDepth).toBe(0);
+    });
+
+    it('outputs correct depths for top and bottom notches', () => {
+        const result = generateBrickOutline2({ ...baseInput, topNotch: true, bottomNotch: true });
+        expect(result.topNotchDepth).toBe(0); // top notch is an inward groove
+        expect(result.bottomNotchDepth).toBe(2); // NOTCH_DEPTH
+    });
+
+    it('outputs correct depths for nested notches on a nesting brick', () => {
+        const result = generateBrickOutline2({
+            ...baseInput,
+            nestingDims: { w: 50, h: 50 },
+            nestedTopNotch: true,
+            nestedBottomNotch: true,
+        });
+        expect(result.nestedTopNotchDepth).toBe(0); // inward into cavity
+        expect(result.nestedBottomNotchDepth).toBe(0); // inward into foot
+    });
+
+    it('ignores nested notches if there is no nesting', () => {
+        const result = generateBrickOutline2({
+            ...baseInput,
+            nestedTopNotch: true,
+            nestedBottomNotch: true,
+        });
+        expect(result.nestedTopNotchDepth).toBe(0);
+        expect(result.nestedBottomNotchDepth).toBe(0);
+    });
+});
+
 // ────────────────────────── Validity Boundaries ──────────────────────────────────────────────────
 
 describe('path V2: validity boundaries (documented, not yet enforced)', () => {

--- a/modules/masonry/src/brick/utils/spec/path2.spec.ts
+++ b/modules/masonry/src/brick/utils/spec/path2.spec.ts
@@ -166,7 +166,7 @@ describe('path V2: computeDimensions', () => {
                 },
                 MINIMUMS,
             );
-            // headHeight = HEAD_PAD_Y1 + max(10,20) + HEAD_PAD_Y2 = 28 ; no tail
+            // headHeight = HEAD_PAD_Y1 + max(10,20) + HEAD_PAD_Y2 = 5 + 20 + 3 = 28
             expect(dims.headHeight).toBe(28);
             expect(dims.height).toBe(28);
             expect(dims.nestHeight).toBe(0);
@@ -198,7 +198,6 @@ describe('path V2: computeDimensions', () => {
                 },
                 MINIMUMS,
             );
-            // headHeight = s/2 + HEAD_PAD_Y1 + max(30,20) + HEAD_PAD_Y2 + s/2 = 3+4+30+4+3 = 44
             expect(dims.headHeight).toBe(44);
             expect(dims.height).toBe(44); // headHeight + 0 (no nesting)
         });
@@ -216,8 +215,8 @@ describe('path V2: computeDimensions', () => {
             );
             expect(dims.headHeight).toBe(32); // s/2 + HEAD_PAD_Y1 + max(20,20) + HEAD_PAD_Y2 + s/2
             expect(dims.nestHeight).toBe(50); // max(50,40)
-            // height = headHeight + (nestHeight + s/2 + TAIL_STEP_H + s/2)
-            expect(dims.height).toBe(32 + 50 + TAIL_STEP_H + s);
+            // height = headHeight + (nestHeight + s/2 + TAIL_STEP_H + s/2) = 32 + (50 + 2 + TAIL_STEP_H + 2) = 92
+            expect(dims.height).toBe(32 + 50 + 4 + TAIL_STEP_H);
         });
 
         it('enforces the minimum nesting height', () => {
@@ -246,8 +245,8 @@ describe('path V2: computeDimensions', () => {
                 },
                 MINIMUMS,
             );
-            // argsTotalHeight = 30 + 30 = 60 ; no gutter added (args account for their own strokes)
-            expect(dims.headHeight).toBe(30 + 30);
+            // argsTotalHeight = 60, but headHeightByParams now dominates: 2(s/2) + 5(pad) + 40(minParams) + 8(gutter) + 3(pad) + 2(s/2) = 60
+            expect(dims.headHeight).toBe(60);
         });
     });
 });
@@ -299,7 +298,7 @@ describe('path V2: generateBrickOutline2', () => {
             nestingDims: { w: 50, h: 50 },
         });
         // width=120, headHeight=32, nestHeight=50, height=92
-        // M s/2 s/2 ; top: 120-4=116 ; head: 32-4=28 ; roof: -(120-6-4)=-110 ; spine: 50+4=54 ; foot: 24 ; step: 6 ; bottom: -30 ; left: -(92-4)=-88
+        // M s/2 s/2 ; top: 120-4=116 ; head: 32-4=28 ; roof: -(120-6-2)= -110 ; left: 50+4=54 ; foot: 30-6 = 24 ; step: 6
         expect(result.path).toBe('M 2 2 h 116 v 28 h -110 v 54 h 24 v 6 h -30 v -88 z');
     });
 
@@ -414,7 +413,7 @@ describe('path V2: notches', () => {
     it('outputs correct depths for top and bottom notches', () => {
         const result = generateBrickOutline2({ ...baseInput, topNotch: true, bottomNotch: true });
         expect(result.topNotchDepth).toBe(0); // top notch is an inward groove
-        expect(result.bottomNotchDepth).toBe(2); // NOTCH_DEPTH
+        expect(result.bottomNotchDepth).toBe(2); // tabWidth / 2
     });
 
     it('outputs correct depths for nested notches on a nesting brick', () => {

--- a/modules/masonry/src/brick/view/components/Path.tsx
+++ b/modules/masonry/src/brick/view/components/Path.tsx
@@ -54,12 +54,12 @@ export function PathBrickView({ input }: { input: BrickOutlineInput }) {
       height={svgToPx(height)}
       style={{ overflow: 'visible' }}
     >
-      <g transform={`translate(${leftPad}, 0)`}>
+      
       {/* Debug underlay: brick bounding box */}
       <rect x={0} y={0} width={svgToPx(width)} height={svgToPx(height)} fill="#efe4e4" />
 
       {/* topPad is 0 but kept for consistency */}
-      <g transform={`translate(0, ${topPad})`}>
+      <g transform={`translate(${leftPad}, ${topPad})`}>
         <path
           d={path}
           transform={`scale(${SCALE})`}

--- a/modules/masonry/src/brick/view/components/Path.tsx
+++ b/modules/masonry/src/brick/view/components/Path.tsx
@@ -19,7 +19,7 @@ const generateBrickOutline = createBrickOutlineGenerator({
 
 export function PathBrickView({ input }: { input: BrickOutlineInput }) {
   const maxArgW = Math.max(0, ...input.paramArgDims.map((p) => p.arg?.w ?? 0));
-  const { width, height, path, bounds } = generateBrickOutline({
+  const { width, height, path, bounds, topNotchDepth, bottomNotchDepth } = generateBrickOutline({
     strokeWidth: pxToSvg(input.strokeWidth),
     labelDims: { w: pxToSvg(input.labelDims.w), h: pxToSvg(input.labelDims.h) },
     paramArgDims: input.paramArgDims.map((p) => ({
@@ -32,71 +32,83 @@ export function PathBrickView({ input }: { input: BrickOutlineInput }) {
           ? { w: pxToSvg(input.nestingDims.w), h: pxToSvg(input.nestingDims.h) }
           : null
         : undefined,
+    // Pass through notch flags (default false when absent)
+    topNotch: input.topNotch,
+    bottomNotch: input.bottomNotch,
   });
+
+  // ── Notch protrusion padding ──
+  // Only bottom notch protrudes, requiring extra SVG height.
+  const topPad = svgToPx(topNotchDepth);    // always 0 (kept for symmetry)
+  const bottomPad = svgToPx(bottomNotchDepth);
 
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width={svgToPx(width) + maxArgW}
-      height={svgToPx(height)}
+      height={svgToPx(height) + topPad + bottomPad}
+      style={{ overflow: 'visible' }}
     >
       {/* Debug underlay: brick bounding box */}
       <rect x={0} y={0} width={svgToPx(width)} height={svgToPx(height)} fill="#efe4e4" />
 
-      <path
-        d={path}
-        transform={`scale(${SCALE})`}
-        fill="#70a1ff"
-        stroke="#3867d6"
-        strokeWidth={pxToSvg(input.strokeWidth)}
-      />
-
-      {/* Debug overlay: visualises the markers */}
-      <>
-        {/* Primary label */}
-        <rect
-          x={svgToPx(bounds.label.x)}
-          y={svgToPx(bounds.label.y)}
-          width={svgToPx(bounds.label.w)}
-          height={svgToPx(bounds.label.h)}
-          fill="#ffcccc"
+      {/* topPad is 0 but kept for consistency */}
+      <g transform={`translate(0, ${topPad})`}>
+        <path
+          d={path}
+          transform={`scale(${SCALE})`}
+          fill="#70a1ff"
+          stroke="#3867d6"
+          strokeWidth={pxToSvg(input.strokeWidth)}
         />
 
-        {/* Per-parameter label areas (optional) — one rect per param name slot */}
-        {bounds.params?.map((b, i) => (
+        {/* Debug overlay: visualises the markers */}
+        <>
+          {/* Primary label */}
           <rect
-            key={i}
-            x={svgToPx(b.x)}
-            y={svgToPx(b.y)}
-            width={svgToPx(b.w)}
-            height={svgToPx(b.h)}
-            fill="#ffda79"
+            x={svgToPx(bounds.label.x)}
+            y={svgToPx(bounds.label.y)}
+            width={svgToPx(bounds.label.w)}
+            height={svgToPx(bounds.label.h)}
+            fill="#ffcccc"
           />
-        ))}
 
-        {/* Per-argument slot areas */}
-        {bounds.args?.map((b, i) => (
-          <rect
-            key={i}
-            x={svgToPx(b.x)}
-            y={svgToPx(b.y)}
-            width={svgToPx(b.w)}
-            height={svgToPx(b.h)}
-            fill={i % 2 === 0 ? '#26de819f' : '#20bf6b9f'}
-          />
-        ))}
+          {/* Per-parameter label areas (optional) — one rect per param name slot */}
+          {bounds.params?.map((b, i) => (
+            <rect
+              key={i}
+              x={svgToPx(b.x)}
+              y={svgToPx(b.y)}
+              width={svgToPx(b.w)}
+              height={svgToPx(b.h)}
+              fill="#ffda79"
+            />
+          ))}
 
-        {/* Nesting (clamp) area — present only on bricks that wrap inner blocks */}
-        {bounds.nesting && (
-          <rect
-            x={svgToPx(bounds.nesting.x)}
-            y={svgToPx(bounds.nesting.y)}
-            width={svgToPx(bounds.nesting.w)}
-            height={svgToPx(bounds.nesting.h)}
-            fill="#a5b1c27f"
-          />
-        )}
-      </>
+          {/* Per-argument slot areas */}
+          {bounds.args?.map((b, i) => (
+            <rect
+              key={i}
+              x={svgToPx(b.x)}
+              y={svgToPx(b.y)}
+              width={svgToPx(b.w)}
+              height={svgToPx(b.h)}
+              fill={i % 2 === 0 ? '#26de819f' : '#20bf6b9f'}
+            />
+          ))}
+
+          {/* Nesting (clamp) area — present only on bricks that wrap inner blocks */}
+          {bounds.nesting && (
+            <rect
+              x={svgToPx(bounds.nesting.x)}
+              y={svgToPx(bounds.nesting.y)}
+              width={svgToPx(bounds.nesting.w)}
+              height={svgToPx(bounds.nesting.h)}
+              fill="#a5b1c27f"
+            />
+          )}
+        </>
+      </g>
     </svg>
   );
 }

--- a/modules/masonry/src/brick/view/components/Path.tsx
+++ b/modules/masonry/src/brick/view/components/Path.tsx
@@ -41,7 +41,7 @@ export function PathBrickView({ input }: { input: BrickOutlineInput }) {
 
   // ── Notch protrusion padding ──
   // Only bottom notch protrudes, requiring extra SVG height.
-  const topPad = svgToPx(topNotchDepth);    // always 0 (kept for symmetry)
+  const topPad = svgToPx(topNotchDepth); // always 0 (kept for symmetry)
   const bottomPad = svgToPx(bottomNotchDepth);
 
   return (

--- a/modules/masonry/src/brick/view/components/Path.tsx
+++ b/modules/masonry/src/brick/view/components/Path.tsx
@@ -19,7 +19,7 @@ const generateBrickOutline = createBrickOutlineGenerator({
 
 export function PathBrickView({ input }: { input: BrickOutlineInput }) {
   const maxArgW = Math.max(0, ...input.paramArgDims.map((p) => p.arg?.w ?? 0));
-  const { width, height, path, bounds, topNotchDepth, bottomNotchDepth } = generateBrickOutline({
+  const { width, height, path, bounds, topNotchDepth } = generateBrickOutline({
     strokeWidth: pxToSvg(input.strokeWidth),
     labelDims: { w: pxToSvg(input.labelDims.w), h: pxToSvg(input.labelDims.h) },
     paramArgDims: input.paramArgDims.map((p) => ({
@@ -40,15 +40,13 @@ export function PathBrickView({ input }: { input: BrickOutlineInput }) {
   });
 
   // ── Notch protrusion padding ──
-  // Only bottom notch protrudes, requiring extra SVG height.
   const topPad = svgToPx(topNotchDepth); // always 0 (kept for symmetry)
-  const bottomPad = svgToPx(bottomNotchDepth);
 
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width={svgToPx(width) + maxArgW}
-      height={svgToPx(height) + topPad + bottomPad}
+      height={svgToPx(height)}
       style={{ overflow: 'visible' }}
     >
       {/* Debug underlay: brick bounding box */}

--- a/modules/masonry/src/brick/view/components/Path.tsx
+++ b/modules/masonry/src/brick/view/components/Path.tsx
@@ -35,6 +35,8 @@ export function PathBrickView({ input }: { input: BrickOutlineInput }) {
     // Pass through notch flags (default false when absent)
     topNotch: input.topNotch,
     bottomNotch: input.bottomNotch,
+    nestedTopNotch: input.nestedTopNotch,
+    nestedBottomNotch: input.nestedBottomNotch,
   });
 
   // ── Notch protrusion padding ──

--- a/modules/masonry/src/brick/view/stories/Path.stories.tsx
+++ b/modules/masonry/src/brick/view/stories/Path.stories.tsx
@@ -132,8 +132,13 @@ export const BothNotches: Story = {
 export const BothNotchesWideStroke: Story = {
   args: {
     input: {
-      strokeWidth: 4,
-      labelDims: { w: 80, h: 20 },
+      strokeWidth: 3,
+
+      labelDims: {
+        w: 80,
+        h: 20,
+      },
+
       paramArgDims: [],
       topNotch: true,
       bottomNotch: true,
@@ -210,10 +215,32 @@ export const AllNotches: Story = {
 export const AllNotchesWideStroke: Story = {
   args: {
     input: {
-      strokeWidth: 4,
-      labelDims: { w: 120, h: 20 },
-      paramArgDims: [{ param: { w: 80, h: 20 }, arg: { w: 100, h: 40 } }],
-      nestingDims: { w: 120, h: 120 },
+      strokeWidth: 3,
+
+      labelDims: {
+        w: 120,
+        h: 20,
+      },
+
+      paramArgDims: [
+        {
+          param: {
+            w: 80,
+            h: 20,
+          },
+
+          arg: {
+            w: 100,
+            h: 40,
+          },
+        },
+      ],
+
+      nestingDims: {
+        w: 120,
+        h: 120,
+      },
+
       topNotch: true,
       bottomNotch: true,
       nestedTopNotch: true,

--- a/modules/masonry/src/brick/view/stories/Path.stories.tsx
+++ b/modules/masonry/src/brick/view/stories/Path.stories.tsx
@@ -89,7 +89,7 @@ export const NestingWide: Story = {
 // The top notch is strokeWidth smaller than the bottom notch so they
 // interlock properly when bricks are stacked.
 
-/** Simple brick with only a top notch protruding upward */
+/** Brick without nesting with only a top notch protruding upward */
 export const TopNotchOnly: Story = {
   args: {
     input: {
@@ -102,7 +102,7 @@ export const TopNotchOnly: Story = {
   },
 };
 
-/** Simple brick with only a bottom notch protruding downward */
+/** Brick without nesting with only a bottom notch protruding downward */
 export const BottomNotchOnly: Story = {
   args: {
     input: {
@@ -115,7 +115,7 @@ export const BottomNotchOnly: Story = {
   },
 };
 
-/** Simple brick with both notches — centres should be vertically aligned */
+/** Brick without nesting with both notches — centres should be vertically aligned */
 export const BothNotches: Story = {
   args: {
     input: {
@@ -141,7 +141,6 @@ export const BothNotchesWideStroke: Story = {
   },
 };
 
-/** Compound brick (nesting) with both notches */
 export const NestingWithNotches: Story = {
   args: {
     input: {
@@ -149,6 +148,78 @@ export const NestingWithNotches: Story = {
       nestingDims: { w: 120, h: 120 },
       topNotch: true,
       bottomNotch: true,
+    },
+  },
+};
+
+// ── Nested notch variants ──
+// These stories demonstrate the nested-top / nested-bottom notch connectors
+// that appear on the cavity roof and floor of nesting bricks.
+
+/** Nesting brick with only a nested-top notch (smaller tab on cavity roof) */
+export const NestedTopNotchOnly: Story = {
+  args: {
+    input: {
+      ...nestingBase,
+      nestingDims: { w: 120, h: 120 },
+      nestedTopNotch: true,
+      nestedBottomNotch: false,
+    },
+  },
+};
+
+/** Nesting brick with only a nested-bottom notch (full-size groove on cavity floor) */
+export const NestedBottomNotchOnly: Story = {
+  args: {
+    input: {
+      ...nestingBase,
+      nestingDims: { w: 120, h: 120 },
+      nestedTopNotch: false,
+      nestedBottomNotch: true,
+    },
+  },
+};
+
+/** Nesting brick with both nested notches — centres should align from tail indent */
+export const BothNestedNotches: Story = {
+  args: {
+    input: {
+      ...nestingBase,
+      nestingDims: { w: 120, h: 120 },
+      nestedTopNotch: true,
+      nestedBottomNotch: true,
+    },
+  },
+};
+
+/** Nesting brick with ALL four notches (top, bottom, nestedTop, nestedBottom) */
+export const AllNotches: Story = {
+  args: {
+    input: {
+      ...nestingBase,
+      nestingDims: { w: 120, h: 120 },
+      topNotch: true,
+      bottomNotch: true,
+      nestedTopNotch: true,
+      nestedBottomNotch: true,
+    },
+  },
+};
+
+/** All notches with a wider stroke to see the size differences */
+export const AllNotchesWideStroke: Story = {
+  args: {
+    input: {
+      strokeWidth: 4,
+      labelDims: { w: 120, h: 20 },
+      paramArgDims: [
+        { param: { w: 80, h: 20 }, arg: { w: 100, h: 40 } },
+      ],
+      nestingDims: { w: 120, h: 120 },
+      topNotch: true,
+      bottomNotch: true,
+      nestedTopNotch: true,
+      nestedBottomNotch: true,
     },
   },
 };

--- a/modules/masonry/src/brick/view/stories/Path.stories.tsx
+++ b/modules/masonry/src/brick/view/stories/Path.stories.tsx
@@ -83,3 +83,72 @@ export const NestingNarrow: Story = {
 export const NestingWide: Story = {
   args: { input: { ...nestingBase, nestingDims: { w: 300, h: 120 } } },
 };
+
+// ── Notch variants ──
+// These stories demonstrate the top / bottom notch connector tabs.
+// The top notch is strokeWidth smaller than the bottom notch so they
+// interlock properly when bricks are stacked.
+
+/** Simple brick with only a top notch protruding upward */
+export const TopNotchOnly: Story = {
+  args: {
+    input: {
+      strokeWidth: 2,
+      labelDims: { w: 60, h: 20 },
+      paramArgDims: [],
+      topNotch: true,
+      bottomNotch: false,
+    },
+  },
+};
+
+/** Simple brick with only a bottom notch protruding downward */
+export const BottomNotchOnly: Story = {
+  args: {
+    input: {
+      strokeWidth: 2,
+      labelDims: { w: 60, h: 20 },
+      paramArgDims: [],
+      topNotch: false,
+      bottomNotch: true,
+    },
+  },
+};
+
+/** Simple brick with both notches — centres should be vertically aligned */
+export const BothNotches: Story = {
+  args: {
+    input: {
+      strokeWidth: 2,
+      labelDims: { w: 60, h: 20 },
+      paramArgDims: [],
+      topNotch: true,
+      bottomNotch: true,
+    },
+  },
+};
+
+/** Both notches with a wider stroke to see the size difference */
+export const BothNotchesWideStroke: Story = {
+  args: {
+    input: {
+      strokeWidth: 4,
+      labelDims: { w: 80, h: 20 },
+      paramArgDims: [],
+      topNotch: true,
+      bottomNotch: true,
+    },
+  },
+};
+
+/** Compound brick (nesting) with both notches */
+export const NestingWithNotches: Story = {
+  args: {
+    input: {
+      ...nestingBase,
+      nestingDims: { w: 120, h: 120 },
+      topNotch: true,
+      bottomNotch: true,
+    },
+  },
+};

--- a/modules/masonry/src/brick/view/stories/Path.stories.tsx
+++ b/modules/masonry/src/brick/view/stories/Path.stories.tsx
@@ -212,9 +212,7 @@ export const AllNotchesWideStroke: Story = {
     input: {
       strokeWidth: 4,
       labelDims: { w: 120, h: 20 },
-      paramArgDims: [
-        { param: { w: 80, h: 20 }, arg: { w: 100, h: 40 } },
-      ],
+      paramArgDims: [{ param: { w: 80, h: 20 }, arg: { w: 100, h: 40 } }],
       nestingDims: { w: 120, h: 120 },
       topNotch: true,
       bottomNotch: true,


### PR DESCRIPTION

### Description

**What does this PR do?**
This PR introduces the foundational geometric logic for dynamic notches on bricks in the Masonry module (`path2.ts`). The new outline generator calculates exact path boundaries and notch depths .

**Features Implemented :**
- **Top & Bottom Notches**
- **Nested Top & Nested Bottom Notches**
- **Unit Testing**: Restored and expanded the test suite in `path2.spec.ts`

**How to Test:**
1. Check out this branch.
2. Run `npm run storybook` inside `modules/masonry`.
3. Open the **Path** stories to visually verify the top, bottom, and nested notch rendering.
4. Run `npm run test` or `vitest` in the masonry module to verify all unit tests in `path2.spec.ts` are passing.