### PR TITLE
fix(masonry): [brick] update bounding box dimensions in Path component

### DIFF
--- a/modules/masonry/src/brick/view/components/Path.tsx
+++ b/modules/masonry/src/brick/view/components/Path.tsx
@@ -39,8 +39,10 @@ export function PathBrickView({ input }: { input: BrickOutlineInput }) {
       xmlns="http://www.w3.org/2000/svg"
       width={svgToPx(width) + maxArgW}
       height={svgToPx(height)}
-      style={{ backgroundColor: '#e4e4e4' }}
     >
+      {/* Debug underlay: brick bounding box */}
+      <rect x={0} y={0} width={svgToPx(width)} height={svgToPx(height)} fill="#efe4e4" />
+
       <path
         d={path}
         transform={`scale(${SCALE})`}


### PR DESCRIPTION
In the `Path` component, the bounding box is shown as the entire box including the args which actually sit outside the bounds of the brick.

We were using background color on the whole SVG to mark the bounding box. That is incorrect. This fixes it by adding a `rect` with the dimensions of the actual bounding box generated by the path generation utility.