### PR TITLE
Add left and right notches to brick outline

### DIFF
--- a/modules/masonry/src/@types/brick.d.ts
+++ b/modules/masonry/src/@types/brick.d.ts
@@ -171,6 +171,12 @@ export interface BrickOutlineInput {
      * - `Size` — nesting exists with known content dimensions
      */
     nestingDims?: Size | null;
+    /**
+     * Whether to draw the convex semicircular tab on the left edge (where this brick plugs
+     * into its parent). The tab protrusion is intentionally excluded from width/height;
+     * defaults to false. The right-edge grooves need no flag — they follow the arguments.
+     */
+    leftNotch?: boolean;
 }
 
 export interface BrickOutlineOutput {
@@ -191,6 +197,12 @@ export interface BrickOutlineOutput {
         /** Bounds of the nesting cavity; absent when there is no nesting */
         nesting?: Bounds;
     };
+    /**
+     * How far the left-edge tabs protrude beyond the brick's left edge (x = 0), in SVG
+     * units. Excluded from width/height by design; renderers may use it as a viewing
+     * gutter so the tabs aren't clipped. 0 when there are no left tabs.
+     */
+    leftNotchDepth: number;
 }
 
 export interface BrickViewProps {

--- a/modules/masonry/src/brick/utils/path2.ts
+++ b/modules/masonry/src/brick/utils/path2.ts
@@ -31,6 +31,19 @@ export const TAIL_STEP_W = 30;
 /** Height of the closing step at the bottom of the tail */
 export const TAIL_STEP_H = 6;
 
+// ── Right notch ──
+// A concave groove on the right edge that receives a side-attached arg's tab.
+// Profile (top → bottom): flat → small lip arc → semicircle → small lip arc → flat.
+// The lip arcs round the corners where the vertical edge meets the semicircle; their
+// radius scales with the stroke (3s/2) so the flare stays proportional as the stroke
+// changes. The semicircle radius is a fixed constant.
+
+/** Radius of the semicircular groove on the right edge */
+export const NOTCH_RADIUS = 4;
+/** Gap from the top of an argument slot down to its notch centre (shared by the right
+ * grooves and the left tab, so they stay aligned). */
+export const NOTCH_OFFSET = 9;
+
 // ────────────────────────── Dimension Calculation ────────────────────────────────────────────────
 
 interface ComputedDimensions {
@@ -126,16 +139,130 @@ function segTopEdge(width: number, strokeWidth: number): string[] {
     ];
 }
 
-function segHeadRight(headHeight: number, strokeWidth: number): string[] {
-    return [`v ${headHeight - strokeWidth / 2 - strokeWidth / 2}`];
+/**
+ * Right edge of the head, top → bottom.
+ * Draws a concave semicircular groove (hasRightNotch) for a side-attached arg.
+ *
+ * @param headHeight    - Height of the head section
+ * @param strokeWidth   - Stroke width in SVG units
+ * @param hasRightNotch - Whether to cut the right notch groove
+ */
+/**
+ * Right edge of the head, top → bottom.
+ * Draws one concave semicircular groove per entry in `notchCentres` (each value is
+ * the absolute y of a notch centre), with flat runs between them.
+ *
+ * Each groove is built from its centre outwards, one portion at a time:
+ *   flat run → lip arc → semicircle → lip arc → flat run.
+ *
+ * @param headHeight   - Height of the head section
+ * @param strokeWidth  - Stroke width in SVG units
+ * @param notchCentres - Absolute y positions (top → bottom) of each groove centre
+ */
+function segHeadRight(headHeight: number, strokeWidth: number, notchCentres: number[]): string[] {
+    const s = strokeWidth;
+
+    // The edge runs between the two corners, each inset by s/2 so the stroke isn't clipped.
+    const edgeStart = s / 2; // top-right corner (pen arrives here)
+    const edgeEnd = headHeight - s / 2; // bottom-right corner
+
+    // ── No notches — single straight run ──
+    if (notchCentres.length === 0) {
+        return [`v ${edgeEnd - edgeStart}`];
+    }
+
+    const r = NOTCH_RADIUS; // semicircle (groove) radius
+    const lip = (3 * s) / 2; // small flare arc radius, proportional to the stroke
+
+    const segs: string[] = [];
+    let pen = edgeStart; // current y of the pen, travelling downwards
+
+    for (const centre of notchCentres) {
+        // Build the notch span from its centre, one portion above and below:
+        //   centre        — the notch centre
+        //   semicircleTop — one radius above the centre
+        //   notchTop      — one lip arc above the semicircle (where the groove begins)
+        const semicircleTop = centre - r;
+        const notchTop = semicircleTop - lip;
+        // ...and symmetrically downwards (where the groove ends):
+        const semicircleBottom = centre + r;
+        const notchBottom = semicircleBottom + lip;
+
+        // Skip a notch that would overlap the previous one or run past the bottom corner,
+        // so the path stays continuous instead of self-crossing.
+        if (notchTop < pen || notchBottom > edgeEnd) {
+            continue;
+        }
+
+        // 1. flat run down to where the groove begins
+        const flatBefore = notchTop - pen;
+        segs.push(`v ${flatBefore}`);
+        // 2. lip arc: peel the edge inwards (−x) into the groove
+        segs.push(`a ${lip} ${lip} 0 0 1 ${-lip} ${lip}`);
+        // 3. semicircle: the concave groove dipping into the brick (−x)
+        segs.push(`a ${r} ${r} 0 0 0 0 ${2 * r}`);
+        // 4. lip arc: bring the edge back out to the straight line
+        segs.push(`a ${lip} ${lip} 0 0 1 ${lip} ${lip}`);
+
+        pen = notchBottom;
+    }
+
+    // 5. remaining flat run down to the bottom corner
+    segs.push(`v ${edgeEnd - pen}`);
+    return segs;
 }
 
 function segHeadBottom(width: number, strokeWidth: number): string[] {
     return [`h ${-(width - strokeWidth / 2 - strokeWidth / 2)}`];
 }
 
-function segLeftEdge(height: number, strokeWidth: number): string[] {
-    return [`v ${-(height - strokeWidth / 2 - strokeWidth / 2)}`];
+/**
+ * Left edge of the brick, bottom → top.
+ * Draws the single convex semicircular tab (at `tabCentre`) where this brick plugs into
+ * its parent, bulging OUT of the brick (−x). The tab radius is one stroke width smaller
+ * than the groove (NOTCH_RADIUS) so the wider groove receives it cleanly, and the
+ * protrusion is deliberately NOT added to the brick's width/height.
+ *
+ * Mirrors segHeadRight but travels bottom → top, so each portion's displacement is
+ * negative and the semicircle bulges out instead of cutting in.
+ *
+ * @param height       - Total outer height of the brick
+ * @param strokeWidth  - Stroke width in SVG units
+ * @param tabCentre    - Absolute y of the tab centre, or null for a plain edge
+ */
+function segLeftEdge(height: number, strokeWidth: number, tabCentre: number | null): string[] {
+    const s = strokeWidth;
+
+    // The edge runs between the two corners, each inset by s/2; travelled upward.
+    const edgeStart = height - s / 2; // bottom-left corner (pen arrives here)
+    const edgeEnd = s / 2; // top-left corner
+
+    // Tab radius = groove radius minus one stroke width, so the wider groove (drawn at
+    // NOTCH_RADIUS) receives this tab cleanly once both strokes are accounted for.
+    const r = NOTCH_RADIUS - s;
+    const lip = (3 * s) / 2; // small flare arc radius, proportional to the stroke (same as the groove's lip)
+
+    // ── No tab (none requested, or the stroke shrank it away) — single straight run up ──
+    if (tabCentre === null || r <= 0) {
+        return [`v ${-(edgeStart - edgeEnd)}`];
+    }
+
+    // Build the tab span from its centre: one lip arc + one radius on each side.
+    const notchBottom = tabCentre + r + lip; // where the tab begins (lower, reached first)
+    const notchTop = tabCentre - r - lip; // where the tab ends (upper)
+
+    // Fall back to a straight edge if the tab wouldn't fit between the two corners.
+    if (notchBottom > edgeStart || notchTop < edgeEnd) {
+        return [`v ${-(edgeStart - edgeEnd)}`];
+    }
+
+    return [
+        `v ${-(edgeStart - notchBottom)}`, // 1. flat run up to where the tab begins
+        `a ${lip} ${lip} 0 0 0 ${-lip} ${-lip}`, // 2. lip arc: peel the edge outwards (−x)
+        `a ${r} ${r} 0 0 1 0 ${-2 * r}`, // 3. semicircle: the convex tab bulging out (−x)
+        `a ${lip} ${lip} 0 0 0 ${lip} ${-lip}`, // 4. lip arc: bring the edge back in
+        `v ${-(notchTop - edgeEnd)}`, // 5. remaining flat run up to the top-left corner
+    ];
 }
 
 function segTailCavityRoof(width: number, strokeWidth: number): string[] {
@@ -172,11 +299,14 @@ function generateBounds(
     const { minLabelHeight, minNestHeight, minParamHeight, minArgHeight } = minimums;
     const strokeWidth = input.strokeWidth;
 
+    // Centre the label on the notch line (NOTCH_OFFSET below the top) so the label
+    // lines up with the connection point. For a label-only head this is also its centre.
+    const labelH = Math.max(input.labelDims.h, minLabelHeight);
     const label: Bounds = {
         x: strokeWidth / 2 + HEAD_PAD_X1,
-        y: strokeWidth / 2 + HEAD_PAD_Y1,
+        y: NOTCH_OFFSET - labelH / 2,
         w: input.labelDims.w,
-        h: Math.max(input.labelDims.h, minLabelHeight),
+        h: labelH,
     };
 
     let nesting: Bounds | undefined;
@@ -247,23 +377,49 @@ export function createBrickOutlineGenerator(
         const hasNesting = input.nestingDims !== undefined;
         const strokeWidth = input.strokeWidth;
 
+        const wantLeft = input.leftNotch ?? false;
+
+        // Constant gap from the top of an argument slot down to that slot's notch centre.
+        const offset = NOTCH_OFFSET;
+
+        // ── Right edge: one groove per argument slot ──
+        // The presence of an argument is the signal — no separate flag is needed. Walk the
+        // slots top → bottom, tracking each slot's top edge. A groove's centre is that slot
+        // top plus the constant offset, so every groove stays the same distance below where
+        // the previous argument ended (independent of arg heights).
+        const rightCentres: number[] = [];
+        let slotTop = 0;
+        for (const { arg } of input.paramArgDims) {
+            const rowH = Math.max(arg?.h ?? 0, minimums.minArgHeight);
+            if (arg !== null) {
+                const centre = slotTop + offset;
+                rightCentres.push(centre);
+            }
+            slotTop += rowH;
+        }
+
+        // ── Left edge: a single tab where this brick plugs into its parent ──
+        // Aligned with the TOP right groove: the first slot's top is 0, so its centre is
+        // just the offset — independent of the argument count.
+        const leftTabCentre = wantLeft ? offset : null;
+
         const segments = !hasNesting
             ? [
                   ...segTopEdge(width, strokeWidth),
-                  ...segHeadRight(headHeight, strokeWidth),
+                  ...segHeadRight(headHeight, strokeWidth, rightCentres),
                   ...segHeadBottom(width, strokeWidth),
-                  ...segLeftEdge(height, strokeWidth),
+                  ...segLeftEdge(height, strokeWidth, leftTabCentre),
                   'z',
               ]
             : [
                   ...segTopEdge(width, strokeWidth),
-                  ...segHeadRight(headHeight, strokeWidth),
+                  ...segHeadRight(headHeight, strokeWidth, rightCentres),
                   ...segTailCavityRoof(width, strokeWidth),
                   ...segTailCavityLeft(nestHeight, strokeWidth),
                   ...segTailFoot(),
                   ...segTailStepRight(),
                   ...segTailStepBottom(),
-                  ...segLeftEdge(height, strokeWidth),
+                  ...segLeftEdge(height, strokeWidth, leftTabCentre),
                   'z',
               ];
 
@@ -271,6 +427,13 @@ export function createBrickOutlineGenerator(
 
         const bounds = generateBounds(input, width, headHeight, nestHeight, hasNesting, minimums);
 
-        return { path, width, height, bounds };
+        // How far the left tabs protrude beyond the brick's left edge (x = 0).
+        // Reported separately so renderers can give it a viewing gutter WITHOUT it
+        // counting toward width/height (which would push connected bricks apart).
+        const tabRadius = NOTCH_RADIUS - strokeWidth;
+        const lip = (3 * strokeWidth) / 2;
+        const leftNotchDepth = leftTabCentre !== null && tabRadius > 0 ? lip + tabRadius : 0;
+
+        return { path, width, height, bounds, leftNotchDepth };
     };
 }

--- a/modules/masonry/src/brick/utils/spec/path2.spec.ts
+++ b/modules/masonry/src/brick/utils/spec/path2.spec.ts
@@ -4,6 +4,8 @@ import {
     HEAD_PAD_X1,
     HEAD_PAD_X2,
     LABEL_PARAM_GUTTER_X,
+    NOTCH_RADIUS,
+    NOTCH_OFFSET,
     TAIL_INDENT_W,
     TAIL_STEP_H,
     TAIL_STEP_W,
@@ -428,5 +430,218 @@ describe('path V2: validity boundaries (documented, not yet enforced)', () => {
         expect(cavityInterior).toBe(50 - s);
         // Content of height 50 no longer fits inside the inset cavity (50 - 4 = 46 < 50).
         expect(cavityInterior).toBeLessThan(50);
+    });
+});
+
+// ────────────────────────── Notches ──────────────────────────────────────────────────────────────
+
+interface ArcSeg {
+    rx: number;
+    sweep: number;
+    dx: number;
+    dy: number;
+}
+
+/** Extract every elliptical-arc (`a rx ry rot large sweep dx dy`) segment from a path. */
+function parseArcs(path: string): ArcSeg[] {
+    const tokens = path.trim().split(/\s+/);
+    const arcs: ArcSeg[] = [];
+    for (let i = 0; i < tokens.length; i++) {
+        if (tokens[i] === 'a') {
+            arcs.push({
+                rx: parseFloat(tokens[i + 1]),
+                sweep: parseFloat(tokens[i + 5]),
+                dx: parseFloat(tokens[i + 6]),
+                dy: parseFloat(tokens[i + 7]),
+            });
+        }
+    }
+    return arcs;
+}
+
+/** Net displacement of the whole path, INCLUDING arc segments (0,0 for a closed loop). */
+function netDisplacementFull(path: string): { dx: number; dy: number } {
+    const tokens = path.trim().split(/\s+/);
+    let dx = 0;
+    let dy = 0;
+    for (let i = 0; i < tokens.length; i++) {
+        const cmd = tokens[i];
+        if (cmd === 'h') dx += parseFloat(tokens[i + 1]);
+        else if (cmd === 'v') dy += parseFloat(tokens[i + 1]);
+        else if (cmd === 'a') {
+            dx += parseFloat(tokens[i + 6]);
+            dy += parseFloat(tokens[i + 7]);
+        }
+    }
+    return { dx, dy };
+}
+
+/**
+ * Absolute y of each semicircle centre for notches of the given radius, by walking the
+ * path. A semicircle's dy spans its full diameter, so its centre is at y + dy/2.
+ */
+function semicircleCentresY(path: string, radius: number): number[] {
+    const tokens = path.trim().split(/\s+/);
+    let y = 0;
+    const centres: number[] = [];
+    for (let i = 0; i < tokens.length; i++) {
+        const cmd = tokens[i];
+        if (cmd === 'M' || cmd === 'm') {
+            y = parseFloat(tokens[i + 2]);
+        } else if (cmd === 'v') {
+            y += parseFloat(tokens[i + 1]);
+        } else if (cmd === 'a') {
+            const rx = parseFloat(tokens[i + 1]);
+            const dy = parseFloat(tokens[i + 7]);
+            if (Math.abs(rx - radius) < 1e-9) centres.push(y + dy / 2);
+            y += dy;
+        }
+    }
+    return centres;
+}
+
+const oneArg = { param: null, arg: { w: 50, h: 40 } };
+
+describe('path V2: notches', () => {
+    it('draws no arcs when there are no args and no left tab', () => {
+        const r = generateBrickOutline2({
+            strokeWidth: 2,
+            labelDims: { w: 60, h: 20 },
+            paramArgDims: [],
+        });
+        expect(parseArcs(r.path)).toHaveLength(0);
+        expect(r.leftNotchDepth).toBe(0);
+    });
+
+    it('right grooves follow the args: one groove per argument slot, no flag needed', () => {
+        const r = generateBrickOutline2({
+            strokeWidth: 2,
+            labelDims: { w: 60, h: 20 },
+            paramArgDims: [oneArg, oneArg, oneArg],
+        });
+        const grooves = parseArcs(r.path).filter((a) => a.rx === NOTCH_RADIUS);
+        expect(grooves).toHaveLength(3);
+    });
+
+    it('left notch: exactly one tab, radius = NOTCH_RADIUS - strokeWidth', () => {
+        const s = 2;
+        const r = generateBrickOutline2({
+            strokeWidth: s,
+            labelDims: { w: 60, h: 20 },
+            paramArgDims: [oneArg, oneArg, oneArg],
+            leftNotch: true,
+        });
+        const tabs = parseArcs(r.path).filter((a) => a.rx === NOTCH_RADIUS - s);
+        expect(tabs).toHaveLength(1);
+        // The groove is wider than the tab so it receives it cleanly.
+        expect(NOTCH_RADIUS - s).toBeLessThan(NOTCH_RADIUS);
+    });
+
+    it('left tab is excluded from width/height but reported via leftNotchDepth', () => {
+        const base: BrickOutlineInput = {
+            strokeWidth: 2,
+            labelDims: { w: 60, h: 20 },
+            paramArgDims: [oneArg, oneArg],
+            nestingDims: { w: 80, h: 80 },
+        };
+        const off = generateBrickOutline2(base);
+        const on = generateBrickOutline2({ ...base, leftNotch: true });
+
+        expect(on.width).toBe(off.width);
+        expect(on.height).toBe(off.height);
+        expect(off.leftNotchDepth).toBe(0);
+        expect(on.leftNotchDepth).toBeGreaterThan(0);
+        // The reported depth is the lip plus the (reduced) tab radius.
+        // lip = 3s/2 (s = 2), tab radius = NOTCH_RADIUS - s.
+        expect(on.leftNotchDepth).toBeCloseTo((3 * 2) / 2 + (NOTCH_RADIUS - 2));
+    });
+
+    it('right grooves do not change width/height (concave, cut inward)', () => {
+        const input: BrickOutlineInput = {
+            strokeWidth: 2,
+            labelDims: { w: 60, h: 20 },
+            paramArgDims: [oneArg, oneArg],
+        };
+        const r = generateBrickOutline2(input);
+        const dims = computeDimensions(input, MINIMUMS);
+        // Grooves are concave, so the outline's size still matches the raw dimensions.
+        expect(r.width).toBe(dims.width);
+        expect(r.height).toBe(dims.height);
+    });
+
+    it('left tab centre aligns with the top right groove (both at NOTCH_OFFSET)', () => {
+        const s = 2;
+        const r = generateBrickOutline2({
+            strokeWidth: s,
+            labelDims: { w: 60, h: 20 },
+            paramArgDims: [oneArg, oneArg, oneArg],
+            leftNotch: true,
+        });
+        const grooveCentres = semicircleCentresY(r.path, NOTCH_RADIUS);
+        const tabCentres = semicircleCentresY(r.path, NOTCH_RADIUS - s);
+
+        expect(tabCentres).toHaveLength(1);
+        expect(grooveCentres[0]).toBeCloseTo(NOTCH_OFFSET);
+        expect(tabCentres[0]).toBeCloseTo(grooveCentres[0]);
+    });
+
+    it('groove centres anchor to each arg slot top + offset (handles uneven heights)', () => {
+        // Slot tops: 0, 40, 100 -> centres: 9, 49, 109 (with NOTCH_OFFSET = 9).
+        const r = generateBrickOutline2({
+            strokeWidth: 2,
+            labelDims: { w: 60, h: 20 },
+            paramArgDims: [
+                { param: null, arg: { w: 50, h: 40 } },
+                { param: null, arg: { w: 50, h: 60 } },
+                { param: null, arg: { w: 50, h: 40 } },
+            ],
+        });
+        const centres = semicircleCentresY(r.path, NOTCH_RADIUS);
+        expect(centres[0]).toBeCloseTo(0 + NOTCH_OFFSET);
+        expect(centres[1]).toBeCloseTo(40 + NOTCH_OFFSET);
+        expect(centres[2]).toBeCloseTo(40 + 60 + NOTCH_OFFSET);
+    });
+
+    it('the label is centred on the notch line', () => {
+        const r = generateBrickOutline2({
+            strokeWidth: 2,
+            labelDims: { w: 60, h: 20 },
+            paramArgDims: [oneArg],
+        });
+        const labelCentreY = r.bounds.label.y + r.bounds.label.h / 2;
+        expect(labelCentreY).toBeCloseTo(NOTCH_OFFSET);
+    });
+
+    it('the outline still closes (net displacement = 0) with notches on', () => {
+        const simple = generateBrickOutline2({
+            strokeWidth: 2,
+            labelDims: { w: 60, h: 20 },
+            paramArgDims: [oneArg, oneArg, oneArg],
+            leftNotch: true,
+        });
+        const compound = generateBrickOutline2({
+            strokeWidth: 2,
+            labelDims: { w: 60, h: 20 },
+            paramArgDims: [oneArg, oneArg],
+            nestingDims: { w: 80, h: 80 },
+            leftNotch: true,
+        });
+        for (const r of [simple, compound]) {
+            const { dx, dy } = netDisplacementFull(r.path);
+            expect(dx).toBeCloseTo(0);
+            expect(dy).toBeCloseTo(0);
+        }
+    });
+
+    it('draws no tab when the stroke shrinks the tab radius to zero', () => {
+        // tab radius = NOTCH_RADIUS - strokeWidth; a stroke == NOTCH_RADIUS zeroes it.
+        const noTab = generateBrickOutline2({
+            strokeWidth: NOTCH_RADIUS,
+            labelDims: { w: 60, h: 20 },
+            paramArgDims: [oneArg],
+            leftNotch: true,
+        });
+        expect(parseArcs(noTab.path)).toHaveLength(0);
+        expect(noTab.leftNotchDepth).toBe(0);
     });
 });

--- a/modules/masonry/src/brick/view/components/Path.tsx
+++ b/modules/masonry/src/brick/view/components/Path.tsx
@@ -19,7 +19,7 @@ const generateBrickOutline = createBrickOutlineGenerator({
 
 export function PathBrickView({ input }: { input: BrickOutlineInput }) {
   const maxArgW = Math.max(0, ...input.paramArgDims.map((p) => p.arg?.w ?? 0));
-  const { width, height, path, bounds } = generateBrickOutline({
+  const { width, height, path, bounds, leftNotchDepth } = generateBrickOutline({
     strokeWidth: pxToSvg(input.strokeWidth),
     labelDims: { w: pxToSvg(input.labelDims.w), h: pxToSvg(input.labelDims.h) },
     paramArgDims: input.paramArgDims.map((p) => ({
@@ -32,14 +32,20 @@ export function PathBrickView({ input }: { input: BrickOutlineInput }) {
           ? { w: pxToSvg(input.nestingDims.w), h: pxToSvg(input.nestingDims.h) }
           : null
         : undefined,
+    leftNotch: input.leftNotch,
   });
+
+  // Viewing gutter so left-edge tabs (which protrude past x=0 and are excluded from
+  // width by design) aren't clipped. Purely visual — does not change brick dimensions.
+  const leftPad = svgToPx(leftNotchDepth);
 
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width={svgToPx(width) + maxArgW}
+      width={svgToPx(width) + maxArgW + leftPad}
       height={svgToPx(height)}
     >
+      <g transform={`translate(${leftPad}, 0)`}>
       {/* Debug underlay: brick bounding box */}
       <rect x={0} y={0} width={svgToPx(width)} height={svgToPx(height)} fill="#efe4e4" />
 
@@ -97,6 +103,7 @@ export function PathBrickView({ input }: { input: BrickOutlineInput }) {
           />
         )}
       </>
+      </g>
     </svg>
   );
 }

--- a/modules/masonry/src/brick/view/stories/Path.stories.tsx
+++ b/modules/masonry/src/brick/view/stories/Path.stories.tsx
@@ -14,6 +14,48 @@ const meta: Meta<typeof PathBrickView> = {
 export default meta;
 type Story = StoryObj<typeof PathBrickView>;
 
+// ── Interactive playground: drive arg count / height from Storybook controls ──
+
+function RightNotchPlaygroundView({
+  argCount,
+  arg1Height,
+  arg2Height,
+  arg3Height,
+  arg4Height,
+  arg5Height,
+  argWidth,
+  strokeWidth,
+  leftNotch,
+}: {
+  argCount: number;
+  arg1Height: number;
+  arg2Height: number;
+  arg3Height: number;
+  arg4Height: number;
+  arg5Height: number;
+  argWidth: number;
+  strokeWidth: number;
+  leftNotch: boolean;
+}) {
+  // One height per argument, so each slot can be sized independently.
+  const heights = [arg1Height, arg2Height, arg3Height, arg4Height, arg5Height];
+  const paramArgDims = Array.from({ length: argCount }, (_, i) => ({
+    param: null,
+    arg: { w: argWidth, h: heights[i] },
+  }));
+  return (
+    <PathBrickView
+      input={{
+        strokeWidth,
+        labelDims: { w: 120, h: 20 },
+        paramArgDims,
+        nestingDims: { w: 120, h: 120 },
+        leftNotch,
+      }}
+    />
+  );
+}
+
 // ── No nesting ──
 
 export const JustLabel: Story = {
@@ -82,4 +124,64 @@ export const NestingNarrow: Story = {
 
 export const NestingWide: Story = {
   args: { input: { ...nestingBase, nestingDims: { w: 300, h: 120 } } },
+};
+
+// ── Right notch (nested brick, one groove per arg) ──
+
+export const NestingRightNotch: Story = {
+  args: {
+    input: {
+      strokeWidth: 2,
+      labelDims: { w: 120, h: 20 },
+      paramArgDims: [
+        { param: null, arg: { w: 100, h: 40 } },
+        { param: null, arg: { w: 100, h: 40 } },
+      ],
+      nestingDims: { w: 120, h: 120 },
+    },
+  },
+};
+
+// Three args with different heights — each notch must anchor to its own slot.
+export const NestingRightNotch3Args: Story = {
+  args: {
+    input: {
+      strokeWidth: 2,
+      labelDims: { w: 120, h: 20 },
+      paramArgDims: [
+        { param: null, arg: { w: 100, h: 40 } },
+        { param: null, arg: { w: 100, h: 80 } },
+        { param: null, arg: { w: 100, h: 40 } },
+      ],
+      nestingDims: { w: 120, h: 120 },
+    },
+  },
+};
+
+// Drag the sliders: change how many args exist and how tall they are, and watch
+// the right-edge notches re-align (one groove per arg, anchored to its slot top).
+export const RightNotchPlayground: StoryObj<typeof RightNotchPlaygroundView> = {
+  args: {
+    argCount: 3,
+    arg1Height: 40,
+    arg2Height: 60,
+    arg3Height: 80,
+    arg4Height: 40,
+    arg5Height: 40,
+    argWidth: 100,
+    strokeWidth: 2,
+    leftNotch: true,
+  },
+  argTypes: {
+    argCount: { control: { type: 'range', min: 0, max: 5, step: 1 } },
+    arg1Height: { control: { type: 'range', min: 20, max: 120, step: 5 } },
+    arg2Height: { control: { type: 'range', min: 20, max: 120, step: 5 } },
+    arg3Height: { control: { type: 'range', min: 20, max: 120, step: 5 } },
+    arg4Height: { control: { type: 'range', min: 20, max: 120, step: 5 } },
+    arg5Height: { control: { type: 'range', min: 20, max: 120, step: 5 } },
+    argWidth: { control: { type: 'range', min: 40, max: 160, step: 10 } },
+    strokeWidth: { control: { type: 'range', min: 1, max: 6, step: 1 } },
+    leftNotch: { control: 'boolean' },
+  },
+  render: (args) => <RightNotchPlaygroundView {...args} />,
 };


### PR DESCRIPTION
Adds interlocking notches to the brick outline (path2):

- **Right edge** - one concave semicircular groove per argument slot, each  centred a fixed offset below its slot, so grooves stay aligned with the arguments regardless of their heights.
- **Left edge** - a single convex tab where the brick plugs into its parent, aligned with the top right groove. Its radius is one stroke width smaller than the groove so the two seat together cleanly.

The left tab is excluded from the brick's width/height (otherwise connected bricks would be pushed apart) and reported separately as `leftNotchDepth`, which the Path view uses as a gutter so the tab isn't clipped. The label is centred on the notch line.

Both notches are off by default. Added a Storybook playground (argCount /argHeight / left+right toggles) to check alignment, and tests covering groove count, tab alignment, dimensions, label position, and path closure.
