### PR TITLE
chore(deps): update typescript to v6

### DIFF
--- a/lib/assets/tsconfig.json
+++ b/lib/assets/tsconfig.json
@@ -5,7 +5,6 @@
         "./**/*.tsx"
     ],
     "compilerOptions": {
-        "baseUrl": ".",
         "paths": {
             "@/*": [
                 "./src/*"

--- a/lib/components/tsconfig.json
+++ b/lib/components/tsconfig.json
@@ -5,7 +5,6 @@
         "./**/*.tsx"
     ],
     "compilerOptions": {
-        "baseUrl": ".",
         "paths": {
             "@/*": [
                 "./src/*"

--- a/lib/config/tsconfig.json
+++ b/lib/config/tsconfig.json
@@ -5,7 +5,6 @@
         "./**/*.tsx"
     ],
     "compilerOptions": {
-        "baseUrl": ".",
         "paths": {
             "@/*": [
                 "./src/*"

--- a/lib/events/tsconfig.json
+++ b/lib/events/tsconfig.json
@@ -5,7 +5,6 @@
         "./**/*.tsx"
     ],
     "compilerOptions": {
-        "baseUrl": ".",
         "paths": {
             "@/*": [
                 "./src/*"

--- a/lib/i18n/tsconfig.json
+++ b/lib/i18n/tsconfig.json
@@ -5,7 +5,6 @@
         "./**/*.tsx"
     ],
     "compilerOptions": {
-        "baseUrl": ".",
         "paths": {
             "@/*": [
                 "./src/*"

--- a/lib/transport/tsconfig.json
+++ b/lib/transport/tsconfig.json
@@ -5,7 +5,6 @@
         "./**/*.tsx"
     ],
     "compilerOptions": {
-        "baseUrl": ".",
         "paths": {
             "@/*": [
                 "./src/*"

--- a/lib/view/tsconfig.json
+++ b/lib/view/tsconfig.json
@@ -5,7 +5,6 @@
         "./**/*.tsx"
     ],
     "compilerOptions": {
-        "baseUrl": ".",
         "paths": {
             "@/*": [
                 "./src/*"

--- a/modules/code-builder/tsconfig.json
+++ b/modules/code-builder/tsconfig.json
@@ -5,7 +5,6 @@
         "./**/*.tsx"
     ],
     "compilerOptions": {
-        "baseUrl": ".",
         "paths": {
             "@/*": [
                 "./src/*"

--- a/modules/editor/tsconfig.json
+++ b/modules/editor/tsconfig.json
@@ -5,7 +5,6 @@
         "./**/*.tsx"
     ],
     "compilerOptions": {
-        "baseUrl": ".",
         "paths": {
             "@/*": [
                 "./src/*"

--- a/modules/menu/tsconfig.json
+++ b/modules/menu/tsconfig.json
@@ -5,7 +5,6 @@
         "./**/*.tsx"
     ],
     "compilerOptions": {
-        "baseUrl": ".",
         "paths": {
             "@/*": [
                 "./src/*"

--- a/modules/painter/tsconfig.json
+++ b/modules/painter/tsconfig.json
@@ -5,7 +5,6 @@
         "./**/*.tsx"
     ],
     "compilerOptions": {
-        "baseUrl": ".",
         "paths": {
             "@/*": [
                 "./src/*"

--- a/modules/runtime/tsconfig.json
+++ b/modules/runtime/tsconfig.json
@@ -4,7 +4,6 @@
         "./**/*.ts"
     ],
     "compilerOptions": {
-        "baseUrl": ".",
         "paths": {
             "@/*": [
                 "./src/*",

--- a/modules/singer/tsconfig.json
+++ b/modules/singer/tsconfig.json
@@ -5,7 +5,6 @@
         "./**/*.tsx"
     ],
     "compilerOptions": {
-        "baseUrl": ".",
         "paths": {
             "@/*": [
                 "./src/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "textlint-rule-no-empty-section": "^1.1.0",
         "textlint-rule-terminology": "^5.2.16",
         "ts-node": "^10.9.2",
-        "typescript": "^5.8.3",
+        "typescript": "^6.0.3",
         "vite": "^6.3.5",
         "vite-plugin-compression": "^0.5.1",
         "vite-plugin-ejs": "^1.7.0",
@@ -14231,6 +14231,20 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/lerna/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -23098,9 +23112,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "textlint-rule-no-empty-section": "^1.1.0",
     "textlint-rule-terminology": "^5.2.16",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vite": "^6.3.5",
     "vite-plugin-compression": "^0.5.1",
     "vite-plugin-ejs": "^1.7.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "es2024",
     "lib": [
       "dom",
-      "dom.iterable",
       "esnext"
     ],
     "allowJs": true,
@@ -29,7 +28,7 @@
    */
   "ts-node": {
     "compilerOptions": {
-      "module": "UMD"
+      "module": "commonjs"
     }
   }
 }


### PR DESCRIPTION
Refs #573

## What changed
Updated TypeScript from `^5.8.3` to `^6.0.3` and addressed all deprecations flagged in the migration report (see #573).

### `package.json`
- `typescript`: `^5.8.3` → `^6.0.3`

### `tsconfig.json` (root)
- Removed `"dom.iterable"` from `lib` array — merged into `dom` in TS6, redundant
- Changed `"module": "UMD"` → `"module": "commonjs"` in ts-node block — UMD is deprecated in TS6

### 13 workspace tsconfigs
Removed `"baseUrl": "."` from:
`lib/assets`, `lib/components`, `lib/config`, `lib/events`, `lib/i18n`, `lib/transport`, `lib/view`, `modules/code-builder`, `modules/editor`, `modules/menu`, `modules/painter`, `modules/runtime`, `modules/singer`

`baseUrl` is deprecated in TS6. All `paths` entries were already relative so no path rewrites were needed.

## Verified
- `npm run check` — same pre-existing failure as before, no new TS errors introduced
- `npm run lint` — same pre-existing failures in `node_modules/`, unrelated to changes
- `npm run build` — passes
- `npm run test` — 293 tests passed
- npm version: `11.12.1`, node version: `v24.12.0`