### PR TITLE
fix(masonry/brick): update connector notch geometry

### DIFF
--- a/modules/masonry/src/brick/utils/path2.ts
+++ b/modules/masonry/src/brick/utils/path2.ts
@@ -45,15 +45,22 @@ export const TAIL_STEP_H = 12;
 // Groove radius = tab radius + strokeWidth (accounts for SVG stroke bleed).
 // Lip arc radii are derived from strokeWidth at each call site.
 
-/** Tab radius for V-notches (top/bottom/nested horizontal edges). */
-export const V_NOTCH_RADIUS = 4;
+/** Tab mouth radius for V-notches (top/bottom/nested horizontal edges). */
+export const V_NOTCH_RADIUS = 2;
+/** End-to-end centre-line width for V-notches. */
+export const V_NOTCH_WIDTH = 16;
 /** x-offset from the left edge (or TAIL_INDENT_W for nested notches) to a V-notch centre. */
-export const NOTCH_OFFSET_X = 18;
+export const V_NOTCH_OFFSET_X = 18;
 
-/** Tab radius for H-notches (left/right side edges). */
-export const H_NOTCH_RADIUS = 4;
+/** Tab mouth radius for H-notches (left/right side edges). */
+export const H_NOTCH_RADIUS = 2;
+/** End-to-end centre-line width for H-notches. */
+export const H_NOTCH_WIDTH = 16;
 /** y-offset from the top of an arg slot down to an H-notch centre. */
-export const NOTCH_OFFSET_Y = 16;
+export const H_NOTCH_OFFSET_Y = 16;
+
+export const NOTCH_OFFSET_X = V_NOTCH_OFFSET_X;
+export const NOTCH_OFFSET_Y = H_NOTCH_OFFSET_Y;
 
 // ── Corner geometry ──
 // Each edge pulled in by CORNER_RADIUS with a quarter-circle arc.
@@ -188,11 +195,13 @@ function buildVGroove(strokeWidth: number): string[] {
     const grooveR = V_NOTCH_RADIUS + strokeWidth / 2 + strokeWidth / 2;
     const lip = strokeWidth / 2;
     const R = grooveR - lip;
+    const middle = V_NOTCH_WIDTH - 2 * (lip + R);
     return [
         // Quarter-arc: horizontal (left) → vertical (down). CW
         arc({ x: lip, y: lip }, { x: lip, y: 0 }),
-        // Semicircle: vertical (down) → vertical (up). CCW (U-shape)
+        // Inner curve and straight span: vertical (down) → vertical (up). CCW (U-shape)
         arc({ x: R, y: R }, { x: 0, y: R }),
+        `h ${middle}`,
         arc({ x: R, y: -R }, { x: R, y: 0 }),
         // Quarter-arc: vertical (up) → horizontal (right). CW
         arc({ x: lip, y: -lip }, { x: 0, y: -lip }),
@@ -203,11 +212,13 @@ function buildVGroove(strokeWidth: number): string[] {
 function buildVTab(strokeWidth: number): string[] {
     const lip = (3 * strokeWidth) / 2;
     const R = V_NOTCH_RADIUS - strokeWidth / 2;
+    const middle = V_NOTCH_WIDTH - 2 * (lip + R);
     return [
         // Quarter-arc: horizontal (right) → vertical (down). CCW
         arc({ x: -lip, y: lip }, { x: -lip, y: 0 }),
-        // Semicircle: vertical (down) → vertical (up). CW (U-shape)
+        // Inner curve and straight span: vertical (down) → vertical (up). CW (U-shape)
         arc({ x: -R, y: R }, { x: 0, y: R }),
+        `h ${-middle}`,
         arc({ x: -R, y: -R }, { x: -R, y: 0 }),
         // Quarter-arc: vertical (up) → horizontal (left). CCW
         arc({ x: -lip, y: -lip }, { x: 0, y: -lip }),
@@ -238,10 +249,9 @@ function segTopEdge(strokeWidth: number, width: number, hasTopNotch: boolean): s
 
     // flatBefore: horizontal run from the starting M position to the notch left edge
     // flatAfter:  horizontal run from the notch right edge to the rounded top-right corner
-    // Nominal groove radius = tab radius + the tab's stroke bleed (s/2) + the groove's own stroke bleed (s/2).
-    const grooveR = V_NOTCH_RADIUS + strokeWidth / 2 + strokeWidth / 2;
-    const flatBefore = NOTCH_OFFSET_X - grooveR - strokeWidth / 2 - CORNER_RADIUS;
-    const flatAfter = width - NOTCH_OFFSET_X - grooveR - strokeWidth / 2 - CORNER_RADIUS;
+    const flatBefore = V_NOTCH_OFFSET_X - V_NOTCH_WIDTH / 2 - strokeWidth / 2 - CORNER_RADIUS;
+    const flatAfter =
+        width - V_NOTCH_OFFSET_X - V_NOTCH_WIDTH / 2 - strokeWidth / 2 - CORNER_RADIUS;
 
     return [
         start,
@@ -278,6 +288,7 @@ function segHeadRight(strokeWidth: number, headHeight: number, notchCentres: num
     const grooveR = H_NOTCH_RADIUS + strokeWidth / 2 + strokeWidth / 2;
     const lip = strokeWidth / 2; // small flare arc radius, proportional to the stroke
     const R = grooveR - lip; // drawn semicircle radius after the lip flare
+    const middle = H_NOTCH_WIDTH - 2 * (lip + R);
 
     const segs: string[] = [];
     let pen = edgeStart; // current y of the pen, travelling downwards
@@ -287,10 +298,10 @@ function segHeadRight(strokeWidth: number, headHeight: number, notchCentres: num
         //   centre        — the notch centre
         //   semicircleTop — one radius above the centre
         //   notchTop      — one lip arc above the semicircle (where the groove begins)
-        const semicircleTop = centre - R;
+        const semicircleTop = centre - middle / 2 - R;
         const notchTop = semicircleTop - lip;
         // ...and symmetrically downwards (where the groove ends):
-        const semicircleBottom = centre + R;
+        const semicircleBottom = centre + middle / 2 + R;
         const notchBottom = semicircleBottom + lip;
 
         // Skip a notch that would overlap the previous one or run past the bottom corner,
@@ -306,6 +317,7 @@ function segHeadRight(strokeWidth: number, headHeight: number, notchCentres: num
         segs.push(arc({ x: -lip, y: lip }, { x: 0, y: lip }));
         // 3. semicircle: the concave groove dipping into the brick (−x)
         segs.push(arc({ x: -R, y: R }, { x: -R, y: 0 }));
+        segs.push(`v ${middle}`);
         segs.push(arc({ x: R, y: R }, { x: 0, y: R }));
         // 4. lip arc: bring the edge back out
         segs.push(arc({ x: lip, y: lip }, { x: lip, y: 0 }));
@@ -344,8 +356,8 @@ function segHeadBottom(strokeWidth: number, width: number, hasBottomNotch: boole
     }
 
     const flatBefore =
-        width - NOTCH_OFFSET_X - V_NOTCH_RADIUS - (3 * strokeWidth) / 2 - CORNER_RADIUS;
-    const flatAfter = NOTCH_OFFSET_X - V_NOTCH_RADIUS - (3 * strokeWidth) / 2 - CORNER_RADIUS;
+        width - V_NOTCH_OFFSET_X - V_NOTCH_WIDTH / 2 - strokeWidth / 2 - CORNER_RADIUS;
+    const flatAfter = V_NOTCH_OFFSET_X - V_NOTCH_WIDTH / 2 - strokeWidth / 2 - CORNER_RADIUS;
 
     return [
         `h ${-flatBefore}`, // flat run to tab right edge
@@ -371,6 +383,7 @@ function segLeftEdge(strokeWidth: number, height: number, hasLeftNotch: boolean)
 
     const tabR = H_NOTCH_RADIUS - strokeWidth / 2;
     const lip = (3 * strokeWidth) / 2;
+    const middle = H_NOTCH_WIDTH - 2 * (lip + tabR);
 
     // Convex top-left corner: end CR right + CR up, curving around a centre CR above.
     const corner = arc({ x: CORNER_RADIUS, y: -CORNER_RADIUS }, { x: 0, y: -CORNER_RADIUS });
@@ -379,8 +392,12 @@ function segLeftEdge(strokeWidth: number, height: number, hasLeftNotch: boolean)
         return [`v ${-(edgeStart - edgeEnd)}`, corner];
     }
 
-    const notchBottom = NOTCH_OFFSET_Y + tabR + lip;
-    const notchTop = NOTCH_OFFSET_Y - tabR - lip;
+    if (strokeWidth >= 2 * H_NOTCH_RADIUS) {
+        return [`v ${-(edgeStart - edgeEnd)}`, corner];
+    }
+
+    const notchBottom = H_NOTCH_OFFSET_Y + middle / 2 + tabR + lip;
+    const notchTop = H_NOTCH_OFFSET_Y - middle / 2 - tabR - lip;
 
     // Fall back to a straight edge if the tab wouldn't fit between the two corners.
     if (notchBottom > edgeStart || notchTop < edgeEnd) {
@@ -391,6 +408,7 @@ function segLeftEdge(strokeWidth: number, height: number, hasLeftNotch: boolean)
         `v ${-(edgeStart - notchBottom)}`, // 1. flat run up to where the tab begins
         arc({ x: -lip, y: -lip }, { x: 0, y: -lip }), // 2. lip arc: peel the edge outwards (−x)
         arc({ x: -tabR, y: -tabR }, { x: -tabR, y: 0 }), // 3. semicircle: the convex tab bulging out (−x)
+        `v ${-middle}`,
         arc({ x: tabR, y: -tabR }, { x: 0, y: -tabR }),
         arc({ x: lip, y: -lip }, { x: lip, y: 0 }), // 4. lip arc: bring the edge back in
         `v ${-(notchTop - edgeEnd)}`, // 5. remaining flat run up to the top-left corner
@@ -427,11 +445,11 @@ function segTailCavityRoof(strokeWidth: number, width: number): string[] {
     const flatBefore =
         width -
         TAIL_INDENT_W -
-        NOTCH_OFFSET_X -
-        V_NOTCH_RADIUS -
-        (5 * strokeWidth) / 2 -
+        V_NOTCH_OFFSET_X -
+        V_NOTCH_WIDTH / 2 -
+        strokeWidth / 2 -
         CORNER_RADIUS;
-    const flatAfter = NOTCH_OFFSET_X - V_NOTCH_RADIUS - strokeWidth / 2 - cavityCornerRadius;
+    const flatAfter = V_NOTCH_OFFSET_X - V_NOTCH_WIDTH / 2 - strokeWidth / 2 - cavityCornerRadius;
 
     return [
         `h ${-flatBefore}`, // flat run to tab right edge
@@ -470,9 +488,8 @@ function segTailFoot(strokeWidth: number): string[] {
 
     const span = TAIL_STEP_W - TAIL_INDENT_W;
 
-    const flatBefore = NOTCH_OFFSET_X - V_NOTCH_RADIUS - strokeWidth / 2 - cavityCornerRadius;
-    const flatAfter =
-        span - NOTCH_OFFSET_X - V_NOTCH_RADIUS - (3 * strokeWidth) / 2 - CORNER_RADIUS;
+    const flatBefore = V_NOTCH_OFFSET_X - V_NOTCH_WIDTH / 2 - strokeWidth / 2 - cavityCornerRadius;
+    const flatAfter = span - V_NOTCH_OFFSET_X - V_NOTCH_WIDTH / 2 - strokeWidth / 2 - CORNER_RADIUS;
 
     // Convex foot → step-right corner: end CR right + CR down, curving around a centre CR to the right.
     const corner = arc({ x: CORNER_RADIUS, y: CORNER_RADIUS }, { x: CORNER_RADIUS, y: 0 });
@@ -514,8 +531,8 @@ function segTailStepBottom(strokeWidth: number, hasBottomNotch: boolean): string
     }
 
     const flatBefore =
-        TAIL_STEP_W - NOTCH_OFFSET_X - V_NOTCH_RADIUS - strokeWidth / 2 - CORNER_RADIUS;
-    const flatAfter = NOTCH_OFFSET_X - V_NOTCH_RADIUS - (3 * strokeWidth) / 2 - CORNER_RADIUS;
+        TAIL_STEP_W - V_NOTCH_OFFSET_X - V_NOTCH_WIDTH / 2 - strokeWidth / 2 - CORNER_RADIUS;
+    const flatAfter = V_NOTCH_OFFSET_X - V_NOTCH_WIDTH / 2 - strokeWidth / 2 - CORNER_RADIUS;
 
     return [
         `h ${-flatBefore}`, // flat run to tab right edge

--- a/modules/masonry/src/brick/utils/path2.ts
+++ b/modules/masonry/src/brick/utils/path2.ts
@@ -46,14 +46,14 @@ export const TAIL_STEP_H = 12;
 // Lip arc radii are derived from strokeWidth at each call site.
 
 /** Centre-line radius for convex V-notch tabs. */
-export const V_NOTCH_RADIUS = 1;
+export const V_NOTCH_RADIUS = 2;
 /** End-to-end centre-line width for V-notches. */
 export const V_NOTCH_WIDTH = 16;
 /** x-offset from the left edge (or TAIL_INDENT_W for nested notches) to a V-notch centre. */
 export const V_NOTCH_OFFSET_X = 18;
 
 /** Centre-line radius for convex H-notch tabs. */
-export const H_NOTCH_RADIUS = 1;
+export const H_NOTCH_RADIUS = 2;
 /** End-to-end centre-line width for H-notches. */
 export const H_NOTCH_WIDTH = 16;
 /** y-offset from the top of an arg slot down to an H-notch centre. */

--- a/modules/masonry/src/brick/utils/path2.ts
+++ b/modules/masonry/src/brick/utils/path2.ts
@@ -45,15 +45,15 @@ export const TAIL_STEP_H = 12;
 // Groove radius = tab radius + strokeWidth (accounts for SVG stroke bleed).
 // Lip arc radii are derived from strokeWidth at each call site.
 
-/** Tab mouth radius for V-notches (top/bottom/nested horizontal edges). */
-export const V_NOTCH_RADIUS = 2;
+/** Centre-line radius for convex V-notch tabs. */
+export const V_NOTCH_RADIUS = 1;
 /** End-to-end centre-line width for V-notches. */
 export const V_NOTCH_WIDTH = 16;
 /** x-offset from the left edge (or TAIL_INDENT_W for nested notches) to a V-notch centre. */
 export const V_NOTCH_OFFSET_X = 18;
 
-/** Tab mouth radius for H-notches (left/right side edges). */
-export const H_NOTCH_RADIUS = 2;
+/** Centre-line radius for convex H-notch tabs. */
+export const H_NOTCH_RADIUS = 1;
 /** End-to-end centre-line width for H-notches. */
 export const H_NOTCH_WIDTH = 16;
 /** y-offset from the top of an arg slot down to an H-notch centre. */
@@ -191,10 +191,8 @@ function arc(end: RelPoint, centre: RelPoint): string {
 
 /** Inward U-shape groove arc (left → right). Used by top notch and nested bottom notch. */
 function buildVGroove(strokeWidth: number): string[] {
-    // Nominal groove radius = tab radius + the tab's stroke bleed (s/2) + the groove's own stroke bleed (s/2).
-    const grooveR = V_NOTCH_RADIUS + strokeWidth / 2 + strokeWidth / 2;
     const lip = strokeWidth / 2;
-    const R = grooveR - lip;
+    const R = V_NOTCH_RADIUS + strokeWidth;
     const middle = V_NOTCH_WIDTH - 2 * (lip + R);
     return [
         // Quarter-arc: horizontal (left) → vertical (down). CW
@@ -211,7 +209,7 @@ function buildVGroove(strokeWidth: number): string[] {
 /** Outward U-shape tab arc (right → left). Used by bottom notch and nested top notch. */
 function buildVTab(strokeWidth: number): string[] {
     const lip = (3 * strokeWidth) / 2;
-    const R = V_NOTCH_RADIUS - strokeWidth / 2;
+    const R = V_NOTCH_RADIUS;
     const middle = V_NOTCH_WIDTH - 2 * (lip + R);
     return [
         // Quarter-arc: horizontal (right) → vertical (down). CCW
@@ -284,10 +282,8 @@ function segHeadRight(strokeWidth: number, headHeight: number, notchCentres: num
         return [`v ${edgeEnd - edgeStart}`, corner];
     }
 
-    // Nominal groove radius = tab radius + the tab's stroke bleed (s/2) + the groove's own stroke bleed (s/2).
-    const grooveR = H_NOTCH_RADIUS + strokeWidth / 2 + strokeWidth / 2;
     const lip = strokeWidth / 2; // small flare arc radius, proportional to the stroke
-    const R = grooveR - lip; // drawn semicircle radius after the lip flare
+    const R = H_NOTCH_RADIUS + strokeWidth;
     const middle = H_NOTCH_WIDTH - 2 * (lip + R);
 
     const segs: string[] = [];
@@ -351,7 +347,7 @@ function segHeadBottom(strokeWidth: number, width: number, hasBottomNotch: boole
         return [`h ${-span}`, corner];
     }
 
-    if (strokeWidth >= 2 * V_NOTCH_RADIUS) {
+    if (V_NOTCH_WIDTH <= 2 * ((3 * strokeWidth) / 2 + V_NOTCH_RADIUS)) {
         return [`h ${-span}`, corner];
     }
 
@@ -381,7 +377,7 @@ function segLeftEdge(strokeWidth: number, height: number, hasLeftNotch: boolean)
     const edgeStart = height - strokeWidth / 2 - CORNER_RADIUS; // above the rounded bottom-left corner
     const edgeEnd = strokeWidth / 2 + CORNER_RADIUS; // below the rounded top-left corner
 
-    const tabR = H_NOTCH_RADIUS - strokeWidth / 2;
+    const tabR = H_NOTCH_RADIUS;
     const lip = (3 * strokeWidth) / 2;
     const middle = H_NOTCH_WIDTH - 2 * (lip + tabR);
 
@@ -392,7 +388,7 @@ function segLeftEdge(strokeWidth: number, height: number, hasLeftNotch: boolean)
         return [`v ${-(edgeStart - edgeEnd)}`, corner];
     }
 
-    if (strokeWidth >= 2 * H_NOTCH_RADIUS) {
+    if (middle <= 0) {
         return [`v ${-(edgeStart - edgeEnd)}`, corner];
     }
 
@@ -437,7 +433,7 @@ function segTailCavityRoof(strokeWidth: number, width: number): string[] {
         { x: -cavityCornerRadius, y: 0 },
     );
 
-    if (strokeWidth >= 2 * V_NOTCH_RADIUS) {
+    if (V_NOTCH_WIDTH <= 2 * ((3 * strokeWidth) / 2 + V_NOTCH_RADIUS)) {
         return [`h ${-span}`, corner];
     }
 
@@ -447,9 +443,9 @@ function segTailCavityRoof(strokeWidth: number, width: number): string[] {
         TAIL_INDENT_W -
         V_NOTCH_OFFSET_X -
         V_NOTCH_WIDTH / 2 -
-        strokeWidth / 2 -
+        (3 * strokeWidth) / 2 -
         CORNER_RADIUS;
-    const flatAfter = V_NOTCH_OFFSET_X - V_NOTCH_WIDTH / 2 - strokeWidth / 2 - cavityCornerRadius;
+    const flatAfter = V_NOTCH_OFFSET_X - V_NOTCH_WIDTH / 2 + strokeWidth / 2 - cavityCornerRadius;
 
     return [
         `h ${-flatBefore}`, // flat run to tab right edge
@@ -488,8 +484,9 @@ function segTailFoot(strokeWidth: number): string[] {
 
     const span = TAIL_STEP_W - TAIL_INDENT_W;
 
-    const flatBefore = V_NOTCH_OFFSET_X - V_NOTCH_WIDTH / 2 - strokeWidth / 2 - cavityCornerRadius;
-    const flatAfter = span - V_NOTCH_OFFSET_X - V_NOTCH_WIDTH / 2 - strokeWidth / 2 - CORNER_RADIUS;
+    const flatBefore = V_NOTCH_OFFSET_X - V_NOTCH_WIDTH / 2 + strokeWidth / 2 - cavityCornerRadius;
+    const flatAfter =
+        span - V_NOTCH_OFFSET_X - V_NOTCH_WIDTH / 2 - (3 * strokeWidth) / 2 - CORNER_RADIUS;
 
     // Convex foot → step-right corner: end CR right + CR down, curving around a centre CR to the right.
     const corner = arc({ x: CORNER_RADIUS, y: CORNER_RADIUS }, { x: CORNER_RADIUS, y: 0 });
@@ -526,7 +523,7 @@ function segTailStepBottom(strokeWidth: number, hasBottomNotch: boolean): string
         return [`h ${-span}`, corner];
     }
 
-    if (strokeWidth >= 2 * V_NOTCH_RADIUS) {
+    if (V_NOTCH_WIDTH <= 2 * ((3 * strokeWidth) / 2 + V_NOTCH_RADIUS)) {
         return [`h ${-span}`, corner];
     }
 

--- a/modules/masonry/src/brick/utils/spec/path2.spec.ts
+++ b/modules/masonry/src/brick/utils/spec/path2.spec.ts
@@ -110,7 +110,7 @@ describe('path V2: generateBrickOutline (integration)', () => {
             nestingDims: { w: 50, h: 50 },
         });
         expect(result.path).toBe(
-            'M 4 0 h 112 a 4 4 0 0 1 4 4 v 24 a 4 4 0 0 1 -4 4 h -86 a 0 0 0 0 0 0 0 a 4 4 0 0 1 -4 4 a 4 4 0 0 1 -4 -4 a 0 0 0 0 0 0 0 h -10 a 4 4 0 0 0 -4 4 v 42 a 4 4 0 0 0 4 4 h 10 a 0 0 0 0 0 0 0 a 4 4 0 0 0 4 4 a 4 4 0 0 0 4 -4 a 0 0 0 0 0 0 0 h 14 a 4 4 0 0 1 4 4 v 4 a 4 4 0 0 1 -4 4 h -40 a 4 4 0 0 1 -4 -4 v -86 a 4 4 0 0 1 4 -4 Z',
+            'M 4 0 h 112 a 4 4 0 0 1 4 4 v 24 a 4 4 0 0 1 -4 4 h -82 a 0 0 0 0 0 0 0 a 2 2 0 0 1 -2 2 h -12 a 2 2 0 0 1 -2 -2 a 0 0 0 0 0 0 0 h -6 a 4 4 0 0 0 -4 4 v 42 a 4 4 0 0 0 4 4 h 6 a 0 0 0 0 0 0 0 a 2 2 0 0 0 2 2 h 12 a 2 2 0 0 0 2 -2 a 0 0 0 0 0 0 0 h 10 a 4 4 0 0 1 4 4 v 4 a 4 4 0 0 1 -4 4 h -40 a 4 4 0 0 1 -4 -4 v -86 a 4 4 0 0 1 4 -4 Z',
         );
     });
 
@@ -122,7 +122,7 @@ describe('path V2: generateBrickOutline (integration)', () => {
             nestingDims: { w: 50, h: 50 },
         });
         expect(result.path).toBe(
-            'M 6 2 h 108 a 4 4 0 0 1 4 4 v 24 a 4 4 0 0 1 -4 4 h -76 a 6 6 0 0 0 -6 6 a 2 2 0 0 1 -2 2 a 2 2 0 0 1 -2 -2 a 6 6 0 0 0 -6 -6 h -4 a 8 8 0 0 0 -8 8 v 38 a 8 8 0 0 0 8 8 h 4 a 2 2 0 0 1 2 2 a 6 6 0 0 0 6 6 a 6 6 0 0 0 6 -6 a 2 2 0 0 1 2 -2 h 8 a 4 4 0 0 1 4 4 v 4 a 4 4 0 0 1 -4 4 h -40 a 4 4 0 0 1 -4 -4 v -90 a 4 4 0 0 1 4 -4 Z',
+            'M 6 2 h 108 a 4 4 0 0 1 4 4 v 24 a 4 4 0 0 1 -4 4 h -96 a 8 8 0 0 0 -8 8 v 38 a 8 8 0 0 0 8 8 h 4 a 2 2 0 0 1 2 2 a 6 6 0 0 0 6 6 h 0 a 6 6 0 0 0 6 -6 a 2 2 0 0 1 2 -2 h 4 a 4 4 0 0 1 4 4 v 4 a 4 4 0 0 1 -4 4 h -40 a 4 4 0 0 1 -4 -4 v -90 a 4 4 0 0 1 4 -4 Z',
         );
     });
 
@@ -199,7 +199,7 @@ describe('path V2: generateBrickOutline (integration)', () => {
                 paramArgDims: [oneArg, oneArg, oneArg],
                 hasOutputNotch: true,
             });
-            const grooveCentres = semicircleCentresY(r.path, H_NOTCH_RADIUS + s / 2);
+            const grooveCentres = rightEdgeGrooveCentresY(r.path, H_NOTCH_RADIUS + s);
             const tabCentre = leftTabCentreY(r.path);
             expect(grooveCentres[0]).toBeCloseTo(NOTCH_OFFSET_Y);
             expect(tabCentre).toBeCloseTo(NOTCH_OFFSET_Y);
@@ -288,27 +288,41 @@ function parseArcs(path: string): ArcSeg[] {
 }
 
 function countRightEdgeGrooves(path: string, radius: number): number {
+    return rightEdgeGrooveCentresY(path, radius).length;
+}
+
+function rightEdgeGrooveCentresY(path: string, radius: number): number[] {
     const tokens = path.trim().split(/\s+/);
-    let count = 0;
+    const centres: number[] = [];
+    let y = 0;
     for (let i = 0; i < tokens.length; i++) {
-        const isInwardArc =
-            tokens[i] === 'a' &&
-            parseFloat(tokens[i + 1]) === radius &&
-            parseFloat(tokens[i + 5]) === 0 &&
-            parseFloat(tokens[i + 6]) === -radius &&
-            parseFloat(tokens[i + 7]) === radius;
-        const isStraightSpan = tokens[i + 8] === 'v';
-        const isOutwardArc =
-            tokens[i + 10] === 'a' &&
-            parseFloat(tokens[i + 11]) === radius &&
-            parseFloat(tokens[i + 15]) === 0 &&
-            parseFloat(tokens[i + 16]) === radius &&
-            parseFloat(tokens[i + 17]) === radius;
-        if (isInwardArc && isStraightSpan && isOutwardArc) {
-            count++;
+        const cmd = tokens[i];
+        if (cmd === 'M' || cmd === 'm') {
+            y = parseFloat(tokens[i + 2]);
+        } else if (cmd === 'v') {
+            y += parseFloat(tokens[i + 1]);
+        } else if (cmd === 'a') {
+            const dy = parseFloat(tokens[i + 7]);
+            const isInwardArc =
+                parseFloat(tokens[i + 1]) === radius &&
+                parseFloat(tokens[i + 5]) === 0 &&
+                parseFloat(tokens[i + 6]) === -radius &&
+                dy === radius;
+            const isStraightSpan = tokens[i + 8] === 'v';
+            const isOutwardArc =
+                tokens[i + 10] === 'a' &&
+                parseFloat(tokens[i + 11]) === radius &&
+                parseFloat(tokens[i + 15]) === 0 &&
+                parseFloat(tokens[i + 16]) === radius &&
+                parseFloat(tokens[i + 17]) === radius;
+            if (isInwardArc && isStraightSpan && isOutwardArc) {
+                const middle = parseFloat(tokens[i + 9]);
+                centres.push(y + radius + middle / 2);
+            }
+            y += dy;
         }
     }
-    return count;
+    return centres;
 }
 
 /** Net displacement of the whole path, INCLUDING arc segments (0,0 for a closed loop). */
@@ -326,31 +340,6 @@ function netDisplacementFull(path: string): { dx: number; dy: number } {
         }
     }
     return { dx, dy };
-}
-
-// Absolute y of each semicircle centre of the given radius (centre = y + dy/2).
-function semicircleCentresY(path: string, radius: number): number[] {
-    const tokens = path.trim().split(/\s+/);
-    let y = 0;
-    const centres: number[] = [];
-    for (let i = 0; i < tokens.length; i++) {
-        const cmd = tokens[i];
-        if (cmd === 'M' || cmd === 'm') {
-            y = parseFloat(tokens[i + 2]);
-        } else if (cmd === 'v') {
-            y += parseFloat(tokens[i + 1]);
-        } else if (cmd === 'a') {
-            const rx = parseFloat(tokens[i + 1]);
-            let dy = parseFloat(tokens[i + 7]);
-            if (tokens[i + 8] === 'a' && Math.abs(parseFloat(tokens[i + 9]) - rx) < 1e-9) {
-                dy += parseFloat(tokens[i + 15]);
-                i += 8;
-            }
-            if (Math.abs(rx - radius) < 1e-9) centres.push(y + dy / 2);
-            y += dy;
-        }
-    }
-    return centres;
 }
 
 // Absolute y of the left-edge tab centre (the only arc with dx=0 and dy<0, travelling upward).

--- a/modules/masonry/src/brick/utils/spec/path2.spec.ts
+++ b/modules/masonry/src/brick/utils/spec/path2.spec.ts
@@ -180,15 +180,15 @@ describe('path V2: generateBrickOutline (integration)', () => {
     });
 
     describe('notch wiring through the public API', () => {
-        it('emits one right-edge groove per arg slot, radius H_NOTCH_RADIUS + s/2', () => {
+        it('emits one right-edge groove per arg slot, radius H_NOTCH_RADIUS + s', () => {
             const s = 2;
             const r = generateBrickOutline({
                 strokeWidth: s,
                 widgetDims: { w: 60, h: 20 },
                 paramArgDims: [oneArg, oneArg, oneArg],
             });
-            const grooves = parseArcs(r.path).filter((a) => a.rx === H_NOTCH_RADIUS + s / 2);
-            expect(grooves).toHaveLength(3);
+            const grooves = countRightEdgeGrooves(r.path, H_NOTCH_RADIUS + s);
+            expect(grooves).toBe(3);
         });
 
         it('the left tab centre aligns with the first right groove, both at NOTCH_OFFSET_Y', () => {
@@ -285,6 +285,30 @@ function parseArcs(path: string): ArcSeg[] {
         }
     }
     return arcs;
+}
+
+function countRightEdgeGrooves(path: string, radius: number): number {
+    const tokens = path.trim().split(/\s+/);
+    let count = 0;
+    for (let i = 0; i < tokens.length; i++) {
+        const isInwardArc =
+            tokens[i] === 'a' &&
+            parseFloat(tokens[i + 1]) === radius &&
+            parseFloat(tokens[i + 5]) === 0 &&
+            parseFloat(tokens[i + 6]) === -radius &&
+            parseFloat(tokens[i + 7]) === radius;
+        const isStraightSpan = tokens[i + 8] === 'v';
+        const isOutwardArc =
+            tokens[i + 10] === 'a' &&
+            parseFloat(tokens[i + 11]) === radius &&
+            parseFloat(tokens[i + 15]) === 0 &&
+            parseFloat(tokens[i + 16]) === radius &&
+            parseFloat(tokens[i + 17]) === radius;
+        if (isInwardArc && isStraightSpan && isOutwardArc) {
+            count++;
+        }
+    }
+    return count;
 }
 
 /** Net displacement of the whole path, INCLUDING arc segments (0,0 for a closed loop). */

--- a/modules/masonry/src/brick/utils/spec/path2.spec.ts
+++ b/modules/masonry/src/brick/utils/spec/path2.spec.ts
@@ -192,7 +192,7 @@ describe('path V2: generateBrickOutline (integration)', () => {
         });
 
         it('the left tab centre aligns with the first right groove, both at NOTCH_OFFSET_Y', () => {
-            const s = 4;
+            const s = 2;
             const r = generateBrickOutline({
                 strokeWidth: s,
                 widgetDims: { w: 60, h: 20 },
@@ -200,7 +200,7 @@ describe('path V2: generateBrickOutline (integration)', () => {
                 hasOutputNotch: true,
             });
             const grooveCentres = rightEdgeGrooveCentresY(r.path, H_NOTCH_RADIUS + s);
-            const tabCentre = leftTabCentreY(r.path);
+            const tabCentre = leftTabCentreY(r.path, H_NOTCH_RADIUS);
             expect(grooveCentres[0]).toBeCloseTo(NOTCH_OFFSET_Y);
             expect(tabCentre).toBeCloseTo(NOTCH_OFFSET_Y);
         });
@@ -342,8 +342,8 @@ function netDisplacementFull(path: string): { dx: number; dy: number } {
     return { dx, dy };
 }
 
-// Absolute y of the left-edge tab centre (the only arc with dx=0 and dy<0, travelling upward).
-function leftTabCentreY(path: string): number | undefined {
+// Absolute y of the left-edge tab centre.
+function leftTabCentreY(path: string, radius: number): number | undefined {
     const tokens = path.trim().split(/\s+/);
     let y = 0;
     for (let i = 0; i < tokens.length; i++) {
@@ -351,15 +351,23 @@ function leftTabCentreY(path: string): number | undefined {
         if (cmd === 'M' || cmd === 'm') y = parseFloat(tokens[i + 2]);
         else if (cmd === 'v') y += parseFloat(tokens[i + 1]);
         else if (cmd === 'a') {
-            const rx = parseFloat(tokens[i + 1]);
-            let dx = parseFloat(tokens[i + 6]);
-            let dy = parseFloat(tokens[i + 7]);
-            if (tokens[i + 8] === 'a' && Math.abs(parseFloat(tokens[i + 9]) - rx) < 1e-9) {
-                dx += parseFloat(tokens[i + 14]);
-                dy += parseFloat(tokens[i + 15]);
-                i += 8;
+            const dy = parseFloat(tokens[i + 7]);
+            const isInwardTabArc =
+                parseFloat(tokens[i + 1]) === radius &&
+                parseFloat(tokens[i + 5]) === 1 &&
+                parseFloat(tokens[i + 6]) === -radius &&
+                dy === -radius;
+            const isStraightSpan = tokens[i + 8] === 'v';
+            const isOutwardTabArc =
+                tokens[i + 10] === 'a' &&
+                parseFloat(tokens[i + 11]) === radius &&
+                parseFloat(tokens[i + 15]) === 1 &&
+                parseFloat(tokens[i + 16]) === radius &&
+                parseFloat(tokens[i + 17]) === -radius;
+            if (isInwardTabArc && isStraightSpan && isOutwardTabArc) {
+                const middle = parseFloat(tokens[i + 9]);
+                return y - radius + middle / 2;
             }
-            if (dx === 0 && dy < 0) return y + dy / 2;
             y += dy;
         }
     }


### PR DESCRIPTION
Fixes #618

  - add separate constants for horizontal and vertical notch geometry
  - update the connector notch paths to use the new 16-unit center-line width
  - keep the existing offset values and dimension calculation unchanged

Verified:
  - formatted `modules/masonry/src/brick/utils/path2.ts`
  - ran `git diff --check`
  - ran `path2.spec.ts` through a scoped `modules/masonry` install; the current tests still assert the old notch path strings, which #603 is expected to replace
  - checked simple, arg, and compound notched outlines close correctly

Could not run the full root checks locally because `npm ci` needs access to `@sugarlabs/musicblocks-v4-lib@0.2.0` from GitHub Packages.