### PR TITLE
chore(masonry): add vitest config

### DIFF
--- a/modules/masonry/src/brick/view/components/spec/BrickViewFixed.spec.tsx
+++ b/modules/masonry/src/brick/view/components/spec/BrickViewFixed.spec.tsx
@@ -1,5 +1,3 @@
-// @vitest-environment jsdom
-//
 // Component test for BrickViewFixed. Unlike the pure-math path2 specs, this
 // renders the React component into a DOM (jsdom) via React Testing Library and
 // asserts on the produced markup.

--- a/modules/masonry/vitest.config.ts
+++ b/modules/masonry/vitest.config.ts
@@ -1,0 +1,33 @@
+import type { UserConfig } from 'vite';
+
+import { defineConfig, mergeConfig } from 'vitest/config';
+import rootConfig from '../../vitest.config';
+
+export default mergeConfig(
+    rootConfig as UserConfig,
+    defineConfig({
+        test: {
+            projects: [
+                {
+                    extends: true,
+                    test: {
+                        name: 'unit',
+                        include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],
+                        exclude: ['src/**/*.spec.tsx', 'src/**/*.test.tsx'],
+                        environment: 'node',
+                    },
+                },
+                {
+                    extends: true,
+                    test: {
+                        name: 'dom',
+                        include: ['src/**/*.spec.tsx', 'src/**/*.test.tsx'],
+                        exclude: ['src/**/*.spec.ts', 'src/**/*.test.ts'],
+                        environment: 'jsdom',
+                        setupFiles: ['./vitest.setup.dom.ts'],
+                    },
+                },
+            ],
+        },
+    }),
+);

--- a/modules/masonry/vitest.setup.dom.ts
+++ b/modules/masonry/vitest.setup.dom.ts
@@ -1,0 +1,12 @@
+Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    value: () => ({
+        font: '',
+        measureText: () => ({
+            width: 0,
+            actualBoundingBoxAscent: 0,
+            actualBoundingBoxDescent: 0,
+        }),
+        fillText: () => {},
+    }),
+    writable: true,
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
       "devDependencies": {
         "@storybook/addon-a11y": "^10.4.6",
         "@storybook/react-vite": "^10.4.6",
-        "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
         "@types/lodash.clonedeep": "^4.5.9",
         "@types/node": "^25.9.3",
@@ -7662,6 +7661,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -8046,7 +8046,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -11363,7 +11364,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -16271,6 +16273,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -21403,6 +21406,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -21418,6 +21422,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -21815,7 +21820,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-is-18": {
       "name": "react-is",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
   "devDependencies": {
     "@storybook/addon-a11y": "^10.4.6",
     "@storybook/react-vite": "^10.4.6",
-    "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/lodash.clonedeep": "^4.5.9",
     "@types/node": "^25.9.3",


### PR DESCRIPTION
- Add Vitest config for masonry
- Configure JSDom as environment for `.test.tsx` and `.spec.tsx` files only