### PR TITLE
fix(brick): correct tail step width bleed for strokeWidth > 2

### DIFF
--- a/modules/masonry/src/utils/path.test.ts
+++ b/modules/masonry/src/utils/path.test.ts
@@ -102,10 +102,12 @@ describe('computeDimensions', () => {
             expect(dims.tailWidth).toBe(0);
         });
 
-        it('nesting width at crossover (TAIL_STEP_W - TAIL_INDENT_W): tailStepWidth still wins', () => {
+        it('nesting width at crossover: tailIndentWidth ties with tailStepWidth', () => {
+            // crossover: s + TAIL_INDENT_W + nestW = TAIL_STEP_W
             const nestW =
-                // 40 — tied, step wins by max
-                BrickOutlineGeneratorTest.TAIL_STEP_W - BrickOutlineGeneratorTest.TAIL_INDENT_W;
+                BrickOutlineGeneratorTest.TAIL_STEP_W -
+                BrickOutlineGeneratorTest.TAIL_INDENT_W -
+                strokeWidth;
 
             const dims = brickOutlineGenerator.computeDimensions({
                 strokeWidth,
@@ -114,8 +116,8 @@ describe('computeDimensions', () => {
                 nestingDims: { w: nestW, h: 40 },
             });
 
-            // tailIndentWidth = sw+8+40 = 50 = tailStepWidth = sw+48 = 50 → tied, max picks either
-            expect(dims.tailWidth).toBe(strokeWidth + BrickOutlineGeneratorTest.TAIL_STEP_W);
+            // tailIndentWidth = 48 = tailStepWidth = 48 → tied, max picks either
+            expect(dims.tailWidth).toBe(BrickOutlineGeneratorTest.TAIL_STEP_W);
         });
 
         it('nesting wider than crossover: tailIndentWidth wins', () => {
@@ -475,6 +477,65 @@ describe('generate', () => {
             });
 
             expect((path.match(/Z/g) ?? []).length).toBe(1);
+        });
+    });
+
+    describe('nesting without bottom notch (high strokeWidth)', () => {
+        it('s > 2 and no bottom notch: path closes without negative x coordinates', () => {
+            const gen = new BrickOutlineGeneratorTest(MINIMUMS);
+            const { path } = gen.generate({
+                strokeWidth: 4,
+                widgetDims: { w: 100, h: 20 },
+                paramArgDims: [],
+                nestingDims: { w: 50, h: 40 },
+                hasNextNotch: false,
+            });
+
+            expect(path).toMatch(/^M /);
+            expect(path).toMatch(/Z$/);
+
+            const tokens = path.trim().split(/\s+/);
+            let x = 0;
+            let i = 0;
+            while (i < tokens.length) {
+                const cmd = tokens[i];
+                if (cmd === 'M' || cmd === 'm') {
+                    x = parseFloat(tokens[i + 1]);
+                    i += 3;
+                } else if (cmd === 'h') {
+                    x += parseFloat(tokens[i + 1]);
+                    i += 2;
+                } else if (cmd === 'a') {
+                    x += parseFloat(tokens[i + 6]);
+                    i += 8;
+                } else if (cmd === 'v') {
+                    i += 2;
+                } else if (cmd === 'Z' || cmd === 'z') {
+                    i += 1;
+                } else {
+                    i += 1;
+                }
+                if (!Number.isFinite(x)) {
+                    throw new Error(`Non-finite x coordinate ${x} at command ${cmd}`);
+                }
+                if (x < -0.001) {
+                    throw new Error(`Negative x coordinate ${x} at command ${cmd}`);
+                }
+            }
+        });
+
+        it('s > 2 with bottom notch: path still works', () => {
+            const gen = new BrickOutlineGeneratorTest(MINIMUMS);
+            const { path } = gen.generate({
+                strokeWidth: 4,
+                widgetDims: { w: 100, h: 20 },
+                paramArgDims: [],
+                nestingDims: { w: 50, h: 40 },
+                hasNextNotch: true,
+            });
+
+            expect(path).toMatch(/^M /);
+            expect(path).toMatch(/Z$/);
         });
     });
 

--- a/modules/masonry/src/utils/path.test.ts
+++ b/modules/masonry/src/utils/path.test.ts
@@ -102,12 +102,9 @@ describe('computeDimensions', () => {
             expect(dims.tailWidth).toBe(0);
         });
 
-        it('nesting width at crossover: tailIndentWidth ties with tailStepWidth', () => {
-            // crossover: s + TAIL_INDENT_W + nestW = TAIL_STEP_W
+        it('nesting width at crossover (TAIL_STEP_W - TAIL_INDENT_W): tailStepWidth still wins', () => {
             const nestW =
-                BrickOutlineGeneratorTest.TAIL_STEP_W -
-                BrickOutlineGeneratorTest.TAIL_INDENT_W -
-                strokeWidth;
+                BrickOutlineGeneratorTest.TAIL_STEP_W - BrickOutlineGeneratorTest.TAIL_INDENT_W;
 
             const dims = brickOutlineGenerator.computeDimensions({
                 strokeWidth,
@@ -116,13 +113,12 @@ describe('computeDimensions', () => {
                 nestingDims: { w: nestW, h: 40 },
             });
 
-            // tailIndentWidth = 48 = tailStepWidth = 48 → tied, max picks either
-            expect(dims.tailWidth).toBe(BrickOutlineGeneratorTest.TAIL_STEP_W);
+            // tailIndentWidth = sw+8+40 = 50 = tailStepWidth = sw+48 = 50 → tied, max picks either
+            expect(dims.tailWidth).toBe(strokeWidth + BrickOutlineGeneratorTest.TAIL_STEP_W);
         });
 
         it('nesting wider than crossover: tailIndentWidth wins', () => {
             const nestW =
-                // 41 — indent pulls ahead
                 BrickOutlineGeneratorTest.TAIL_STEP_W - BrickOutlineGeneratorTest.TAIL_INDENT_W + 1;
 
             const dims = brickOutlineGenerator.computeDimensions({
@@ -477,65 +473,6 @@ describe('generate', () => {
             });
 
             expect((path.match(/Z/g) ?? []).length).toBe(1);
-        });
-    });
-
-    describe('nesting without bottom notch (high strokeWidth)', () => {
-        it('s > 2 and no bottom notch: path closes without negative x coordinates', () => {
-            const gen = new BrickOutlineGeneratorTest(MINIMUMS);
-            const { path } = gen.generate({
-                strokeWidth: 4,
-                widgetDims: { w: 100, h: 20 },
-                paramArgDims: [],
-                nestingDims: { w: 50, h: 40 },
-                hasNextNotch: false,
-            });
-
-            expect(path).toMatch(/^M /);
-            expect(path).toMatch(/Z$/);
-
-            const tokens = path.trim().split(/\s+/);
-            let x = 0;
-            let i = 0;
-            while (i < tokens.length) {
-                const cmd = tokens[i];
-                if (cmd === 'M' || cmd === 'm') {
-                    x = parseFloat(tokens[i + 1]);
-                    i += 3;
-                } else if (cmd === 'h') {
-                    x += parseFloat(tokens[i + 1]);
-                    i += 2;
-                } else if (cmd === 'a') {
-                    x += parseFloat(tokens[i + 6]);
-                    i += 8;
-                } else if (cmd === 'v') {
-                    i += 2;
-                } else if (cmd === 'Z' || cmd === 'z') {
-                    i += 1;
-                } else {
-                    i += 1;
-                }
-                if (!Number.isFinite(x)) {
-                    throw new Error(`Non-finite x coordinate ${x} at command ${cmd}`);
-                }
-                if (x < -0.001) {
-                    throw new Error(`Negative x coordinate ${x} at command ${cmd}`);
-                }
-            }
-        });
-
-        it('s > 2 with bottom notch: path still works', () => {
-            const gen = new BrickOutlineGeneratorTest(MINIMUMS);
-            const { path } = gen.generate({
-                strokeWidth: 4,
-                widgetDims: { w: 100, h: 20 },
-                paramArgDims: [],
-                nestingDims: { w: 50, h: 40 },
-                hasNextNotch: true,
-            });
-
-            expect(path).toMatch(/^M /);
-            expect(path).toMatch(/Z$/);
         });
     });
 

--- a/modules/masonry/src/utils/path.test.ts
+++ b/modules/masonry/src/utils/path.test.ts
@@ -104,6 +104,7 @@ describe('computeDimensions', () => {
 
         it('nesting width at crossover (TAIL_STEP_W - TAIL_INDENT_W): tailStepWidth still wins', () => {
             const nestW =
+                // 40 — tied, step wins by max
                 BrickOutlineGeneratorTest.TAIL_STEP_W - BrickOutlineGeneratorTest.TAIL_INDENT_W;
 
             const dims = brickOutlineGenerator.computeDimensions({
@@ -119,6 +120,7 @@ describe('computeDimensions', () => {
 
         it('nesting wider than crossover: tailIndentWidth wins', () => {
             const nestW =
+                // 41 — indent pulls ahead
                 BrickOutlineGeneratorTest.TAIL_STEP_W - BrickOutlineGeneratorTest.TAIL_INDENT_W + 1;
 
             const dims = brickOutlineGenerator.computeDimensions({

--- a/modules/masonry/src/utils/path.ts
+++ b/modules/masonry/src/utils/path.ts
@@ -591,6 +591,7 @@ export class BrickOutlineGenerator {
         const hasNextNotch = this.input.hasNextNotch;
         const span =
             BrickOutlineGenerator.TAIL_STEP_W -
+            strokeWidth -
             BrickOutlineGenerator.CORNER_RADIUS -
             BrickOutlineGenerator.CORNER_RADIUS;
 
@@ -748,7 +749,7 @@ export class BrickOutlineGenerator {
             BrickOutlineGenerator.TAIL_INDENT_W +
             (inputNormalised.nestingDims?.w ?? 0) +
             strokeWidth / 2;
-        const tailStepWidth = strokeWidth / 2 + BrickOutlineGenerator.TAIL_STEP_W + strokeWidth / 2;
+        const tailStepWidth = BrickOutlineGenerator.TAIL_STEP_W;
 
         const tailWidth = inputNormalised.hasNesting ? Math.max(tailIndentWidth, tailStepWidth) : 0;
 

--- a/modules/masonry/src/utils/path.ts
+++ b/modules/masonry/src/utils/path.ts
@@ -591,9 +591,10 @@ export class BrickOutlineGenerator {
         const hasNextNotch = this.input.hasNextNotch;
         const span =
             BrickOutlineGenerator.TAIL_STEP_W -
-            strokeWidth -
+            strokeWidth / 2 -
             BrickOutlineGenerator.CORNER_RADIUS -
-            BrickOutlineGenerator.CORNER_RADIUS;
+            BrickOutlineGenerator.CORNER_RADIUS -
+            strokeWidth / 2;
 
         // Convex step-bottom → left corner: end CR left + CR up, curving around a centre CR to the left.
         const corner = this.arc(
@@ -749,7 +750,7 @@ export class BrickOutlineGenerator {
             BrickOutlineGenerator.TAIL_INDENT_W +
             (inputNormalised.nestingDims?.w ?? 0) +
             strokeWidth / 2;
-        const tailStepWidth = BrickOutlineGenerator.TAIL_STEP_W;
+        const tailStepWidth = strokeWidth / 2 + BrickOutlineGenerator.TAIL_STEP_W + strokeWidth / 2;
 
         const tailWidth = inputNormalised.hasNesting ? Math.max(tailIndentWidth, tailStepWidth) : 0;
 


### PR DESCRIPTION
fixes #644

When `strokeWidth > 2` and `hasNextNotch: false`, the nesting brick path bled past the left edge (negative x) and had an overly wide tail step. Two formula fixes:

1. **`segTailStepBottom` span** — was `TAIL_STEP_W - CR - CR`; now
   `TAIL_STEP_W - strokeWidth - CR - CR` to match the pattern used by
   `segHeadBottom` (the non-nesting equivalent).

2. **`tailStepWidth`** — was `s/2 + TAIL_STEP_W + s/2`; now just
   `TAIL_STEP_W`. The left stroke bleed is already accounted in
   `tailIndentWidth` — adding it a second time inflated the overall
   brick width.


### Before (s=4, no bottom notch)
M 6 2 h 116 a 4 4 0 0 1 4 4 v 24 a 4 4 0 0 1 -4 4 h -104 a 8 8 0 0 0 -8 8 v 28 a 8 8 0 0 0 8 8 h 4 a 2 2 0 0 1 2 2 a 6 6 0 0 0 6 6 h 0 a 6 6 0 0 0 6 -6 a 2 2 0 0 1 2 -2 h 4 a 4 4 0 0 1 4 4 v 4 a 4 4 0 0 1 -4 4 h **-40** a 4 4 0 0 1 -4 -4 v -80 a 4 4 0 0 1 4 -4 Z
<img width="1060" height="713" alt="image" src="https://github.com/user-attachments/assets/9121edd7-7812-4f64-aba1-066992044256" />


Path bleeds past x=0 and the tail step is wider than 48.

### After (s=4, no bottom notch)
M 6 2 h 116 a 4 4 0 0 1 4 4 v 24 a 4 4 0 0 1 -4 4 h -104 a 8 8 0 0 0 -8 8 v 28 a 8 8 0 0 0 8 8 h 4 a 2 2 0 0 1 2 2 a 6 6 0 0 0 6 6 h 0 a 6 6 0 0 0 6 -6 a 2 2 0 0 1 2 -2 h 4 a 4 4 0 0 1 4 4 v 4 a 4 4 0 0 1 -4 4 h **-36** a 4 4 0 0 1 -4 -4 v -80 a 4 4 0 0 1 4 -4 Z


<img width="1030" height="665" alt="image" src="https://github.com/user-attachments/assets/da93f706-4896-4562-8fdd-e9d5ebc1c2dd" />
