### PR TITLE
#637 | feat(masonry): add model classes for Bricks

### DIFF
--- a/modules/masonry/src/@types/brick.types.ts
+++ b/modules/masonry/src/@types/brick.types.ts
@@ -104,7 +104,7 @@ export interface BrickMinimums {
 // -------------------------------------------------------------------------------------------------
 
 /** Display widgets — represent the brick's identity/operation; used by all brick kinds. */
-type WidgetDisplay =
+export type WidgetDisplay =
     /** Text label identifying the brick, with an optional icon glyph. */
     | { type: 'label'; text: string; glyph?: { name?: string; src?: string; color?: string } }
     /** Static image representing the brick's identity. */

--- a/modules/masonry/src/models/brick.ts
+++ b/modules/masonry/src/models/brick.ts
@@ -1,0 +1,291 @@
+import type {
+    BrickOutlineInput,
+    BrickOutlineOutput,
+    Size,
+    WidgetDisplay,
+    WidgetInput,
+} from '@/@types/brick.types';
+
+import { SCALE_LEVEL_CONFIG } from '@/utils/constants';
+import { BrickOutlineGenerator } from '@/utils/brick-shape';
+
+const STROKE_WIDTH = 2;
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+abstract class BrickModelBase {
+    abstract readonly kind: 'value' | 'expression' | 'statement';
+
+    readonly id: string;
+    readonly colorsDefault: {
+        readonly background: string;
+        readonly foreground: string;
+        readonly border: string;
+    };
+    readonly tooltipText: string;
+
+    /** Rendered size of the primary widget; set by the view after measurement. */
+    widgetDims: Size = { w: 0, h: 0 };
+
+    private _dims: Size = { w: 0, h: 0 };
+    private _path: string = '';
+    private _bounds: BrickOutlineOutput['bounds'] = { widget: { x: 0, y: 0, w: 0, h: 0 } };
+
+    get dims(): Size {
+        return this._dims;
+    }
+
+    get path(): string {
+        return this._path;
+    }
+
+    get bounds(): BrickOutlineOutput['bounds'] {
+        return this._bounds;
+    }
+
+    private _scaleLevel: 1 | 2 | 3;
+    private _outlineGenerator: BrickOutlineGenerator;
+
+    get scaleLevel(): 1 | 2 | 3 {
+        return this._scaleLevel;
+    }
+
+    set scaleLevel(value: 1 | 2 | 3) {
+        this._scaleLevel = value;
+        this._outlineGenerator = BrickModelBase._buildOutlineGenerator(value);
+        // TODO: trigger side effects here
+    }
+
+    protected get outlineGenerator(): BrickOutlineGenerator {
+        return this._outlineGenerator;
+    }
+
+    /** Converts a pixel value to SVG units for the current scale level. */
+    protected pxToSvg(px: number): number {
+        return px / SCALE_LEVEL_CONFIG[this._scaleLevel].brickScale;
+    }
+
+    /** Assembles the generator input from this brick's current state. */
+    protected abstract _buildOutlineInput(): BrickOutlineInput;
+
+    /** Recomputes outer dimensions using the outline generator and stores them in `dims`. */
+    public computeDims(): void {
+        const { width, height } = this.outlineGenerator.computeDimensions(
+            this._buildOutlineInput(),
+        );
+        this._dims = { w: width, h: height };
+    }
+
+    /** Generates the SVG path and layout bounds and stores them in `path` and `bounds`. */
+    public computeOutline(): void {
+        const { width, height, path, bounds } = this.outlineGenerator.generate(
+            this._buildOutlineInput(),
+        );
+        this._dims = { w: width, h: height };
+        this._path = path;
+        this._bounds = bounds;
+    }
+
+    private static _buildOutlineGenerator(level: 1 | 2 | 3): BrickOutlineGenerator {
+        const { brickScale, minWidth, minArgNestHeight, minWidgetParamHeight } =
+            SCALE_LEVEL_CONFIG[level];
+        const pxToSvg = (px: number) => px / brickScale;
+        return new BrickOutlineGenerator({
+            minWidth: pxToSvg(minWidth),
+            minWidgetHeight: pxToSvg(minWidgetParamHeight),
+            minParamHeight: pxToSvg(minWidgetParamHeight),
+            minArgHeight: pxToSvg(minArgNestHeight),
+            minNestHeight: pxToSvg(minArgNestHeight),
+        });
+    }
+
+    constructor(config: {
+        id?: string;
+        colorsDefault: { background: string; foreground: string; border: string };
+        tooltipText: string;
+        scaleLevel?: 1 | 2 | 3;
+    }) {
+        this.id = config.id ?? crypto.randomUUID();
+        this.colorsDefault = config.colorsDefault;
+        this.tooltipText = config.tooltipText;
+        this._scaleLevel = config.scaleLevel ?? 2;
+        this._outlineGenerator = BrickModelBase._buildOutlineGenerator(this._scaleLevel);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Terminal value brick — literal, variable, constant, or direct input widget. */
+export class ValueBrickModel extends BrickModelBase {
+    readonly kind = 'value' as const;
+
+    // The widget kind is fixed at creation; for input/variant widgets the inner
+    // value field may be mutated directly as the user interacts.
+    readonly widget: WidgetDisplay | WidgetInput;
+
+    protected _buildOutlineInput(): BrickOutlineInput {
+        return {
+            strokeWidth: this.pxToSvg(STROKE_WIDTH),
+            widgetDims: { w: this.pxToSvg(this.widgetDims.w), h: this.pxToSvg(this.widgetDims.h) },
+            paramArgDims: [],
+            hasOutputNotch: true,
+        };
+    }
+
+    constructor(config: {
+        id?: string;
+        colorsDefault: { background: string; foreground: string; border: string };
+        tooltipText: string;
+        scaleLevel?: 1 | 2 | 3;
+        widget: WidgetDisplay | WidgetInput;
+    }) {
+        super(config);
+        this.widget = config.widget;
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Value-producing brick with argument slots — operator, function call, etc. */
+export class ExpressionBrickModel extends BrickModelBase {
+    readonly kind = 'expression' as const;
+
+    // For variant widgets, the inner value field may be mutated.
+    readonly widget: WidgetDisplay;
+
+    // At least one slot is required; labels are structural and fixed.
+    readonly params: readonly [string | null, ...(string | null)[]];
+
+    private _argDims: (Size | null)[];
+
+    get argDims(): (Size | null)[] {
+        return this._argDims;
+    }
+
+    set argDims(value: (Size | null)[]) {
+        this._argDims = value;
+        // TODO: trigger side effects here
+    }
+
+    protected _buildOutlineInput(): BrickOutlineInput {
+        return {
+            strokeWidth: this.pxToSvg(STROKE_WIDTH),
+            widgetDims: { w: this.pxToSvg(this.widgetDims.w), h: this.pxToSvg(this.widgetDims.h) },
+            paramArgDims: this._argDims.map((dim) => ({
+                param: null,
+                arg: dim ? { w: this.pxToSvg(dim.w), h: this.pxToSvg(dim.h) } : null,
+            })),
+            hasOutputNotch: true,
+        };
+    }
+
+    constructor(config: {
+        id?: string;
+        colorsDefault: { background: string; foreground: string; border: string };
+        tooltipText: string;
+        scaleLevel?: 1 | 2 | 3;
+        widget: WidgetDisplay;
+        params: [string | null, ...(string | null)[]];
+        argDims?: (Size | null)[];
+    }) {
+        super(config);
+        this.widget = config.widget;
+        this.params = config.params;
+        this._argDims = config.argDims ?? config.params.map(() => null);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Executable brick that participates in a sequence — statement, block, loop, conditional, etc. */
+export class StatementBrickModel extends BrickModelBase {
+    readonly kind = 'statement' as const;
+
+    // For variant widgets, the inner value field may be mutated.
+    readonly widget: WidgetDisplay;
+
+    // Param labels are structural and fixed; slot count won't change.
+    readonly params: readonly (string | null)[];
+
+    private _argDims: (Size | null)[];
+
+    get argDims(): (Size | null)[] {
+        return this._argDims;
+    }
+
+    set argDims(value: (Size | null)[]) {
+        this._argDims = value;
+        // TODO: trigger side effects here
+    }
+
+    // Whether this brick structurally has a nesting cavity — fixed at creation.
+    readonly hasNesting: boolean;
+
+    private _nestingDims: Size | null;
+
+    get nestingDims(): Size | null {
+        return this._nestingDims;
+    }
+
+    set nestingDims(value: Size | null) {
+        this._nestingDims = value;
+        // TODO: trigger side effects here
+    }
+
+    // Mutable: change as bricks are linked or unlinked in a sequence.
+    hasConnectionPrev: boolean;
+    hasConnectionNext: boolean;
+
+    // Mutable: toggled by the user to collapse or expand the nesting cavity.
+    isNestingFolded: boolean;
+
+    protected _buildOutlineInput(): BrickOutlineInput {
+        let nestingDims: Size | null | undefined;
+        if (this.hasNesting) {
+            nestingDims = this._nestingDims
+                ? { w: this.pxToSvg(this._nestingDims.w), h: this.pxToSvg(this._nestingDims.h) }
+                : null;
+        }
+        return {
+            strokeWidth: this.pxToSvg(STROKE_WIDTH),
+            widgetDims: { w: this.pxToSvg(this.widgetDims.w), h: this.pxToSvg(this.widgetDims.h) },
+            paramArgDims: this._argDims.map((dim) => ({
+                param: null,
+                arg: dim ? { w: this.pxToSvg(dim.w), h: this.pxToSvg(dim.h) } : null,
+            })),
+            nestingDims,
+            hasPrevNotch: this.hasConnectionPrev,
+            hasNextNotch: this.hasConnectionNext,
+        };
+    }
+
+    constructor(config: {
+        id?: string;
+        colorsDefault: { background: string; foreground: string; border: string };
+        tooltipText: string;
+        scaleLevel?: 1 | 2 | 3;
+        widget: WidgetDisplay;
+        params?: (string | null)[];
+        argDims?: (Size | null)[];
+        hasNesting?: boolean;
+        nestingDims?: Size | null;
+        hasConnectionPrev?: boolean;
+        hasConnectionNext?: boolean;
+        isNestingFolded?: boolean;
+    }) {
+        super(config);
+        this.widget = config.widget;
+        this.params = config.params ?? [];
+        this._argDims = config.argDims ?? (config.params ?? []).map(() => null);
+        this.hasNesting = config.hasNesting ?? false;
+        this._nestingDims = config.nestingDims ?? null;
+        this.hasConnectionPrev = config.hasConnectionPrev ?? false;
+        this.hasConnectionNext = config.hasConnectionNext ?? false;
+        this.isNestingFolded = config.isNestingFolded ?? false;
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Discriminated union over all brick model kinds; narrow via `kind`. */
+export type BrickModel = ValueBrickModel | ExpressionBrickModel | StatementBrickModel;


### PR DESCRIPTION
Add the following model classes for Bricks
- `BrickModelBase` (abstract)
- `ValueBrickModel`
- `ExpressionBrickModel`
- `StatementBrickModel`

part of #637.