### PR TITLE
#552 | feat(masonry): add new playground

### DIFF
--- a/modules/masonry/.storybook/main.ts
+++ b/modules/masonry/.storybook/main.ts
@@ -1,36 +1,24 @@
 import type { UserConfig } from 'vite';
 
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { StorybookConfig } from '@storybook/react-vite';
 import { mergeConfig } from 'vite';
-import tailwindcss from '@tailwindcss/vite';
+
+import baseConfig from '../vite.config';
 
 // -------------------------------------------------------------------------------------------------
 
-function resolve(rootPath: string) {
-    return path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', rootPath);
-}
-
-export default {
+const config: StorybookConfig = {
     stories: ['../src/**/*.mdx', '../src/**/*.stories.@(tsx|ts|jsx|js)'],
     addons: ['@storybook/addon-a11y'],
     framework: {
         name: '@storybook/react-vite',
-        options: {},
-    },
-    docs: {
-        autodocs: 'tag',
+        options: {
+            strictMode: true,
+        },
     },
     async viteFinal(config: UserConfig) {
-        return mergeConfig(config, {
-            plugins: [tailwindcss()],
-            resolve: {
-                alias: {
-                    '@': resolve('src'),
-                    '@res': resolve('../../res'),
-                },
-                extensions: ['.tsx', '.ts', '.js', '.scss', '.sass', '.json'],
-            },
-        });
+        return mergeConfig(config, baseConfig);
     },
 };
+
+export default config;

--- a/modules/masonry/docs/README.md
+++ b/modules/masonry/docs/README.md
@@ -65,6 +65,24 @@ reference only. They do not describe the new code.
 
 ---
 
+## Playground
+
+A standalone Vite + React app for manual, interactive testing of masonry components and
+behaviours. It is not part of the library build — it exists only as a dev harness.
+
+| Item | Detail |
+| --- | --- |
+| Location | `src/playground/` |
+| Entry | `src/playground/index.tsx` |
+| Script | `npm run playground2` (port 5602) |
+| Routing | `react-router-dom` `BrowserRouter`; each page is a route in `App.tsx` |
+| Pages | `src/playground/pages/` — one file per route |
+
+See [`src/playground/README.md`](../src/playground/README.md) for routing conventions and
+how to add new pages.
+
+---
+
 ## Dead / Pending Replacement
 
 The following `src/` directories and files belong to the old implementation. They are

--- a/modules/masonry/package.json
+++ b/modules/masonry/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint src",
     "storybook": "storybook dev -p 6006 --no-open",
     "build-storybook": "storybook build",
-    "playground": "vite playground --host --port 5601"
+    "playground": "vite playground --host --port 5601",
+    "playground2": "vite src/playground --host --port 5602"
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
@@ -29,8 +30,18 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.1",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
     "@types/uuid": "^10.0.0",
+    "@vitejs/plugin-react": "^5.2.0",
     "prettier-plugin-tailwindcss": "^0.8.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-router-dom": "^7.18.0",
     "tailwindcss": "^4.3.1"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   }
 }

--- a/modules/masonry/src/playground/App.tsx
+++ b/modules/masonry/src/playground/App.tsx
@@ -1,0 +1,20 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+
+import Layout from './components/Layout';
+import { pages } from './pages';
+import Home from './pages/Home';
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route element={<Layout />}>
+          <Route path="/" element={<Home />} />
+          {pages.map(({ path, component: Page }) => (
+            <Route key={path} path={path} element={<Page />} />
+          ))}
+        </Route>
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/modules/masonry/src/playground/README.md
+++ b/modules/masonry/src/playground/README.md
@@ -1,0 +1,62 @@
+# Masonry Playground
+
+A standalone Vite + React dev harness for manually testing masonry components and
+behaviours. It is **not** part of the library build and is never published.
+
+## Running
+
+```sh
+npm run playground2
+```
+
+Starts a dev server at `http://localhost:5602` with HMR.
+
+## Structure
+
+```text
+src/playground/
+├── index.html              # HTML entry point
+├── index.tsx               # React root mount
+├── App.tsx                 # BrowserRouter + route table (generated from pages.ts)
+├── vite.config.ts          # Extends modules/masonry/vite.config.ts, adds react()
+├── components/
+│   ├── Layout.tsx          # Top bar + page outlet
+│   └── TopBar.tsx          # Nav bar with home button and per-page route buttons
+└── pages/
+    ├── index.ts            # Single source of truth: path, label, description, component
+    └── Home.tsx            # Catalog — lists all pages with descriptions
+```
+
+## Adding a page
+
+1. Create `src/playground/pages/MyPage.tsx` and export a default component.
+
+2. Add an entry to `pages.ts`:
+
+   ```ts
+   import MyPage from './pages/MyPage';
+
+   export const pages: PageDef[] = [
+     {
+       path: '/my-page',
+       label: 'My Page',
+       description: 'One sentence on what this page demonstrates.',
+       component: MyPage,
+     },
+   ];
+   ```
+
+   This automatically adds the route in `App.tsx`, a nav button in `TopBar`, and a
+   catalog card on `Home`.
+
+## Conventions
+
+- One file per route under `pages/`. No nested folders unless a page is genuinely
+  complex enough to warrant its own sub-components.
+- Use the `@` alias for imports from the library source (`@/components/...`,
+  `@/utils/...`). The alias resolves to `modules/masonry/src/`.
+- Keep pages self-contained. Shared playground-only utilities can live directly in
+  `src/playground/` alongside `App.tsx`.
+- Pages fill the content area exactly — `Layout` constrains it to the remaining
+  viewport height with no layout-level scroll. Implement scrolling inside the page
+  if needed.

--- a/modules/masonry/src/playground/components/Layout.tsx
+++ b/modules/masonry/src/playground/components/Layout.tsx
@@ -1,0 +1,14 @@
+import { Outlet } from 'react-router-dom';
+
+import TopBar from './TopBar';
+
+export default function Layout() {
+  return (
+    <div className="flex h-screen flex-col overflow-hidden">
+      <TopBar />
+      <main className="flex flex-1 flex-col overflow-hidden">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/modules/masonry/src/playground/components/TopBar.tsx
+++ b/modules/masonry/src/playground/components/TopBar.tsx
@@ -1,0 +1,46 @@
+import { NavLink } from 'react-router-dom';
+
+import { cn } from '@/lib/utils';
+
+import { pages } from '../pages';
+
+export default function TopBar() {
+  return (
+    <nav
+      className={cn(
+        'sticky top-0 z-100 flex h-12 items-center gap-4',
+        'border-b border-slate-800 bg-slate-900 px-5',
+      )}
+    >
+      <NavLink
+        to="/"
+        className={cn(
+          'text-sm font-bold tracking-wide text-white',
+          'opacity-75 transition-opacity hover:opacity-100',
+        )}
+      >
+        Masonry Playground
+      </NavLink>
+
+      <div className="h-4 w-px bg-slate-700" />
+
+      <div className="flex gap-1">
+        {pages.map(({ path, label }) => (
+          <NavLink
+            key={path}
+            to={path}
+            className={({ isActive }) =>
+              `rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                isActive
+                  ? 'bg-slate-700 text-white'
+                  : 'text-slate-400 hover:bg-slate-800 hover:text-white'
+              }`
+            }
+          >
+            {label}
+          </NavLink>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/modules/masonry/src/playground/index.html
+++ b/modules/masonry/src/playground/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Masonry Playground</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./index.tsx"></script>
+  </body>
+</html>

--- a/modules/masonry/src/playground/index.tsx
+++ b/modules/masonry/src/playground/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+import '@/index.css';
+
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root')!);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/modules/masonry/src/playground/pages/Home.tsx
+++ b/modules/masonry/src/playground/pages/Home.tsx
@@ -1,0 +1,42 @@
+import { NavLink } from 'react-router-dom';
+
+import { cn } from '@/lib/utils';
+
+import { pages } from '.';
+
+export default function Home() {
+  return (
+    <div className="p-10">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-slate-900">Masonry Playground</h1>
+        <p className="mt-2 text-sm text-slate-500">
+          A dev harness for building, experimenting with, and demoing Masonry components in
+          isolation — outside the full application context.
+        </p>
+      </div>
+
+      {pages.length > 0 && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {pages.map(({ path, label, description }) => (
+            <NavLink
+              key={path}
+              to={path}
+              className={cn(
+                'group flex flex-col gap-2 rounded-lg',
+                'border border-slate-200 p-5',
+                'transition-colors hover:bg-slate-50',
+              )}
+            >
+              <span className="text-sm font-semibold text-slate-800 group-hover:text-slate-900">
+                {label}
+              </span>
+              <span className="text-xs text-slate-400 group-hover:text-slate-500">
+                {description}
+              </span>
+            </NavLink>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/modules/masonry/src/playground/pages/index.ts
+++ b/modules/masonry/src/playground/pages/index.ts
@@ -1,0 +1,10 @@
+import type { ComponentType } from 'react';
+
+export interface PageDef {
+    path: string;
+    label: string;
+    description: string;
+    component: ComponentType;
+}
+
+export const pages: PageDef[] = [];

--- a/modules/masonry/src/playground/vite.config.ts
+++ b/modules/masonry/src/playground/vite.config.ts
@@ -1,0 +1,11 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig, mergeConfig } from 'vite';
+
+import baseConfig from '../../vite.config';
+
+export default mergeConfig(
+    baseConfig,
+    defineConfig({
+        plugins: [react()],
+    }),
+);

--- a/modules/masonry/vite.config.ts
+++ b/modules/masonry/vite.config.ts
@@ -1,0 +1,18 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig } from 'vite';
+import tailwindcss from '@tailwindcss/vite';
+
+const dir = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+    plugins: [tailwindcss()],
+    resolve: {
+        alias: {
+            '@': resolve(dir, './src'),
+            '@res': resolve(dir, '../../res'),
+        },
+        extensions: ['.tsx', '.ts', '.js', '.scss', '.sass', '.json'],
+    },
+});

--- a/modules/masonry/vitest.config.ts
+++ b/modules/masonry/vitest.config.ts
@@ -1,18 +1,13 @@
 import type { UserConfig } from 'vite';
 
 import { defineConfig, mergeConfig } from 'vitest/config';
-import rootConfig from '../../vitest.config';
 
-import path from 'path';
+import rootConfig from '../../vitest.config';
+import baseConfig from './vite.config';
 
 export default mergeConfig(
-    rootConfig as UserConfig,
+    mergeConfig(rootConfig as UserConfig, baseConfig as UserConfig),
     defineConfig({
-        resolve: {
-            alias: {
-                '@': path.resolve(__dirname, './src'),
-            },
-        },
         test: {
             projects: [
                 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -207,9 +207,19 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.3.1",
+        "@types/react": "^19.1.8",
+        "@types/react-dom": "^19.1.6",
         "@types/uuid": "^10.0.0",
+        "@vitejs/plugin-react": "^5.2.0",
         "prettier-plugin-tailwindcss": "^0.8.0",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-router-dom": "^7.18.0",
         "tailwindcss": "^4.3.1"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "modules/menu": {


### PR DESCRIPTION
- add new playground Vite/React app in `modules/masonry/src/playground`
- add documentation

closes #552.