### PR TITLE
Define the config object for the Brick Palette

### DIFF
--- a/modules/masonry/docs/specification.md
+++ b/modules/masonry/docs/specification.md
@@ -42,13 +42,13 @@ An executable construct in a sequence — an assignment, loop, conditional, bloc
 
 ### Connectors
 
-| Connector | Value | Expression | Statement |
-| --- | --- | --- | --- |
-| Value-out | always | always | never |
-| Sequence-in | never | never | optional |
-| Sequence-out | never | never | optional |
-| Value-in per arg slot | never | implicit | implicit |
-| Cavity entry/exit connectors | never | never | implicit when nesting present |
+| Connector                    | Value  | Expression | Statement                     |
+| ---------------------------- | ------ | ---------- | ----------------------------- |
+| Value-out                    | always | always     | never                         |
+| Sequence-in                  | never  | never      | optional                      |
+| Sequence-out                 | never  | never      | optional                      |
+| Value-in per arg slot        | never  | implicit   | implicit                      |
+| Cavity entry/exit connectors | never  | never      | implicit when nesting present |
 
 ### Primary Slot (Widget)
 
@@ -65,26 +65,49 @@ Input widgets (`textbox`, `numberbox`, `toggle`, `slider`) are exclusive to valu
 
 #### Display widgets (all kinds)
 
-| Type | Description |
-| --- | --- |
-| `label` | Text string identifying the brick; optional icon glyph alongside |
-| `graphic` | Static image representing the brick's identity |
+| Type      | Description                                                      |
+| --------- | ---------------------------------------------------------------- |
+| `label`   | Text string identifying the brick; optional icon glyph alongside |
+| `graphic` | Static image representing the brick's identity                   |
 | `variant` | Dropdown selector for choosing a structural variant of the brick |
 
 #### Input widgets (value kind only)
 
-| Type | Description |
-| --- | --- |
-| `textbox` | Freeform text input; optional `maxLength` |
-| `numberbox` | Numeric input with optional `min`, `max`, `step` |
-| `toggle` | Boolean on/off switch; optional `on`/`off` state labels |
-| `slider` | Range slider; `min` and `max` required, `step` defaults to 1 |
-| `select` | Selection from a fixed set of runtime value options |
+| Type        | Description                                                  |
+| ----------- | ------------------------------------------------------------ |
+| `textbox`   | Freeform text input; optional `maxLength`                    |
+| `numberbox` | Numeric input with optional `min`, `max`, `step`             |
+| `toggle`    | Boolean on/off switch; optional `on`/`off` state labels      |
+| `slider`    | Range slider; `min` and `max` required, `step` defaults to 1 |
+| `select`    | Selection from a fixed set of runtime value options          |
 
 ### Optional Features
 
 - **Glyph** — expression and statement bricks may have a glyph alongside the primary label
 - **Switch button** — expression and statement bricks may have a button to swap to an alternate
-  brick type *(not yet implemented)*
+  brick type _(not yet implemented)_
 - **Fold button** — statement bricks with a nesting cavity always have a fold/unfold toggle;
   this is not configurable independently of nesting
+
+---
+
+## Palette
+
+The catalog of available bricks the user picks from. The config describes what the Palette lists
+and how entries are grouped — not how a brick is rendered. Shape: `PaletteConfig` in
+`src/@types/palette.types.ts`.
+
+### Structure
+
+A three-level tree: **Category → Section → Brick**.
+
+| Level    | Fields                                           | Role                           |
+| -------- | ------------------------------------------------ | ------------------------------ |
+| Category | `name`, `icon`, `sections`                       | Top-level group (e.g. "Music") |
+| Section  | `name`, `icon`, `color`, `bricks`                | Colored group (e.g. "Pitch")   |
+| Brick    | `id`, `name`, `description`, `thumbnail`, `bbox` | A catalog entry                |
+
+A brick entry is a catalog descriptor, not a live brick: `id` keys it to the brick's definition
+(resolved to a `BrickModel` on instantiation), `name`/`description` feed listing and search, and
+`thumbnail`/`bbox` are the preview. Kind, widgets, connectors, and colors belong to the rendered
+brick (`BrickViewProps` / `BrickModel`), not the catalog.

--- a/modules/masonry/docs/specification.md
+++ b/modules/masonry/docs/specification.md
@@ -93,21 +93,22 @@ Input widgets (`textbox`, `numberbox`, `toggle`, `slider`) are exclusive to valu
 
 ## Palette
 
-The catalog of available bricks the user picks from. The config describes what the Palette lists
-and how entries are grouped — not how a brick is rendered. Shape: `PaletteConfig` in
-`src/@types/palette.types.ts`.
+The catalog of available bricks the user picks from. The config describes what the Palette lists,
+how entries are grouped, and — per entry — the full render config used to preview the brick. Shape:
+`PaletteConfig` in `src/@types/palette.types.ts`.
 
 ### Structure
 
 A three-level tree: **Category → Section → Brick**.
 
-| Level    | Fields                                           | Role                           |
-| -------- | ------------------------------------------------ | ------------------------------ |
-| Category | `name`, `icon`, `sections`                       | Top-level group (e.g. "Music") |
-| Section  | `name`, `icon`, `color`, `bricks`                | Colored group (e.g. "Pitch")   |
-| Brick    | `id`, `name`, `description`, `thumbnail`, `bbox` | A catalog entry                |
+| Level    | Fields                               | Role                           |
+| -------- | ------------------------------------ | ------------------------------ |
+| Category | `name`, `icon`, `sections`           | Top-level group (e.g. "Music") |
+| Section  | `name`, `icon`, `color`, `bricks`    | Colored group (e.g. "Pitch")   |
+| Brick    | `id`, `name`, `description`, `brick` | A catalog entry                |
 
-A brick entry is a catalog descriptor, not a live brick: `id` keys it to the brick's definition
-(resolved to a `BrickModel` on instantiation), `name`/`description` feed listing and search, and
-`thumbnail`/`bbox` are the preview. Kind, widgets, connectors, and colors belong to the rendered
-brick (`BrickViewProps` / `BrickModel`), not the catalog.
+A brick entry carries both cataloging metadata and the full render config: `id` keys it to the
+brick's definition (resolved to a `BrickModel` on instantiation), `name`/`description` feed listing
+and search, and `brick` is the complete render config (`BrickViewProps` — kind, widgets, connectors,
+colors, nesting, etc.). The Palette previews each entry by rendering `brick` with the Brick renderer,
+so previews are live brick shapes rather than static images.

--- a/modules/masonry/src/@types/palette.types.ts
+++ b/modules/masonry/src/@types/palette.types.ts
@@ -1,0 +1,60 @@
+import type { Size } from './brick.types';
+
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * A single brick entry in the Palette catalog.
+ *
+ * This is a catalog descriptor used to list and preview a brick in the Palette — it is not a live
+ * brick instance. See `BrickModel` / `BrickViewProps` in `brick.types.ts` for the rendered brick.
+ * The `id` keys this entry to the brick's definition, which is resolved when the brick is
+ * instantiated into the workspace.
+ */
+export interface PaletteBrickConfig {
+    /** Unique identifier; key used to resolve the brick's definition/model on instantiation. */
+    id: string;
+    /** Display name; shown in the Palette and matched against search text. */
+    name: string;
+    /** Longer description; shown on hover and matched against search text. */
+    description: string;
+    /** Source of the thumbnail graphic previewed as the brick in the Palette. */
+    thumbnail: string;
+    /** Bounding-box dimensions of the thumbnail preview, in pixels. */
+    bbox: Size;
+}
+
+/**
+ * A Section groups related bricks within a Category (e.g. "Pitch" within "Music").
+ */
+export interface PaletteSectionConfig {
+    /** Display name of the section. */
+    name: string;
+    /** Source of the section's icon. */
+    icon: string;
+    /** Accent color for the section, as a CSS color string. */
+    color: string;
+    /** Ordered bricks shown in this section. */
+    bricks: PaletteBrickConfig[];
+}
+
+/**
+ * A Category is a top-level grouping of Sections (e.g. "Music", "Flow", "Graphics").
+ */
+export interface PaletteCategoryConfig {
+    /** Display name of the category. */
+    name: string;
+    /** Source of the category's icon. */
+    icon: string;
+    /** Ordered sections within this category. */
+    sections: PaletteSectionConfig[];
+}
+
+/**
+ * Top-level configuration object for the Brick Palette.
+ *
+ * Defines the full Category → Section → Brick hierarchy the Palette renders.
+ */
+export interface PaletteConfig {
+    /** Ordered categories shown in the Palette. */
+    categories: PaletteCategoryConfig[];
+}

--- a/modules/masonry/src/@types/palette.types.ts
+++ b/modules/masonry/src/@types/palette.types.ts
@@ -1,13 +1,15 @@
-import type { Size } from './brick.types';
+import type { BrickViewProps } from './brick.types';
 
 // -------------------------------------------------------------------------------------------------
 
 /**
  * A single brick entry in the Palette catalog.
  *
- * This is a catalog descriptor used to list and preview a brick in the Palette — it is not a live
- * brick instance. See `BrickModel` / `BrickViewProps` in `brick.types.ts` for the rendered brick.
- * The `id` keys this entry to the brick's definition, which is resolved when the brick is
+ * In addition to cataloging metadata (`id`, `name`, `description`), this entry embeds the full
+ * render config for the brick (`brick`). The Palette previews the entry by feeding this config to
+ * the Brick renderer — the same renderer used in the workspace — so previews are live brick shapes
+ * (colors, connectors, nesting, widgets, labels) rather than static images. The `id` keys this
+ * entry to the brick's definition, which is resolved into a live model when the brick is
  * instantiated into the workspace.
  */
 export interface PaletteBrickConfig {
@@ -17,10 +19,8 @@ export interface PaletteBrickConfig {
     name: string;
     /** Longer description; shown on hover and matched against search text. */
     description: string;
-    /** Source of the thumbnail graphic previewed as the brick in the Palette. */
-    thumbnail: string;
-    /** Bounding-box dimensions of the thumbnail preview, in pixels. */
-    bbox: Size;
+    /** Full render config; the Palette previews the entry by rendering it via the Brick renderer. */
+    brick: BrickViewProps;
 }
 
 /**


### PR DESCRIPTION
Closes #567.

This adds the config object for the Brick Palette, following the same pattern we used for the Brick config (#553)  it's just the type definition plus a docs entry, no rendering or component logic.

### What's here

- `modules/masonry/src/@types/palette.types.ts` - the `PaletteConfig` type and its parts. The Palette is modelled as a three-level tree, matching the Techspec:
  - **Category** (`name`, `icon`, `sections`) - top-level group, e.g. "Music"
  - **Section** (`name`, `icon`, `color`, `bricks`) - colored group, e.g. "Pitch"
  - **Brick** (`id`, `name`, `description`, `thumbnail`, `bbox`) - a catalog entry
- `modules/masonry/docs/specification.md` - a short `## Palette` section describing the shape.


