### PR TITLE
Brick Palette shell components

### DIFF
--- a/modules/masonry/playground/pages/workspace/index.tsx
+++ b/modules/masonry/playground/pages/workspace/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import PaletteWrapper from '../../../src/palette/components/paletteWrapper';
-import '../../../src/palette/palette.css';
+import { Palette } from '../../../src/palette/palette';
+import { sampleConfig } from '../../../src/palette/data/sampleConfig';
 import WorkSpaceView from '../../../src/workspace/view/components/WorkspaceView';
 
 export default function App() {
@@ -12,11 +12,15 @@ export default function App() {
       <aside
         style={{
           width: 280,
+          height: '100%',
           borderRight: '1px solid #ddd',
-          overflowY: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
         }}
       >
-        <PaletteWrapper />
+        <div style={{ flex: 1, minHeight: 0 }}>
+          <Palette config={sampleConfig} />
+        </div>
 
         {/* Collision Test Button */}
         <div

--- a/modules/masonry/playground/pages/workspace/index.tsx
+++ b/modules/masonry/playground/pages/workspace/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { Palette } from '../../../src/palette/palette';
-import { sampleConfig } from '../../../src/palette/data/sampleConfig';
+import PaletteWrapper from '../../../src/palette/components/paletteWrapper';
+import '../../../src/palette/palette.css';
 import WorkSpaceView from '../../../src/workspace/view/components/WorkspaceView';
 
 export default function App() {
@@ -12,15 +12,11 @@ export default function App() {
       <aside
         style={{
           width: 280,
-          height: '100%',
           borderRight: '1px solid #ddd',
-          display: 'flex',
-          flexDirection: 'column',
+          overflowY: 'auto',
         }}
       >
-        <div style={{ flex: 1, minHeight: 0 }}>
-          <Palette config={sampleConfig} />
-        </div>
+        <PaletteWrapper />
 
         {/* Collision Test Button */}
         <div

--- a/modules/masonry/src/palette/components/brickSlot.tsx
+++ b/modules/masonry/src/palette/components/brickSlot.tsx
@@ -1,0 +1,30 @@
+import type { PaletteBrickConfig } from '@/@types/palette.types';
+import { cn } from '@/lib/utils';
+
+interface BrickSlotProps {
+  /**
+   * The full palette brick config for this entry. The placeholder only reads `name`/`description`
+   * today, but it receives the entire object so a later PR can turn this slot into a drag source
+   * that carries the config as its payload without changing the prop contract.
+   */
+  brick: PaletteBrickConfig;
+}
+
+/**
+ * Placeholder render boundary for a single palette brick. Renders a styled box showing the brick's
+ * name with its description as a native hover tooltip. It intentionally renders no SVG and imports
+ * no brick view components — live brick previews are the subject of a later PR.
+ */
+export function BrickSlot({ brick }: BrickSlotProps) {
+  return (
+    <div
+      title={brick.description}
+      data-brick-id={brick.id}
+      className={cn(
+        'border-border bg-card text-card-foreground hover:bg-accent hover:text-accent-foreground flex min-h-11 cursor-grab items-center rounded-md border px-3 py-2 text-sm font-medium shadow-sm transition-colors select-none',
+      )}
+    >
+      <span className="truncate">{brick.name}</span>
+    </div>
+  );
+}

--- a/modules/masonry/src/palette/components/categoryRail.tsx
+++ b/modules/masonry/src/palette/components/categoryRail.tsx
@@ -1,0 +1,60 @@
+import type { PaletteCategoryConfig } from '@/@types/palette.types';
+import { cn } from '@/lib/utils';
+import { Button } from '@/ui/button';
+
+import { resolveIcon } from './icons';
+
+interface CategoryRailProps {
+  /** Ordered categories to show, one button per category. */
+  categories: PaletteCategoryConfig[];
+  /** Index of the currently active category. */
+  activeIndex: number;
+  /** Called with the index of the category the user selects. */
+  onSelect: (index: number) => void;
+  /** Layout direction of the rail. Defaults to the vertical, Scratch-style column. */
+  orientation?: 'vertical' | 'horizontal';
+}
+
+/**
+ * Scratch-style category rail. Renders one icon-and-name button per category and highlights the
+ * active one. Defaults to a vertical column; pass `orientation="horizontal"` to lay the buttons in a
+ * row.
+ */
+export function CategoryRail({
+  categories,
+  activeIndex,
+  onSelect,
+  orientation = 'vertical',
+}: CategoryRailProps) {
+  const isHorizontal = orientation === 'horizontal';
+  return (
+    <nav
+      className={cn(
+        'border-border bg-muted/40 flex shrink-0 gap-1 p-2',
+        isHorizontal
+          ? 'flex-row overflow-x-auto border-b'
+          : 'w-20 flex-col overflow-y-auto border-r',
+      )}
+    >
+      {categories.map((category, i) => {
+        const Icon = resolveIcon(category.icon);
+        const isActive = i === activeIndex;
+        return (
+          <Button
+            key={category.name}
+            variant={isActive ? 'secondary' : 'ghost'}
+            size="default"
+            onClick={() => onSelect(i)}
+            className={cn(
+              'h-auto flex-col gap-1 px-1 py-2 text-[0.7rem]',
+              isActive && 'ring-ring ring-1',
+            )}
+          >
+            <Icon className="size-5" />
+            <span className="w-full truncate text-center">{category.name}</span>
+          </Button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/modules/masonry/src/palette/components/icons.ts
+++ b/modules/masonry/src/palette/components/icons.ts
@@ -1,0 +1,32 @@
+import {
+    Box,
+    GitBranch,
+    Music,
+    Palette,
+    Play,
+    Repeat,
+    Shapes,
+    Waves,
+    type LucideIcon,
+} from 'lucide-react';
+
+/**
+ * Maps the string icon identifiers used in `PaletteConfig` (category/section `icon` fields) to
+ * concrete lucide-react components. Config carries icon names as plain strings, so both the category
+ * rail and the section list resolve them through this shared lookup to avoid drift.
+ */
+const iconMap: Record<string, LucideIcon> = {
+    Music,
+    Waves,
+    GitBranch,
+    Shapes,
+    Play,
+    Repeat,
+    Palette,
+    Box,
+};
+
+/** Resolves an icon name from the config to a lucide component, falling back to `Box`. */
+export function resolveIcon(name: string): LucideIcon {
+    return iconMap[name] ?? Box;
+}

--- a/modules/masonry/src/palette/components/paletteSearch.tsx
+++ b/modules/masonry/src/palette/components/paletteSearch.tsx
@@ -1,0 +1,28 @@
+import { Search } from 'lucide-react';
+
+import { Input } from '@/ui/input';
+
+interface PaletteSearchProps {
+  /** Current search query. */
+  value: string;
+  /** Called with the next query whenever the input changes. */
+  onChange: (next: string) => void;
+}
+
+/**
+ * Presentational controlled search input with a leading search icon. Filtering itself lives in the
+ * parent `Palette` component; this component only surfaces the query and reports edits.
+ */
+export function PaletteSearch({ value, onChange }: PaletteSearchProps) {
+  return (
+    <div className="relative">
+      <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
+      <Input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Search bricks"
+        className="pl-8"
+      />
+    </div>
+  );
+}

--- a/modules/masonry/src/palette/components/sectionList.tsx
+++ b/modules/masonry/src/palette/components/sectionList.tsx
@@ -1,0 +1,50 @@
+import type { PaletteSectionConfig } from '@/@types/palette.types';
+
+import { BrickSlot } from './brickSlot';
+import { resolveIcon } from './icons';
+
+interface SectionListProps {
+  /** Sections to render (already filtered by the parent for search/active category). */
+  sections: PaletteSectionConfig[];
+  /** Message shown when there are no sections/bricks to display. */
+  emptyMessage?: string;
+}
+
+/**
+ * Scrollable content panel for the active category. Renders each section with a color-accented
+ * header and a vertical stack of `BrickSlot` placeholders.
+ */
+export function SectionList({ sections, emptyMessage }: SectionListProps) {
+  if (sections.length === 0) {
+    return (
+      <div className="flex-1 overflow-y-auto p-4">
+        <p className="text-muted-foreground text-sm">
+          {emptyMessage ?? 'No bricks match your search.'}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto p-4">
+      {sections.map((section) => {
+        const Icon = resolveIcon(section.icon);
+        return (
+          <section key={section.name} className="mb-6">
+            <div className="mb-2 flex items-center gap-2">
+              <Icon className="size-4" style={{ color: section.color }} />
+              <h3 className="text-sm font-semibold" style={{ color: section.color }}>
+                {section.name}
+              </h3>
+            </div>
+            <div className="flex flex-col gap-2">
+              {section.bricks.map((brick) => (
+                <BrickSlot key={brick.id} brick={brick} />
+              ))}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/modules/masonry/src/palette/data/sampleConfig.ts
+++ b/modules/masonry/src/palette/data/sampleConfig.ts
@@ -1,0 +1,225 @@
+import type { BrickViewProps } from '@/@types/brick.types';
+import type { PaletteConfig } from '@/@types/palette.types';
+
+// -------------------------------------------------------------------------------------------------
+// Realistic mock PaletteConfig used by the Storybook story and the playground.
+//
+// The `brick` field of every entry is a minimal but VALID `BrickViewProps` stub. The palette shell
+// never renders these (BrickSlot is a placeholder), so the stubs exist only to satisfy the type; a
+// later PR will replace them / feed real definitions.
+// -------------------------------------------------------------------------------------------------
+
+/** Builds a minimal valid `statement` brick stub (kind/widget/colorsDefault/tooltipText only). */
+const stubBrick = (text: string, bg: string): BrickViewProps => ({
+    kind: 'statement',
+    widget: { type: 'label', text },
+    colorsDefault: { background: bg, foreground: '#ffffff', border: '#00000033' },
+    tooltipText: text,
+});
+
+/** Builds a minimal valid `value` brick stub (used for a couple of terminal entries). */
+const stubValueBrick = (text: string, bg: string): BrickViewProps => ({
+    kind: 'value',
+    widget: { type: 'label', text },
+    colorsDefault: { background: bg, foreground: '#ffffff', border: '#00000033' },
+    tooltipText: text,
+});
+
+export const sampleConfig: PaletteConfig = {
+    categories: [
+        {
+            name: 'Rhythm',
+            icon: 'Music',
+            sections: [
+                {
+                    name: 'Notes',
+                    icon: 'Music',
+                    color: '#e07a5f',
+                    bricks: [
+                        {
+                            id: 'rhythm.note.1',
+                            name: 'Note',
+                            description: 'Play a note for a given duration',
+                            brick: stubBrick('Note', '#e07a5f'),
+                        },
+                        {
+                            id: 'rhythm.rest.1',
+                            name: 'Rest',
+                            description: 'Silence for a given duration',
+                            brick: stubBrick('Rest', '#e07a5f'),
+                        },
+                        {
+                            id: 'rhythm.notevalue.1',
+                            name: 'Note Value',
+                            description: 'The duration value of the current note',
+                            brick: stubValueBrick('Note Value', '#e6957f'),
+                        },
+                    ],
+                },
+                {
+                    name: 'Meter',
+                    icon: 'Repeat',
+                    color: '#d1603f',
+                    bricks: [
+                        {
+                            id: 'rhythm.meter.1',
+                            name: 'Meter',
+                            description: 'Set the beats per measure and note value per beat',
+                            brick: stubBrick('Meter', '#d1603f'),
+                        },
+                        {
+                            id: 'rhythm.beat.1',
+                            name: 'On Every Beat',
+                            description: 'Run contained bricks on every beat',
+                            brick: stubBrick('On Every Beat', '#d1603f'),
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'Pitch',
+            icon: 'Waves',
+            sections: [
+                {
+                    name: 'Solfege',
+                    icon: 'Music',
+                    color: '#3d84a8',
+                    bricks: [
+                        {
+                            id: 'pitch.pitch.1',
+                            name: 'Pitch',
+                            description: 'Play a specific pitch by solfege and octave',
+                            brick: stubBrick('Pitch', '#3d84a8'),
+                        },
+                        {
+                            id: 'pitch.hertz.1',
+                            name: 'Hertz',
+                            description: 'Play a pitch at a specific frequency in hertz',
+                            brick: stubBrick('Hertz', '#3d84a8'),
+                        },
+                        {
+                            id: 'pitch.number.1',
+                            name: 'Pitch Number',
+                            description: 'The numeric index of the current pitch',
+                            brick: stubValueBrick('Pitch Number', '#4d94b8'),
+                        },
+                    ],
+                },
+                {
+                    name: 'Intervals',
+                    icon: 'Waves',
+                    color: '#2c6e91',
+                    bricks: [
+                        {
+                            id: 'pitch.interval.1',
+                            name: 'Scalar Interval',
+                            description: 'Add a scalar interval to contained pitches',
+                            brick: stubBrick('Scalar Interval', '#2c6e91'),
+                        },
+                        {
+                            id: 'pitch.semitone.1',
+                            name: 'Semitone Interval',
+                            description: 'Add a semitone interval to contained pitches',
+                            brick: stubBrick('Semitone Interval', '#2c6e91'),
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'Flow',
+            icon: 'GitBranch',
+            sections: [
+                {
+                    name: 'Loops',
+                    icon: 'Repeat',
+                    color: '#81b29a',
+                    bricks: [
+                        {
+                            id: 'flow.repeat.1',
+                            name: 'Repeat',
+                            description: 'Repeat contained bricks a number of times',
+                            brick: stubBrick('Repeat', '#81b29a'),
+                        },
+                        {
+                            id: 'flow.forever.1',
+                            name: 'Forever',
+                            description: 'Repeat contained bricks indefinitely',
+                            brick: stubBrick('Forever', '#81b29a'),
+                        },
+                    ],
+                },
+                {
+                    name: 'Conditionals',
+                    icon: 'GitBranch',
+                    color: '#6a9c82',
+                    bricks: [
+                        {
+                            id: 'flow.if.1',
+                            name: 'If',
+                            description: 'Run contained bricks when a condition is true',
+                            brick: stubBrick('If', '#6a9c82'),
+                        },
+                        {
+                            id: 'flow.ifelse.1',
+                            name: 'If Else',
+                            description: 'Branch between two blocks based on a condition',
+                            brick: stubBrick('If Else', '#6a9c82'),
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'Graphics',
+            icon: 'Shapes',
+            sections: [
+                {
+                    name: 'Pen',
+                    icon: 'Palette',
+                    color: '#9d6bb3',
+                    bricks: [
+                        {
+                            id: 'graphics.penup.1',
+                            name: 'Pen Up',
+                            description: 'Lift the pen so movement leaves no trail',
+                            brick: stubBrick('Pen Up', '#9d6bb3'),
+                        },
+                        {
+                            id: 'graphics.pendown.1',
+                            name: 'Pen Down',
+                            description: 'Lower the pen so movement draws a trail',
+                            brick: stubBrick('Pen Down', '#9d6bb3'),
+                        },
+                        {
+                            id: 'graphics.color.1',
+                            name: 'Set Color',
+                            description: 'Set the pen color',
+                            brick: stubBrick('Set Color', '#9d6bb3'),
+                        },
+                    ],
+                },
+                {
+                    name: 'Movement',
+                    icon: 'Play',
+                    color: '#865a9c',
+                    bricks: [
+                        {
+                            id: 'graphics.forward.1',
+                            name: 'Forward',
+                            description: 'Move the turtle forward by a distance',
+                            brick: stubBrick('Forward', '#865a9c'),
+                        },
+                        {
+                            id: 'graphics.right.1',
+                            name: 'Right',
+                            description: 'Turn the turtle clockwise by an angle',
+                            brick: stubBrick('Right', '#865a9c'),
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+};

--- a/modules/masonry/src/palette/palette.tsx
+++ b/modules/masonry/src/palette/palette.tsx
@@ -1,0 +1,55 @@
+import { useMemo, useState } from 'react';
+
+import type { PaletteConfig } from '@/@types/palette.types';
+
+import { CategoryRail } from './components/categoryRail';
+import { PaletteSearch } from './components/paletteSearch';
+import { SectionList } from './components/sectionList';
+
+interface PaletteProps {
+  /** Full Category → Section → Brick hierarchy the palette renders. */
+  config: PaletteConfig;
+}
+
+/**
+ * Root Brick Palette shell. Owns the active-category selection and the search query, composes the
+ * category rail, search input, and section list, and computes the filtered sections for the active
+ * category. This is the shell only — bricks render as placeholders (see `BrickSlot`).
+ */
+export function Palette({ config }: PaletteProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [query, setQuery] = useState('');
+
+  const categories = config.categories;
+  const clampedIndex = categories.length === 0 ? 0 : Math.min(activeIndex, categories.length - 1);
+  const activeCategory = categories[clampedIndex];
+
+  const filteredSections = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const sections = activeCategory?.sections ?? [];
+    if (!q) return sections;
+    return sections
+      .map((section) => ({
+        ...section,
+        bricks: section.bricks.filter(
+          (brick) =>
+            brick.name.toLowerCase().includes(q) || brick.description.toLowerCase().includes(q),
+        ),
+      }))
+      .filter((section) => section.bricks.length > 0);
+  }, [activeCategory, query]);
+
+  return (
+    <div className="border-border bg-background text-foreground flex h-full min-h-0 w-full overflow-hidden rounded-lg border">
+      <CategoryRail categories={categories} activeIndex={clampedIndex} onSelect={setActiveIndex} />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="border-border border-b p-3">
+          <PaletteSearch value={query} onChange={setQuery} />
+        </div>
+        <SectionList sections={filteredSections} />
+      </div>
+    </div>
+  );
+}
+
+export default Palette;

--- a/modules/masonry/src/palette/stories/brickSlot.stories.tsx
+++ b/modules/masonry/src/palette/stories/brickSlot.stories.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import type { Meta, StoryFn } from '@storybook/react-vite';
+import { BrickSlot } from '../components/brickSlot';
+import { sampleConfig } from '../data/sampleConfig';
+
+const sampleBrick = sampleConfig.categories[0].sections[0].bricks[0];
+
+export default {
+  title: 'Palette/BrickSlot',
+  component: BrickSlot,
+  decorators: [
+    (Story) => (
+      <div style={{ display: 'flex', justifyContent: 'center', padding: '2rem', width: '16rem' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    brick: { control: 'object' },
+  },
+} as Meta<typeof BrickSlot>;
+
+const Template: StoryFn<React.ComponentProps<typeof BrickSlot>> = (args) => <BrickSlot {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  brick: sampleBrick,
+};

--- a/modules/masonry/src/palette/stories/categoryRail.stories.tsx
+++ b/modules/masonry/src/palette/stories/categoryRail.stories.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import type { Meta, StoryFn } from '@storybook/react-vite';
+import { CategoryRail } from '../components/categoryRail';
+import { sampleConfig } from '../data/sampleConfig';
+
+export default {
+  title: 'Palette/CategoryRail',
+  component: CategoryRail,
+  decorators: [
+    (Story) => (
+      <div style={{ display: 'flex', width: '100%', padding: '1rem' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} as Meta<typeof CategoryRail>;
+
+const Template: StoryFn<React.ComponentProps<typeof CategoryRail>> = (args) => {
+  const [activeIndex, setActiveIndex] = useState(args.activeIndex);
+  return <CategoryRail {...args} activeIndex={activeIndex} onSelect={setActiveIndex} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  categories: sampleConfig.categories,
+  activeIndex: 0,
+  orientation: 'horizontal',
+};

--- a/modules/masonry/src/palette/stories/palette.stories.tsx
+++ b/modules/masonry/src/palette/stories/palette.stories.tsx
@@ -1,21 +1,26 @@
-// src/palette/palette.stories.tsx
-
 import React from 'react';
-import type { Meta, StoryObj } from '@storybook/react-vite';
-import PaletteWrapper from '../components/paletteWrapper';
+import type { Meta, StoryFn } from '@storybook/react-vite';
+import { Palette } from '../palette';
+import { sampleConfig } from '../data/sampleConfig';
 
-const meta: Meta<typeof PaletteWrapper> = {
-  title: 'Palette/Playground',
-  component: PaletteWrapper,
+export default {
+  title: 'Palette/Palette',
+  component: Palette,
   parameters: {
-    controls: { hideNoControlsWarning: true },
+    layout: 'fullscreen',
   },
-};
+  decorators: [
+    (Story) => (
+      <div style={{ height: '100vh' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} as Meta<typeof Palette>;
 
-export default meta;
+const Template: StoryFn<React.ComponentProps<typeof Palette>> = (args) => <Palette {...args} />;
 
-type Story = StoryObj<typeof PaletteWrapper>;
-
-export const Default: Story = {
-  name: 'Palette',
+export const Default = Template.bind({});
+Default.args = {
+  config: sampleConfig,
 };

--- a/modules/masonry/src/palette/stories/paletteSearch.stories.tsx
+++ b/modules/masonry/src/palette/stories/paletteSearch.stories.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import type { Meta, StoryFn } from '@storybook/react-vite';
+import { PaletteSearch } from '../components/paletteSearch';
+
+export default {
+  title: 'Palette/PaletteSearch',
+  component: PaletteSearch,
+  decorators: [
+    (Story) => (
+      <div style={{ width: '20rem', padding: '2rem' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} as Meta<typeof PaletteSearch>;
+
+const Template: StoryFn<React.ComponentProps<typeof PaletteSearch>> = (args) => {
+  const [value, setValue] = useState(args.value);
+  return <PaletteSearch {...args} value={value} onChange={setValue} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  value: '',
+};

--- a/modules/masonry/src/palette/stories/sectionList.stories.tsx
+++ b/modules/masonry/src/palette/stories/sectionList.stories.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import type { Meta, StoryFn } from '@storybook/react-vite';
+import { SectionList } from '../components/sectionList';
+import { sampleConfig } from '../data/sampleConfig';
+
+export default {
+  title: 'Palette/SectionList',
+  component: SectionList,
+  decorators: [
+    (Story) => (
+      <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', width: '24rem' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} as Meta<typeof SectionList>;
+
+const Template: StoryFn<React.ComponentProps<typeof SectionList>> = (args) => (
+  <SectionList {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  sections: sampleConfig.categories[0].sections,
+};
+
+export const Empty = Template.bind({});
+Empty.args = {
+  sections: [],
+};


### PR DESCRIPTION
This builds the shell for the Brick Palette (#565) - the layout components only, without rendering actual bricks yet.

What's here:

- A config-driven Palette: a category rail, a search box, a section list, and placeholder brick slots, all driven by the `PaletteConfig` types.
- Built with shadcn components and Tailwind - no custom stylesheet.
- A Storybook story per component plus a mock config, so everything can be previewed in isolation.
- The playground wired up to the new Palette.

Left for follow-ups: rendering the real bricks, drag-and-drop from the palette into the workspace, and swapping the mock data for the actual brick catalog.

Closes #565
