### PR TITLE
Traverse Brick Tower Argument sub-trees bottom up for bounds calculation

### DIFF
--- a/modules/masonry/src/components/Brick/BrickFixed.tsx
+++ b/modules/masonry/src/components/Brick/BrickFixed.tsx
@@ -225,6 +225,8 @@ export function BrickViewFixed(props: BrickViewPropsWithModel) {
     setPath(generatedPath);
     setDims({ w: width, h: height });
     model.setDims(width, height);
+    // Persist generated bounds to the model so useTowerLayout can use them for top-down positioning
+    model.setBounds(bounds);
 
     setLabelBounds({
       x: svgToPx(bounds.widget.x),

--- a/modules/masonry/src/components/Brick/BrickFixed.tsx
+++ b/modules/masonry/src/components/Brick/BrickFixed.tsx
@@ -224,6 +224,7 @@ export function BrickViewFixed(props: BrickViewPropsWithModel) {
 
     setPath(generatedPath);
     setDims({ w: width, h: height });
+    model.setDims(width, height);
 
     setLabelBounds({
       x: svgToPx(bounds.widget.x),
@@ -259,6 +260,7 @@ export function BrickViewFixed(props: BrickViewPropsWithModel) {
     svgToPx,
     pxToSvg,
     minArgNestHeight,
+    model,
   ]);
 
   return (

--- a/modules/masonry/src/components/Brick/BrickInput.tsx
+++ b/modules/masonry/src/components/Brick/BrickInput.tsx
@@ -119,6 +119,7 @@ export function BrickViewInput(props: BrickViewInputPropsWithModel) {
 
     setPath(generatedPath);
     setDims({ w: width, h: height });
+    model.setDims(width, height);
 
     setLabelBounds({
       x: svgToPx(bounds.widget.x),
@@ -126,7 +127,7 @@ export function BrickViewInput(props: BrickViewInputPropsWithModel) {
       w: svgToPx(bounds.widget.w),
       h: svgToPx(bounds.widget.h),
     });
-  }, [labelDims.w, labelDims.h, generateOutline, svgToPx, pxToSvg]);
+  }, [labelDims.w, labelDims.h, generateOutline, svgToPx, pxToSvg, model]);
 
   return (
     <svg

--- a/modules/masonry/src/components/Brick/BrickInput.tsx
+++ b/modules/masonry/src/components/Brick/BrickInput.tsx
@@ -120,6 +120,8 @@ export function BrickViewInput(props: BrickViewInputPropsWithModel) {
     setPath(generatedPath);
     setDims({ w: width, h: height });
     model.setDims(width, height);
+    // Persist generated bounds to the model so useTowerLayout can use them for top-down positioning
+    model.setBounds(bounds);
 
     setLabelBounds({
       x: svgToPx(bounds.widget.x),

--- a/modules/masonry/src/hooks/useTowerLayout.ts
+++ b/modules/masonry/src/hooks/useTowerLayout.ts
@@ -56,6 +56,27 @@ export function useTowerLayout(root: TowerNode) {
             return;
         }
 
+        // Propagate dimensions from already-rendered children into this batch's models
+        batch.forEach((node) => {
+            if (node.kind === 'expression' || node.kind === 'statement') {
+                node.model.argDims = node.args.map((arg) =>
+                    arg ? { w: arg.model.dims.w, h: arg.model.dims.h } : null,
+                );
+            }
+            if (node.kind === 'statement' && node.nestedNext) {
+                // Sum heights and find max width of the inner statement chain
+                let current: TowerNode | null = node.nestedNext;
+                let totalH = 0;
+                let maxW = 0;
+                while (current !== null) {
+                    totalH += current.model.dims.h;
+                    if (current.model.dims.w > maxW) maxW = current.model.dims.w;
+                    current = current.kind === 'statement' ? current.next : null;
+                }
+                node.model.nestingDims = { w: maxW, h: totalH };
+            }
+        });
+
         // Mark this batch's bricks ready so BrickWrappers render (and measure) them.
         useBrickLayoutStore.setState((state) => ({
             ready: {

--- a/modules/masonry/src/hooks/useTowerLayout.ts
+++ b/modules/masonry/src/hooks/useTowerLayout.ts
@@ -1,8 +1,8 @@
-import { useRef } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 
 import { TowerNode } from '@/@types/tower.types';
 import { useBrickLayoutStore } from '@/stores';
-import { listNodes } from '@/utils/tower-traversal';
+import { listNodes, traverseBottomUp } from '@/utils/tower-traversal';
 
 /**
  * Resolves the layout of a tower rooted at `root`.
@@ -14,6 +14,11 @@ import { listNodes } from '@/utils/tower-traversal';
  */
 export function useTowerLayout(root: TowerNode) {
     const isInitialized = useRef(false);
+    const generatorRef = useRef<Generator<TowerNode[]> | null>(null);
+    const isDoneRef = useRef(false);
+
+    // Incrementing this forces a re-render so the layout effect fires again for the next batch.
+    const [tick, setTick] = useState(0);
 
     const nodes = listNodes(root);
 
@@ -36,8 +41,54 @@ export function useTowerLayout(root: TowerNode) {
             },
         }));
 
+        // Create the generator once so each call to next() resumes from where it left off.
+        generatorRef.current = traverseBottomUp(root);
         isInitialized.current = true;
     }
+
+    useLayoutEffect(() => {
+        if (isDoneRef.current || generatorRef.current === null) return;
+
+        const { value: batch, done } = generatorRef.current.next();
+
+        if (done || !batch || batch.length === 0) {
+            isDoneRef.current = true;
+            return;
+        }
+
+        // Mark this batch's bricks ready so BrickWrappers render (and measure) them.
+        useBrickLayoutStore.setState((state) => ({
+            ready: {
+                ...state.ready,
+                ...Object.fromEntries(batch.map((node) => [node.model.id, true])),
+            },
+        }));
+
+        // After the BrickWrappers have rendered and updated model.dims, propagate those
+        // dimensions into the layout store's bounds.
+        useBrickLayoutStore.setState((state) => ({
+            bounds: {
+                ...state.bounds,
+                ...Object.fromEntries(
+                    batch.map((node) => {
+                        const existing = state.bounds[node.model.id] ?? { x: 0, y: 0, w: 0, h: 0 };
+                        return [
+                            node.model.id,
+                            {
+                                ...existing,
+                                w: node.model.dims.w,
+                                h: node.model.dims.h,
+                            },
+                        ];
+                    }),
+                ),
+            },
+        }));
+
+        // Schedule the next batch by triggering a re-render.
+        setTick((t) => t + 1);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [tick]);
 
     return nodes;
 }

--- a/modules/masonry/src/hooks/useTowerLayout.ts
+++ b/modules/masonry/src/hooks/useTowerLayout.ts
@@ -2,7 +2,7 @@ import { useLayoutEffect, useRef, useState } from 'react';
 
 import { TowerNode } from '@/@types/tower.types';
 import { useBrickLayoutStore } from '@/stores';
-import { listNodes, traverseBottomUp } from '@/utils/tower-traversal';
+import { listNodes, traverseBottomUp, traverseTopDown } from '@/utils/tower-traversal';
 
 /**
  * Resolves the layout of a tower rooted at `root`.
@@ -17,10 +17,16 @@ export function useTowerLayout(root: TowerNode) {
     const generatorRef = useRef<Generator<TowerNode[]> | null>(null);
     const isDoneRef = useRef(false);
 
+    const generatorTDRef = useRef<Generator<TowerNode[]> | null>(null);
+    const isDoneTDRef = useRef(false);
+    const parentMapRef = useRef<Map<TowerNode, TowerNode> | null>(null);
+
     // Incrementing this forces a re-render so the layout effect fires again for the next batch.
     const [tick, setTick] = useState(0);
 
     const nodes = listNodes(root);
+
+    const layoutVersion = useBrickLayoutStore((state) => state.layoutVersion);
 
     if (!isInitialized.current) {
         useBrickLayoutStore.setState((state) => ({
@@ -43,16 +49,110 @@ export function useTowerLayout(root: TowerNode) {
 
         // Create the generator once so each call to next() resumes from where it left off.
         generatorRef.current = traverseBottomUp(root);
+
+        // Build parent lookup map for top-down positioning
+        const pMap = new Map<TowerNode, TowerNode>();
+        nodes.forEach((node) => {
+            if (node.kind === 'statement') {
+                if (node.next) pMap.set(node.next, node);
+                if (node.nestedNext) pMap.set(node.nestedNext, node);
+                node.args.forEach((arg) => {
+                    if (arg) pMap.set(arg, node);
+                });
+            } else if (node.kind === 'expression') {
+                node.args.forEach((arg) => {
+                    if (arg) pMap.set(arg, node);
+                });
+            }
+        });
+        parentMapRef.current = pMap;
+
         isInitialized.current = true;
     }
 
+    // When layoutVersion changes externally (e.g. child resizing), restart layout engine
+    // without resetting isReady=false so children don't unmount!
     useLayoutEffect(() => {
-        if (isDoneRef.current || generatorRef.current === null) return;
+        isDoneRef.current = false;
+        isDoneTDRef.current = false;
+        generatorRef.current = traverseBottomUp(root);
+        generatorTDRef.current = null;
+        setTick((t) => t + 1);
+    }, [layoutVersion, root]);
+
+    useLayoutEffect(() => {
+        if (isDoneRef.current || generatorRef.current === null) {
+            if (isDoneTDRef.current) return;
+
+            if (generatorTDRef.current === null) {
+                generatorTDRef.current = traverseTopDown(root);
+            }
+
+            const { value: batch, done } = generatorTDRef.current!.next();
+
+            if (done || !batch || batch.length === 0) {
+                isDoneTDRef.current = true;
+                return;
+            }
+
+            const parentMap = parentMapRef.current!;
+            const layoutState = useBrickLayoutStore.getState();
+
+            // Accumulate bounds sequentially so nodes in the same batch can read newly computed bounds
+            // of their predecessors (e.g. statement chain positioning).
+            const nextBounds = { ...layoutState.bounds };
+
+            // We must process parents before children to correctly position them top-down.
+            // Since traverseTopDown yields statements in bottom-up order within the same nesting depth batch,
+            // we reverse the batch before processing so that parents are processed first.
+            const processingBatch = [...batch].reverse();
+
+            processingBatch.forEach((node) => {
+                const parent = parentMap.get(node);
+                let x = 0;
+                let y = 0;
+
+                if (parent) {
+                    const pBounds = nextBounds[parent.model.id];
+                    if (parent.kind === 'statement' && parent.next === node) {
+                        x = pBounds.x;
+                        y = pBounds.y + parent.model.dims.h;
+                    } else if (parent.kind === 'statement' && parent.nestedNext === node) {
+                        const nestBounds = parent.model.bounds.nesting;
+                        x = pBounds.x + (nestBounds?.x ?? 0);
+                        y = pBounds.y + (nestBounds?.y ?? 0);
+                    } else if (parent.kind === 'expression' || parent.kind === 'statement') {
+                        const argIndex = parent.args.indexOf(node);
+                        if (argIndex !== -1) {
+                            const argBounds = parent.model.bounds.args?.[argIndex];
+                            x = pBounds.x + (argBounds?.x ?? 0);
+                            y = pBounds.y + (argBounds?.y ?? 0);
+                        }
+                    }
+                }
+
+                const existing = nextBounds[node.model.id] ?? { w: 0, h: 0 };
+                nextBounds[node.model.id] = {
+                    ...existing,
+                    x,
+                    y,
+                };
+            });
+
+            useBrickLayoutStore.setState(() => ({
+                bounds: nextBounds,
+            }));
+
+            // Schedule the next batch by triggering a re-render.
+            setTick((t) => t + 1);
+            return;
+        }
 
         const { value: batch, done } = generatorRef.current.next();
 
         if (done || !batch || batch.length === 0) {
             isDoneRef.current = true;
+            setTick((t) => t + 1); // Trigger top-down phase
             return;
         }
 

--- a/modules/masonry/src/mocks/tower.ts
+++ b/modules/masonry/src/mocks/tower.ts
@@ -58,7 +58,11 @@ function makeExpressionArg(
 function makeStatementArg(
     path: string,
     argFactories: ((self: TowerStatementNode, path: string) => TowerNode)[],
-    options: { hasNesting?: boolean } = {},
+    options: {
+        hasNesting?: boolean;
+        hasConnectionPrev?: boolean;
+        hasConnectionNext?: boolean;
+    } = {},
 ): TowerStatementNode {
     const node: TowerStatementNode = {
         kind: 'statement',
@@ -69,6 +73,8 @@ function makeStatementArg(
             widget: { type: 'label', text: lastPathSegment(path) },
             params: argFactories.map((_, index) => String.fromCharCode(65 + index)),
             hasNesting: options.hasNesting ?? false,
+            hasConnectionPrev: options.hasConnectionPrev ?? true,
+            hasConnectionNext: options.hasConnectionNext ?? true,
         }),
         prev: null,
         next: null,
@@ -86,8 +92,6 @@ function linkStatementChain(statements: TowerStatementNode[]): TowerStatementNod
         const next = statements[index + 1] ?? null;
         statement.prev = prev;
         statement.next = next;
-        statement.model.hasConnectionPrev = prev !== null;
-        statement.model.hasConnectionNext = next !== null;
     });
     return statements[0];
 }
@@ -148,7 +152,7 @@ export const expressionTree: TowerExpressionNode = makeExpressionArg(null, 'Add 
 
 function getStatements() {
     // St1 — no args.
-    const statement1 = makeStatementArg('Statement 1', []);
+    const statement1 = makeStatementArg('Statement 1', [], { hasConnectionPrev: false });
 
     // St2 — 1 arg, a 1-level add chain.
     const statement2 = makeStatementArg('Statement 2', [
@@ -193,10 +197,14 @@ function getStatements() {
     ]);
 
     // St5 — 2 value-only args: 113, 114.
-    const statement5 = makeStatementArg('Statement 5', [
-        (self, path) => makeValueArg(self, `${path}.113`),
-        (self, path) => makeValueArg(self, `${path}.114`),
-    ]);
+    const statement5 = makeStatementArg(
+        'Statement 5',
+        [
+            (self, path) => makeValueArg(self, `${path}.113`),
+            (self, path) => makeValueArg(self, `${path}.114`),
+        ],
+        { hasConnectionNext: false },
+    );
 
     return [statement1, statement2, statement3, statement4, statement5];
 }

--- a/modules/masonry/src/models/brick.ts
+++ b/modules/masonry/src/models/brick.ts
@@ -43,6 +43,11 @@ abstract class BrickModelBase {
         return this._bounds;
     }
 
+    /** Called by the view to persist the final rendered dimensions. */
+    public setDims(w: number, h: number): void {
+        this._dims = { w, h };
+    }
+
     private _scaleLevel: 1 | 2 | 3;
     private _outlineGenerator: BrickOutlineGenerator;
 

--- a/modules/masonry/src/models/brick.ts
+++ b/modules/masonry/src/models/brick.ts
@@ -8,6 +8,7 @@ import type { Size } from '@/@types/common.types';
 
 import { BrickOutlineGenerator } from '@/utils/brick-shape';
 import { SCALE_LEVEL_CONFIG } from '@/utils/constants';
+import { useBrickLayoutStore } from '@/stores';
 
 const STROKE_WIDTH = 2;
 
@@ -45,7 +46,17 @@ abstract class BrickModelBase {
 
     /** Called by the view to persist the final rendered dimensions. */
     public setDims(w: number, h: number): void {
-        this._dims = { w, h };
+        if (this._dims.w !== w || this._dims.h !== h) {
+            this._dims = { w, h };
+            // Trigger global layout update when a brick's intrinsic size changes
+            // (e.g. from user typing) so parent expressions can resize accordingly.
+            useBrickLayoutStore.getState().markLayoutDirty();
+        }
+    }
+
+    /** Called by the view to persist the final rendered bounds. */
+    public setBounds(bounds: BrickOutlineOutput['bounds']): void {
+        this._bounds = bounds;
     }
 
     private _scaleLevel: 1 | 2 | 3;
@@ -208,6 +219,15 @@ export class ExpressionBrickModel extends BrickModelBase {
     }
 
     set argDims(value: (Size | null)[]) {
+        if (
+            this._argDims.length === value.length &&
+            this._argDims.every(
+                (v, i) =>
+                    v === value[i] || (v && value[i] && v.w === value[i]!.w && v.h === value[i]!.h),
+            )
+        ) {
+            return;
+        }
         this._argDims = value;
         this._notifyUpdate();
     }
@@ -259,6 +279,15 @@ export class StatementBrickModel extends BrickModelBase {
     }
 
     set argDims(value: (Size | null)[]) {
+        if (
+            this._argDims.length === value.length &&
+            this._argDims.every(
+                (v, i) =>
+                    v === value[i] || (v && value[i] && v.w === value[i]!.w && v.h === value[i]!.h),
+            )
+        ) {
+            return;
+        }
         this._argDims = value;
         this._notifyUpdate();
     }
@@ -273,6 +302,15 @@ export class StatementBrickModel extends BrickModelBase {
     }
 
     set nestingDims(value: Size | null) {
+        if (
+            this._nestingDims === value ||
+            (this._nestingDims &&
+                value &&
+                this._nestingDims.w === value.w &&
+                this._nestingDims.h === value.h)
+        ) {
+            return;
+        }
         this._nestingDims = value;
         this._notifyUpdate();
     }

--- a/modules/masonry/src/stores/index.ts
+++ b/modules/masonry/src/stores/index.ts
@@ -8,6 +8,16 @@ export interface BrickLayoutStore {
     bounds: Record<string, Bounds>;
     /** Per-brick, whether ready for rendering, keyed by brick (node model) id. */
     ready: Record<string, boolean>;
+    /**
+     * Incremented to trigger a full re-layout of all towers.
+     * Added so the layout engine can listen for dynamic block resizing.
+     */
+    layoutVersion: number;
+    /**
+     * Triggers a full re-layout across all active towers.
+     * Call this whenever a block's intrinsic size changes.
+     */
+    markLayoutDirty: () => void;
 }
 
 /**
@@ -17,8 +27,10 @@ export interface BrickLayoutStore {
  * subscribe to a single brick's bounds in isolation, not just whole-store changes.
  */
 export const useBrickLayoutStore = create<BrickLayoutStore>()(
-    subscribeWithSelector(() => ({
+    subscribeWithSelector((set) => ({
         bounds: {},
         ready: {},
+        layoutVersion: 0,
+        markLayoutDirty: () => set((state) => ({ layoutVersion: state.layoutVersion + 1 })),
     })),
 );

--- a/modules/masonry/src/utils/spec/tower-traversal.spec.ts
+++ b/modules/masonry/src/utils/spec/tower-traversal.spec.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+
+import { listNodes, traverseBottomUp } from '../tower-traversal';
+import {
+    valueTree,
+    expressionTree,
+    statementTreeNoNesting,
+    statementTreeWithNesting,
+} from '@/mocks/tower';
+import type { TowerNode } from '@/@types/tower.types';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Drain the generator into a flat array of batches. */
+function collectBatches(root: TowerNode): TowerNode[][] {
+    const batches: TowerNode[][] = [];
+    for (const batch of traverseBottomUp(root)) {
+        batches.push(batch);
+    }
+    return batches;
+}
+
+/** Flat list of all nodes in yield order. */
+function collectNodes(root: TowerNode): TowerNode[] {
+    return collectBatches(root).flat();
+}
+
+/**
+ * Returns true when, for every node in `nodes`, all of that node's direct arg-children
+ * appear at an earlier index in `nodes` than the node itself.
+ */
+function argsAlwaysBeforeParent(root: TowerNode, nodes: TowerNode[]): boolean {
+    const pos = new Map<TowerNode, number>(nodes.map((node, i) => [node, i]));
+    const visited = new Set<TowerNode>();
+    const stack: TowerNode[] = [root];
+
+    while (stack.length > 0) {
+        const node = stack.pop()!;
+        if (visited.has(node)) continue;
+        visited.add(node);
+
+        if (node.kind === 'expression' || node.kind === 'statement') {
+            const parentPos = pos.get(node);
+            for (const arg of node.args) {
+                if (arg === null) continue;
+                const argPos = pos.get(arg);
+                if (argPos === undefined || parentPos === undefined) return false;
+                if (argPos >= parentPos) return false;
+                stack.push(arg);
+            }
+        }
+
+        if (node.kind === 'statement') {
+            if (node.next) stack.push(node.next);
+        }
+    }
+
+    return true;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('tower-traversal', () => {
+    describe('listNodes', () => {
+        it('collects all nodes in a flat list', () => {
+            const nodes = listNodes(expressionTree);
+            expect(nodes.length).toBeGreaterThan(0);
+
+            const ids = nodes.map((n) => n.model.id);
+            expect(ids).toContain('Add 1');
+            expect(ids).toContain('Add 1.Add 2');
+        });
+    });
+
+    describe('traverseBottomUp', () => {
+        // ── 1. Single value node ─────────────────────────────────────────────
+        it('yields exactly one batch containing the value node when given a single value root', () => {
+            const batches = collectBatches(valueTree);
+
+            expect(batches).toHaveLength(1);
+            expect(batches[0]).toHaveLength(1);
+            expect(batches[0][0].model.id).toBe(valueTree.model.id);
+        });
+
+        // ── 2. Expression tree — leaf-first ordering ─────────────────────────
+        it('yields leaf value nodes before their parent expression nodes', () => {
+            const nodes = collectNodes(expressionTree);
+            const ids = nodes.map((n) => n.model.id);
+
+            // The root expression (Add 1) must be last.
+            expect(ids[ids.length - 1]).toBe('Add 1');
+
+            // Every arg child must appear before its parent.
+            expect(argsAlwaysBeforeParent(expressionTree, nodes)).toBe(true);
+        });
+
+        it('covers every node in the expression tree exactly once', () => {
+            const nodes = collectNodes(expressionTree);
+            const unique = new Set(nodes.map((n) => n.model.id));
+
+            expect(unique.size).toBe(nodes.length);
+            expect(unique.has('Add 1')).toBe(true);
+            expect(unique.has('Add 1.Add 2')).toBe(true);
+        });
+
+        // ── 3. Statement with no args ────────────────────────────────────────
+        it('yields a single batch with just the statement when it has no args', () => {
+            const generator = traverseBottomUp(statementTreeNoNesting);
+            const firstBatch = generator.next().value;
+
+            expect(firstBatch).toBeDefined();
+            expect(firstBatch).toHaveLength(1);
+            expect(firstBatch![0].model.id).toBe('Statement 1');
+        });
+
+        // ── 4. Statement chain (no nesting) — order constraint ──────────────
+        it('ensures all arg subtree nodes appear before each statement node', () => {
+            const nodes = collectNodes(statementTreeNoNesting);
+            expect(argsAlwaysBeforeParent(statementTreeNoNesting, nodes)).toBe(true);
+        });
+
+        it('covers every node in the no-nesting statement tree exactly once', () => {
+            const nodes = collectNodes(statementTreeNoNesting);
+            const unique = new Set(nodes.map((n) => n.model.id));
+
+            expect(unique.size).toBe(nodes.length);
+            expect(unique.has('Statement 1')).toBe(true);
+            expect(unique.has('Statement 2')).toBe(true);
+        });
+
+        // ── 5. Statement chain (with nesting) — nestedNext exclusion ─────────
+        it('does NOT include nestedNext cavity nodes in argument-subtree batches', () => {
+            const nodes = collectNodes(statementTreeWithNesting);
+            const unique = new Set(nodes.map((n) => n.model.id));
+
+            // NS1 and NS3 are direct members of the outer statement chain, so they ARE yielded.
+            expect(unique.has('Nesting Statement 1')).toBe(true);
+            expect(unique.has('Nesting Statement 3')).toBe(true);
+
+            // NS2 lives inside NS1's nestedNext cavity — it must NOT appear.
+            expect(unique.has('Nesting Statement 1.Nesting Statement 2')).toBe(false);
+
+            // Cavity-only statements must NOT appear.
+            expect(unique.has('Nesting Statement 1.Statement 6')).toBe(false);
+            expect(unique.has('Nesting Statement 3.Statement 8')).toBe(false);
+        });
+
+        // ── 6. Batch non-emptiness ───────────────────────────────────────────
+        it('never yields an empty batch', () => {
+            for (const tree of [
+                valueTree,
+                expressionTree,
+                statementTreeNoNesting,
+                statementTreeWithNesting,
+            ]) {
+                for (const batch of traverseBottomUp(tree)) {
+                    expect(batch.length).toBeGreaterThan(0);
+                }
+            }
+        });
+    });
+});

--- a/modules/masonry/src/utils/tower-traversal.test.ts
+++ b/modules/masonry/src/utils/tower-traversal.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { listNodes, traverseBottomUp } from './tower-traversal';
+import { listNodes, traverseBottomUp, traverseTopDown } from './tower-traversal';
 import {
     valueTree,
     expressionTree,
@@ -194,6 +194,57 @@ describe('tower-traversal', () => {
                 statementTreeWithNesting,
             ]) {
                 for (const batch of traverseBottomUp(tree)) {
+                    expect(batch.length).toBeGreaterThan(0);
+                }
+            }
+        });
+    });
+
+    describe('traverseTopDown', () => {
+        function collectBatchesTD(root: TowerNode): TowerNode[][] {
+            const batches: TowerNode[][] = [];
+            for (const batch of traverseTopDown(root)) {
+                batches.push(batch);
+            }
+            return batches;
+        }
+
+        function collectNodesTD(root: TowerNode): TowerNode[] {
+            return collectBatchesTD(root).flat();
+        }
+
+        it('yields parent statements before nested cavity statements', () => {
+            const nodes = collectNodesTD(statementTreeWithNesting);
+
+            const parentIndex = nodes.findIndex((n) => n.model.id === 'Nesting Statement 1');
+            const nestedIndex = nodes.findIndex(
+                (n) => n.model.id === 'Nesting Statement 1.Nesting Statement 2',
+            );
+
+            expect(parentIndex).toBeLessThan(nestedIndex);
+            expect(parentIndex).not.toBe(-1);
+            expect(nestedIndex).not.toBe(-1);
+        });
+
+        it('yields parent expressions before their argument children', () => {
+            const nodes = collectNodesTD(expressionTree);
+
+            const parentIndex = nodes.findIndex((n) => n.model.id === 'Add 1');
+            const childIndex = nodes.findIndex((n) => n.model.id === 'Add 1.Add 2');
+
+            expect(parentIndex).toBeLessThan(childIndex);
+            expect(parentIndex).not.toBe(-1);
+            expect(childIndex).not.toBe(-1);
+        });
+
+        it('never yields an empty batch', () => {
+            for (const tree of [
+                valueTree,
+                expressionTree,
+                statementTreeNoNesting,
+                statementTreeWithNesting,
+            ]) {
+                for (const batch of traverseTopDown(tree)) {
                     expect(batch.length).toBeGreaterThan(0);
                 }
             }

--- a/modules/masonry/src/utils/tower-traversal.test.ts
+++ b/modules/masonry/src/utils/tower-traversal.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { listNodes, traverseBottomUp } from '../tower-traversal';
+import { listNodes, traverseBottomUp } from './tower-traversal';
 import {
     valueTree,
     expressionTree,

--- a/modules/masonry/src/utils/tower-traversal.test.ts
+++ b/modules/masonry/src/utils/tower-traversal.test.ts
@@ -51,7 +51,45 @@ function argsAlwaysBeforeParent(root: TowerNode, nodes: TowerNode[]): boolean {
         }
 
         if (node.kind === 'statement') {
+            if (node.nestedNext) stack.push(node.nestedNext);
             if (node.next) stack.push(node.next);
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Returns true when, for every statement in `nodes`, its `nestedNext` cavity chain
+ * appears at an earlier index in `nodes` than the statement itself.
+ */
+function nestedAlwaysBeforeParent(root: TowerNode, nodes: TowerNode[]): boolean {
+    const pos = new Map<TowerNode, number>(nodes.map((node, i) => [node, i]));
+    const visited = new Set<TowerNode>();
+    const stack: TowerNode[] = [root];
+
+    while (stack.length > 0) {
+        const node = stack.pop()!;
+        if (visited.has(node)) continue;
+        visited.add(node);
+
+        if (node.kind === 'statement') {
+            const parentPos = pos.get(node);
+            if (node.nestedNext) {
+                const childPos = pos.get(node.nestedNext);
+                if (childPos === undefined || parentPos === undefined) return false;
+                if (childPos >= parentPos) return false;
+                stack.push(node.nestedNext);
+            }
+            if (node.next) stack.push(node.next);
+
+            for (const arg of node.args) {
+                if (arg) stack.push(arg);
+            }
+        } else if (node.kind === 'expression') {
+            for (const arg of node.args) {
+                if (arg) stack.push(arg);
+            }
         }
     }
 
@@ -105,7 +143,8 @@ describe('tower-traversal', () => {
 
         // ── 3. Statement with no args ────────────────────────────────────────
         it('yields a single batch with just the statement when it has no args', () => {
-            const generator = traverseBottomUp(statementTreeNoNesting);
+            const singleStatement = { ...statementTreeNoNesting, next: null };
+            const generator = traverseBottomUp(singleStatement);
             const firstBatch = generator.next().value;
 
             expect(firstBatch).toBeDefined();
@@ -128,21 +167,22 @@ describe('tower-traversal', () => {
             expect(unique.has('Statement 2')).toBe(true);
         });
 
-        // ── 5. Statement chain (with nesting) — nestedNext exclusion ─────────
-        it('does NOT include nestedNext cavity nodes in argument-subtree batches', () => {
+        // ── 5. Statement chain (with nesting) — full traversal constraint ────
+        it('includes nestedNext cavity nodes and yields them before their parent statements', () => {
             const nodes = collectNodes(statementTreeWithNesting);
             const unique = new Set(nodes.map((n) => n.model.id));
 
-            // NS1 and NS3 are direct members of the outer statement chain, so they ARE yielded.
+            // Must contain outer statements
             expect(unique.has('Nesting Statement 1')).toBe(true);
             expect(unique.has('Nesting Statement 3')).toBe(true);
 
-            // NS2 lives inside NS1's nestedNext cavity — it must NOT appear.
-            expect(unique.has('Nesting Statement 1.Nesting Statement 2')).toBe(false);
+            // Must contain nested statements inside cavities
+            expect(unique.has('Nesting Statement 1.Nesting Statement 2')).toBe(true);
+            expect(unique.has('Nesting Statement 1.Statement 6')).toBe(true);
+            expect(unique.has('Nesting Statement 3.Statement 8')).toBe(true);
 
-            // Cavity-only statements must NOT appear.
-            expect(unique.has('Nesting Statement 1.Statement 6')).toBe(false);
-            expect(unique.has('Nesting Statement 3.Statement 8')).toBe(false);
+            // Nested statement chains must appear BEFORE the parent statement containing the cavity
+            expect(nestedAlwaysBeforeParent(statementTreeWithNesting, nodes)).toBe(true);
         });
 
         // ── 6. Batch non-emptiness ───────────────────────────────────────────

--- a/modules/masonry/src/utils/tower-traversal.ts
+++ b/modules/masonry/src/utils/tower-traversal.ts
@@ -76,66 +76,83 @@ export function* traverseBottomUp(root: TowerNode): Generator<TowerNode[]> {
 
     const visited = new Set<TowerNode>();
 
-    /**
-     * Recursively traverses the tree.
-     * @returns For arguments: the maximum depth of its sub-tree.
-     *          For statements: 0 (statements don't report depth to their parents).
-     */
-    function traverse(node: TowerNode, nestingDepth: number): number {
-        if (visited.has(node)) return 0;
-        visited.add(node);
+    type TraversalState = {
+        node: TowerNode;
+        nestingDepth: number;
+        phase: 'ENTER' | 'EXIT';
+    };
 
-        if (node.kind === 'value' || node.kind === 'expression') {
-            let maxChildDepth = -1;
-            if (node.kind === 'expression') {
-                for (const arg of node.args) {
+    const stack: TraversalState[] = [{ node: root, nestingDepth: 0, phase: 'ENTER' }];
+    const entered = new Set<TowerNode>();
+    const argDepthMap = new Map<TowerNode, number>();
+
+    while (stack.length > 0) {
+        const { node, nestingDepth, phase } = stack.pop()!;
+
+        if (phase === 'ENTER') {
+            if (entered.has(node)) continue;
+            entered.add(node);
+
+            // Push the EXIT phase so it runs after all children are processed
+            stack.push({ node, nestingDepth, phase: 'EXIT' });
+
+            if (node.kind === 'statement') {
+                // Push children in reverse order so they are popped in forward order:
+                // args first, then nestedNext, then next.
+                if (node.next !== null) {
+                    stack.push({ node: node.next, nestingDepth, phase: 'ENTER' });
+                }
+                if (node.nestedNext !== null && node.nestedNext !== undefined) {
+                    stack.push({
+                        node: node.nestedNext,
+                        nestingDepth: nestingDepth + 1,
+                        phase: 'ENTER',
+                    });
+                }
+                for (let i = node.args.length - 1; i >= 0; i--) {
+                    const arg = node.args[i];
                     if (arg !== null) {
-                        const childDepth = traverse(arg, nestingDepth);
-                        if (childDepth > maxChildDepth) {
-                            maxChildDepth = childDepth;
-                        }
+                        stack.push({ node: arg, nestingDepth, phase: 'ENTER' });
+                    }
+                }
+            } else if (node.kind === 'expression') {
+                for (let i = node.args.length - 1; i >= 0; i--) {
+                    const arg = node.args[i];
+                    if (arg !== null) {
+                        stack.push({ node: arg, nestingDepth, phase: 'ENTER' });
                     }
                 }
             }
-            const myDepth = maxChildDepth + 1;
+        } else {
+            // phase === 'EXIT'
+            if (visited.has(node)) continue;
+            visited.add(node);
 
-            const bucket = argsByDepth.get(myDepth) ?? [];
-            bucket.push(node);
-            argsByDepth.set(myDepth, bucket);
-
-            return myDepth;
-        }
-
-        if (node.kind === 'statement') {
-            // Process arguments of the statement
-            for (const arg of node.args) {
-                if (arg !== null) {
-                    traverse(arg, nestingDepth);
+            if (node.kind === 'value' || node.kind === 'expression') {
+                let maxChildDepth = -1;
+                if (node.kind === 'expression') {
+                    for (const arg of node.args) {
+                        if (arg !== null) {
+                            const childDepth = argDepthMap.get(arg) ?? 0;
+                            if (childDepth > maxChildDepth) {
+                                maxChildDepth = childDepth;
+                            }
+                        }
+                    }
                 }
+                const myDepth = maxChildDepth + 1;
+                argDepthMap.set(node, myDepth);
+
+                const bucket = argsByDepth.get(myDepth) ?? [];
+                bucket.push(node);
+                argsByDepth.set(myDepth, bucket);
+            } else if (node.kind === 'statement') {
+                const bucket = stmtsByDepth.get(nestingDepth) ?? [];
+                bucket.push(node);
+                stmtsByDepth.set(nestingDepth, bucket);
             }
-
-            // Process nested cavity if any (increase nesting depth)
-            if (node.nestedNext !== null && node.nestedNext !== undefined) {
-                traverse(node.nestedNext, nestingDepth + 1);
-            }
-
-            // Process next statement in the sequence (same nesting depth)
-            if (node.next !== null) {
-                traverse(node.next, nestingDepth);
-            }
-
-            const bucket = stmtsByDepth.get(nestingDepth) ?? [];
-            bucket.push(node);
-            stmtsByDepth.set(nestingDepth, bucket);
-
-            return 0;
         }
-
-        return 0;
     }
-
-    // Start traversal from the root. The root is at nesting depth 0.
-    traverse(root, 0);
 
     // Yield arguments from highest depth (leaves, depth 0) down to top-level args
     const argDepths = Array.from(argsByDepth.keys()).sort((a, b) => a - b);

--- a/modules/masonry/src/utils/tower-traversal.ts
+++ b/modules/masonry/src/utils/tower-traversal.ts
@@ -57,3 +57,97 @@ export function listNodes(root: TowerNode): TowerNode[] {
 
     return nodes;
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Assigns a depth value to every node in an argument sub-tree using an iterative DFS.
+ *
+ * `depth` here means "distance from the subtree root". Leaf nodes end up with the highest
+ * depth numbers so that, when we sort descending, they appear first (bottom-up order).
+ *
+ * @param argRoot   The root of a single argument sub-tree (value or expression).
+ * @param depthMap  Accumulator: maps node → depth (updated in place).
+ */
+function collectArgDepths(argRoot: TowerNode, depthMap: Map<TowerNode, number>): void {
+    // Stack entries carry the node and the depth at which it sits.
+    const stack: { node: TowerNode; depth: number }[] = [{ node: argRoot, depth: 0 }];
+
+    while (stack.length > 0) {
+        const { node, depth } = stack.pop()!;
+
+        // Only deepen if we haven't visited this node yet, or if a deeper path is found.
+        const existing = depthMap.get(node);
+        if (existing === undefined || depth > existing) {
+            depthMap.set(node, depth);
+        }
+
+        // Push argument children (value/expression only — no statement chains here).
+        if (node.kind === 'expression') {
+            for (const arg of node.args) {
+                if (arg !== null) {
+                    stack.push({ node: arg, depth: depth + 1 });
+                }
+            }
+        }
+        // value nodes are leaves — nothing to push.
+    }
+}
+
+/**
+ * Traverses all Argument sub-trees of a Brick Tower tree, **bottom-up**, yielding one batch of
+ * `TowerNode`s per iteration.
+ *
+ * @param root - The root node of the tower tree.
+ */
+export function* traverseBottomUp(root: TowerNode): Generator<TowerNode[]> {
+    // Collect the top-level statement chain (or a single non-statement root).
+    const statementChain: TowerNode[] = [];
+
+    if (root.kind === 'statement') {
+        let current: TowerStatementNode | null = root;
+        while (current !== null) {
+            statementChain.push(current);
+            current = current.next as TowerStatementNode | null;
+        }
+    } else {
+        // Expression or value at the root — treat as one argument sub-tree.
+        statementChain.push(root);
+    }
+
+    for (const stmtNode of statementChain) {
+        // Determine which nodes have argument children (expressions/statements with args).
+        const argsToProcess: TowerNode[] =
+            stmtNode.kind === 'statement' || stmtNode.kind === 'expression'
+                ? stmtNode.args.filter((a): a is TowerNode => a !== null)
+                : [];
+
+        if (argsToProcess.length > 0) {
+            // Build a depth map for every node in every arg sub-tree of this statement.
+            const depthMap = new Map<TowerNode, number>();
+            for (const argRoot of argsToProcess) {
+                collectArgDepths(argRoot, depthMap);
+            }
+
+            // Group nodes by depth (ascending = shallow, highest number = deepest leaf).
+            const byDepth = new Map<number, TowerNode[]>();
+            for (const [node, depth] of depthMap.entries()) {
+                const bucket = byDepth.get(depth);
+                if (bucket) {
+                    bucket.push(node);
+                } else {
+                    byDepth.set(depth, [node]);
+                }
+            }
+
+            // Yield batches deepest-first (leaves before parents).
+            const depths = [...byDepth.keys()].sort((a, b) => b - a);
+            for (const depth of depths) {
+                yield byDepth.get(depth)!;
+            }
+        }
+
+        // Yield the statement/root node itself after all its arg children have been yielded.
+        yield [stmtNode];
+    }
+}

--- a/modules/masonry/src/utils/tower-traversal.ts
+++ b/modules/masonry/src/utils/tower-traversal.ts
@@ -170,3 +170,116 @@ export function* traverseBottomUp(root: TowerNode): Generator<TowerNode[]> {
         }
     }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Traverses all nodes in a Brick Tower tree in a single pass, separating them into two buckets:
+ * 1. Statements
+ * 2. Arguments (Values and Expressions)
+ *
+ * Yields batches of nodes top-down: first, all statements (outermost main chain first),
+ * and then all arguments (shallowest root arguments first).
+ *
+ * @param root - The root node of the tower tree.
+ */
+export function* traverseTopDown(root: TowerNode): Generator<TowerNode[]> {
+    const argsByDepth = new Map<number, TowerNode[]>();
+    const stmtsByDepth = new Map<number, TowerNode[]>();
+
+    const visited = new Set<TowerNode>();
+
+    type TraversalState = {
+        node: TowerNode;
+        nestingDepth: number;
+        phase: 'ENTER' | 'EXIT';
+    };
+
+    const stack: TraversalState[] = [{ node: root, nestingDepth: 0, phase: 'ENTER' }];
+    const entered = new Set<TowerNode>();
+    const argDepthMap = new Map<TowerNode, number>();
+
+    while (stack.length > 0) {
+        const { node, nestingDepth, phase } = stack.pop()!;
+
+        if (phase === 'ENTER') {
+            if (entered.has(node)) continue;
+            entered.add(node);
+
+            // Push the EXIT phase so it runs after all children are processed
+            stack.push({ node, nestingDepth, phase: 'EXIT' });
+
+            if (node.kind === 'statement') {
+                // Push children in reverse order so they are popped in forward order:
+                // args first, then nestedNext, then next.
+                if (node.next !== null) {
+                    stack.push({ node: node.next, nestingDepth, phase: 'ENTER' });
+                }
+                if (node.nestedNext !== null && node.nestedNext !== undefined) {
+                    stack.push({
+                        node: node.nestedNext,
+                        nestingDepth: nestingDepth + 1,
+                        phase: 'ENTER',
+                    });
+                }
+                for (let i = node.args.length - 1; i >= 0; i--) {
+                    const arg = node.args[i];
+                    if (arg !== null) {
+                        stack.push({ node: arg, nestingDepth, phase: 'ENTER' });
+                    }
+                }
+            } else if (node.kind === 'expression') {
+                for (let i = node.args.length - 1; i >= 0; i--) {
+                    const arg = node.args[i];
+                    if (arg !== null) {
+                        stack.push({ node: arg, nestingDepth, phase: 'ENTER' });
+                    }
+                }
+            }
+        } else {
+            // phase === 'EXIT'
+            if (visited.has(node)) continue;
+            visited.add(node);
+
+            if (node.kind === 'value' || node.kind === 'expression') {
+                let maxChildDepth = -1;
+                if (node.kind === 'expression') {
+                    for (const arg of node.args) {
+                        if (arg !== null) {
+                            const childDepth = argDepthMap.get(arg) ?? 0;
+                            if (childDepth > maxChildDepth) {
+                                maxChildDepth = childDepth;
+                            }
+                        }
+                    }
+                }
+                const myDepth = maxChildDepth + 1;
+                argDepthMap.set(node, myDepth);
+
+                const bucket = argsByDepth.get(myDepth) ?? [];
+                bucket.push(node);
+                argsByDepth.set(myDepth, bucket);
+            } else if (node.kind === 'statement') {
+                const bucket = stmtsByDepth.get(nestingDepth) ?? [];
+                bucket.push(node);
+                stmtsByDepth.set(nestingDepth, bucket);
+            }
+        }
+    }
+
+    // Top-Down: Yield statements from outermost main chain (depth 0) down to innermost cavities
+    const stmtDepths = Array.from(stmtsByDepth.keys()).sort((a, b) => a - b);
+    for (const depth of stmtDepths) {
+        if (stmtsByDepth.get(depth)!.length > 0) {
+            yield stmtsByDepth.get(depth)!;
+        }
+    }
+
+    // Top-Down: Yield arguments from highest depth (shallowest, root args) down to 0 (leaves)
+    const argDepths = Array.from(argsByDepth.keys()).sort((a, b) => b - a);
+    for (const depth of argDepths) {
+        if (argsByDepth.get(depth)!.length > 0) {
+            yield argsByDepth.get(depth)!;
+        }
+    }
+}

--- a/modules/masonry/src/utils/tower-traversal.ts
+++ b/modules/masonry/src/utils/tower-traversal.ts
@@ -61,93 +61,95 @@ export function listNodes(root: TowerNode): TowerNode[] {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Assigns a depth value to every node in an argument sub-tree using an iterative DFS.
+ * Traverses all nodes in a Brick Tower tree in a single pass, separating them into two buckets:
+ * 1. Arguments (Values and Expressions)
+ * 2. Statements
  *
- * `depth` here means "distance from the subtree root". Leaf nodes end up with the highest
- * depth numbers so that, when we sort descending, they appear first (bottom-up order).
- *
- * @param argRoot   The root of a single argument sub-tree (value or expression).
- * @param depthMap  Accumulator: maps node → depth (updated in place).
- */
-function collectArgDepths(argRoot: TowerNode, depthMap: Map<TowerNode, number>): void {
-    // Stack entries carry the node and the depth at which it sits.
-    const stack: { node: TowerNode; depth: number }[] = [{ node: argRoot, depth: 0 }];
-
-    while (stack.length > 0) {
-        const { node, depth } = stack.pop()!;
-
-        // Only deepen if we haven't visited this node yet, or if a deeper path is found.
-        const existing = depthMap.get(node);
-        if (existing === undefined || depth > existing) {
-            depthMap.set(node, depth);
-        }
-
-        // Push argument children (value/expression only — no statement chains here).
-        if (node.kind === 'expression') {
-            for (const arg of node.args) {
-                if (arg !== null) {
-                    stack.push({ node: arg, depth: depth + 1 });
-                }
-            }
-        }
-        // value nodes are leaves — nothing to push.
-    }
-}
-
-/**
- * Traverses all Argument sub-trees of a Brick Tower tree, **bottom-up**, yielding one batch of
- * `TowerNode`s per iteration.
+ * Yields batches of nodes bottom-up: first, all arguments (deepest leaves first),
+ * and then all statements (innermost cavities first).
  *
  * @param root - The root node of the tower tree.
  */
 export function* traverseBottomUp(root: TowerNode): Generator<TowerNode[]> {
-    // Collect the top-level statement chain (or a single non-statement root).
-    const statementChain: TowerNode[] = [];
+    const argsByDepth = new Map<number, TowerNode[]>();
+    const stmtsByDepth = new Map<number, TowerNode[]>();
 
-    if (root.kind === 'statement') {
-        let current: TowerStatementNode | null = root;
-        while (current !== null) {
-            statementChain.push(current);
-            current = current.next as TowerStatementNode | null;
-        }
-    } else {
-        // Expression or value at the root — treat as one argument sub-tree.
-        statementChain.push(root);
-    }
+    const visited = new Set<TowerNode>();
 
-    for (const stmtNode of statementChain) {
-        // Determine which nodes have argument children (expressions/statements with args).
-        const argsToProcess: TowerNode[] =
-            stmtNode.kind === 'statement' || stmtNode.kind === 'expression'
-                ? stmtNode.args.filter((a): a is TowerNode => a !== null)
-                : [];
+    /**
+     * Recursively traverses the tree.
+     * @returns For arguments: the maximum depth of its sub-tree.
+     *          For statements: 0 (statements don't report depth to their parents).
+     */
+    function traverse(node: TowerNode, nestingDepth: number): number {
+        if (visited.has(node)) return 0;
+        visited.add(node);
 
-        if (argsToProcess.length > 0) {
-            // Build a depth map for every node in every arg sub-tree of this statement.
-            const depthMap = new Map<TowerNode, number>();
-            for (const argRoot of argsToProcess) {
-                collectArgDepths(argRoot, depthMap);
+        if (node.kind === 'value' || node.kind === 'expression') {
+            let maxChildDepth = -1;
+            if (node.kind === 'expression') {
+                for (const arg of node.args) {
+                    if (arg !== null) {
+                        const childDepth = traverse(arg, nestingDepth);
+                        if (childDepth > maxChildDepth) {
+                            maxChildDepth = childDepth;
+                        }
+                    }
+                }
             }
+            const myDepth = maxChildDepth + 1;
 
-            // Group nodes by depth (ascending = shallow, highest number = deepest leaf).
-            const byDepth = new Map<number, TowerNode[]>();
-            for (const [node, depth] of depthMap.entries()) {
-                const bucket = byDepth.get(depth);
-                if (bucket) {
-                    bucket.push(node);
-                } else {
-                    byDepth.set(depth, [node]);
+            const bucket = argsByDepth.get(myDepth) ?? [];
+            bucket.push(node);
+            argsByDepth.set(myDepth, bucket);
+
+            return myDepth;
+        }
+
+        if (node.kind === 'statement') {
+            // Process arguments of the statement
+            for (const arg of node.args) {
+                if (arg !== null) {
+                    traverse(arg, nestingDepth);
                 }
             }
 
-            // Yield batches deepest-first (leaves before parents).
-            const depths = [...byDepth.keys()].sort((a, b) => b - a);
-            for (const depth of depths) {
-                yield byDepth.get(depth)!;
+            // Process nested cavity if any (increase nesting depth)
+            if (node.nestedNext !== null && node.nestedNext !== undefined) {
+                traverse(node.nestedNext, nestingDepth + 1);
             }
+
+            // Process next statement in the sequence (same nesting depth)
+            if (node.next !== null) {
+                traverse(node.next, nestingDepth);
+            }
+
+            const bucket = stmtsByDepth.get(nestingDepth) ?? [];
+            bucket.push(node);
+            stmtsByDepth.set(nestingDepth, bucket);
+
+            return 0;
         }
 
-        // Yield the statement/root node itself after all its arg children have been yielded.
-        yield [stmtNode];
+        return 0;
+    }
+
+    // Start traversal from the root. The root is at nesting depth 0.
+    traverse(root, 0);
+
+    // Yield arguments from highest depth (leaves, depth 0) down to top-level args
+    const argDepths = Array.from(argsByDepth.keys()).sort((a, b) => a - b);
+    for (const depth of argDepths) {
+        if (argsByDepth.get(depth)!.length > 0) {
+            yield argsByDepth.get(depth)!;
+        }
+    }
+
+    // Yield statements from highest nesting depth (innermost cavities) down to 0 (main chain)
+    const stmtDepths = Array.from(stmtsByDepth.keys()).sort((a, b) => b - a);
+    for (const depth of stmtDepths) {
+        if (stmtsByDepth.get(depth)!.length > 0) {
+            yield stmtsByDepth.get(depth)!;
+        }
     }
 }


### PR DESCRIPTION
Created a layout utility generator function that traverses the Argument sub-trees of a Brick Tower tree, bottom up, generating batches of Bricks to render, in every iteration.

As Bricks render, they'll calculate and update their dimensions in their models which is then be propagated by to the layout store