### PR TITLE
#796 | feat(masonry/validation): add block connection validation engine

### DIFF
--- a/modules/masonry/src/components/Palette/Palette.test.tsx
+++ b/modules/masonry/src/components/Palette/Palette.test.tsx
@@ -33,15 +33,17 @@ const StubIcon = (props: { className?: string; style?: React.CSSProperties }) =>
   <span data-testid="stub-icon" {...props} />
 );
 
-// The placeholder BrickSlot never reads `brick`, so an empty cast keeps fixtures terse.
-const brick = {} as PaletteBrickConfig['brick'];
-
-/** Builds a single palette brick entry. */
+/** Builds a single palette brick entry with a value-kind brick config that renders the name. */
 const entry = (id: string, name: string, description: string): PaletteBrickConfig => ({
   id,
   name,
   description,
-  brick,
+  brick: {
+    kind: 'value',
+    colorsDefault: { background: '', foreground: '', border: '' },
+    tooltipText: '',
+    widget: { type: 'label', text: name },
+  },
 });
 
 /** Builds a category with an accent color and the given bricks. */

--- a/modules/masonry/src/validation/connectionRules.ts
+++ b/modules/masonry/src/validation/connectionRules.ts
@@ -1,0 +1,65 @@
+import type { TNotchType } from '../../@types/tower';
+
+export interface ConnectionRule {
+    parentPattern: RegExp;
+    childPattern: RegExp;
+    notchTypes: TNotchType[];
+    reason?: string;
+}
+
+export const RULES_NESTED: ConnectionRule[] = [
+    { parentPattern: /Start|Action/, childPattern: /.*/, notchTypes: ['nested'] },
+    {
+        parentPattern:
+            /Repeat|Forever|While|Until|If|If\sElse|On\sEvery\sBeat|On\sStrong\sBeat|On\sEvent/,
+        childPattern: /^.+$/,
+        notchTypes: ['nested'],
+    },
+    {
+        parentPattern: /Note|Rest|Dotted\sNote|Tie|Tuplet/,
+        childPattern:
+            /Pitch|Solfege|Hertz|Note\sName|Scalar\sInterval|Semitone\sInterval|Transpose|Set\sOctave|Set\sMode|Sharp|Flat|Glide|Set\sInstrument|Staccato|Slur|Accent|Envelope|Set\sVolume|Crescendo|Decrescendo|Pan|Play\sDrum|Set\sDrum|Play\sNoise|Map\sPitch/,
+        notchTypes: ['nested'],
+    },
+    {
+        parentPattern: /Scalar\sInterval|Semitone\sInterval|Transpose|Set\sOctave|Set\sMode/,
+        childPattern: /Pitch|Solfege|Hertz|Note\sName|Sharp|Flat|Glide/,
+        notchTypes: ['nested'],
+    },
+    {
+        parentPattern: /Set\sDrum|Map\sPitch\sTo\sDrum/,
+        childPattern: /Pitch|Solfege|Hertz/,
+        notchTypes: ['nested'],
+    },
+    {
+        parentPattern: /Staccato|Slur|Accent|Envelope|Set\sVolume|Crescendo|Decrescendo|Pan/,
+        childPattern: /Pitch|Solfege|Hertz|Note\sName/,
+        notchTypes: ['nested'],
+    },
+];
+
+export const RULES_ARG: ConnectionRule[] = [
+    {
+        parentPattern:
+            /Add|Subtract|Multiply|Divide|Random|Equals|Greater|Less|And|Or|Not|Box|Named\sBox|Store\sIn\sBox|Add\sTo\sBox|Set\sHeap\sEntry|Heap\sEntry/,
+        childPattern:
+            /Number|Boolean|Note\sValue|Pitch\sNumber|Volume\sLevel|Beat\sCount|Heading|Mouse|Key|Time|Turtle|Pop|Heap\sLength|Box|Named\sBox|Add|Subtract|Multiply|Divide|Random|Equals|Greater|Less|And|Or|Not/,
+        notchTypes: ['right-left'],
+    },
+];
+
+export function matchRule(
+    parentName: string,
+    childName: string,
+    notchType: TNotchType,
+    rules: ConnectionRule[],
+): { matched: boolean; reason?: string } {
+    for (const rule of rules) {
+        const notchMatch = rule.notchTypes.includes(notchType);
+        if (!notchMatch) continue;
+        if (rule.parentPattern.test(parentName) && rule.childPattern.test(childName)) {
+            return { matched: true, reason: rule.reason };
+        }
+    }
+    return { matched: false, reason: `${childName} cannot be placed inside ${parentName}` };
+}

--- a/modules/masonry/src/validation/index.ts
+++ b/modules/masonry/src/validation/index.ts
@@ -1,0 +1,4 @@
+export { ValidationEngine } from './validationEngine';
+export { useBlockValidation } from './useBlockValidation';
+export { matchRule, RULES_NESTED, RULES_ARG } from './connectionRules';
+export type { ConnectionRule } from './connectionRules';

--- a/modules/masonry/src/validation/useBlockValidation.ts
+++ b/modules/masonry/src/validation/useBlockValidation.ts
@@ -1,0 +1,17 @@
+import { useMemo, useCallback } from 'react';
+import type { IBrick } from '../../@types/brick';
+import type { TNotchType, TConnectionValidation } from '../../@types/tower';
+import { ValidationEngine } from './validationEngine';
+
+export function useBlockValidation() {
+    const engine = useMemo(() => new ValidationEngine(), []);
+
+    const canConnect = useCallback(
+        (parent: IBrick, child: IBrick, notchType: TNotchType): TConnectionValidation => {
+            return engine.canConnect(parent.name, parent.type, child.name, child.type, notchType);
+        },
+        [engine],
+    );
+
+    return { canConnect };
+}

--- a/modules/masonry/src/validation/validationEngine.test.ts
+++ b/modules/masonry/src/validation/validationEngine.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { ValidationEngine } from './validationEngine';
+
+describe('ValidationEngine', () => {
+    const engine = new ValidationEngine();
+
+    it('allows top-bottom connection for any brick pair', () => {
+        expect(engine.canConnect('Note', 'Compound', 'Pitch', 'Simple', 'top-bottom')).toEqual({
+            isValid: true,
+        });
+        expect(engine.canConnect('Start', 'Simple', 'Note', 'Simple', 'top-bottom')).toEqual({
+            isValid: true,
+        });
+    });
+
+    it('allows Note to contain Pitch via nested', () => {
+        expect(engine.canConnect('Note', 'Compound', 'Pitch', 'Simple', 'nested')).toEqual({
+            isValid: true,
+        });
+    });
+
+    it('allows Note to contain Set Instrument via nested', () => {
+        expect(engine.canConnect('Note', 'Compound', 'Set Instrument', 'Simple', 'nested')).toEqual(
+            {
+                isValid: true,
+            },
+        );
+    });
+
+    it('rejects placing Number inside Note via nested', () => {
+        const result = engine.canConnect('Note', 'Compound', 'Number', 'Expression', 'nested');
+        expect(result.isValid).toBe(false);
+        expect(result.reason).toMatch(/cannot be placed/);
+    });
+
+    it('allows Flow blocks to contain any statement via nested', () => {
+        expect(engine.canConnect('Repeat', 'Compound', 'Note', 'Simple', 'nested')).toEqual({
+            isValid: true,
+        });
+        expect(engine.canConnect('Forever', 'Compound', 'Pitch', 'Simple', 'nested')).toEqual({
+            isValid: true,
+        });
+        expect(engine.canConnect('If', 'Compound', 'Wait', 'Simple', 'nested')).toEqual({
+            isValid: true,
+        });
+    });
+
+    it('allows Start to contain any statement via nested', () => {
+        expect(engine.canConnect('Start', 'Compound', 'Note', 'Simple', 'nested')).toEqual({
+            isValid: true,
+        });
+    });
+
+    it('rejects nesting an unrelated block inside Pitch', () => {
+        const result = engine.canConnect('Pitch', 'Simple', 'Repeat', 'Compound', 'nested');
+        expect(result.isValid).toBe(false);
+    });
+
+    it('allows Add expression to accept Number via right-left', () => {
+        expect(
+            engine.canConnect('Add', 'Expression', 'Number', 'Expression', 'right-left'),
+        ).toEqual({
+            isValid: true,
+        });
+    });
+
+    it('allows Add expression to accept Boolean via right-left', () => {
+        expect(
+            engine.canConnect('Add', 'Expression', 'Boolean', 'Expression', 'right-left'),
+        ).toEqual({
+            isValid: true,
+        });
+    });
+
+    it('rejects placing Start inside Add via right-left', () => {
+        const result = engine.canConnect('Add', 'Expression', 'Start', 'Simple', 'right-left');
+        expect(result.isValid).toBe(false);
+    });
+
+    it('allows nested Interval blocks to contain Pitch', () => {
+        expect(
+            engine.canConnect('Scalar Interval', 'Compound', 'Pitch', 'Simple', 'nested'),
+        ).toEqual({ isValid: true });
+    });
+
+    it('allows Drum Set to contain Pitch', () => {
+        expect(engine.canConnect('Set Drum', 'Compound', 'Pitch', 'Simple', 'nested')).toEqual({
+            isValid: true,
+        });
+    });
+});

--- a/modules/masonry/src/validation/validationEngine.ts
+++ b/modules/masonry/src/validation/validationEngine.ts
@@ -1,0 +1,35 @@
+import type { TBrickType } from '../../@types/brick';
+import type { TNotchType, TConnectionValidation } from '../../@types/tower';
+import { matchRule, RULES_NESTED, RULES_ARG } from './connectionRules';
+
+export class ValidationEngine {
+    canConnect(
+        parentName: string,
+        parentType: TBrickType,
+        childName: string,
+        childType: TBrickType,
+        notchType: TNotchType,
+    ): TConnectionValidation {
+        if (notchType === 'top-bottom') {
+            return { isValid: true };
+        }
+
+        if (notchType === 'nested') {
+            const result = matchRule(parentName, childName, notchType, RULES_NESTED);
+            if (!result.matched) {
+                return { isValid: false, reason: result.reason };
+            }
+            return { isValid: true };
+        }
+
+        if (notchType === 'right-left' || notchType === 'left-right') {
+            const result = matchRule(parentName, childName, notchType, RULES_ARG);
+            if (!result.matched) {
+                return { isValid: false, reason: result.reason };
+            }
+            return { isValid: true };
+        }
+
+        return { isValid: true };
+    }
+}


### PR DESCRIPTION
## Summary
Add real-time block connection validation engine for the masonry editor.

## Related Issue
C4GT: #796

## What changed
- \ValidationEngine\ class with \canConnect()\ method that checks
  semantic + structural compatibility for nested and arg-slot connections
- Rule sets (\RULES_NESTED\, \RULES_ARG\) mapping musical-block semantics
  (e.g., Note→Pitch allowed, Pitch→Repeat rejected, Add→Number allowed)
- \useBlockValidation()\ React hook for drag-and-drop integration
- 12 unit tests with full coverage of top-bottom, arg-slot, and
  compound-block connection scenarios
- Fixed 28 pre-existing test failures in Palette.test.tsx where empty
  mock brick data crashed BrickSlot's createPreviewModel

## Why this approach
Minimal surface — engine is a pure function class, hook is a thin
wrapper. No new dependencies. Can be composed into existing
drag-and-drop handlers via \useBlockValidation\.

## Testing done
- 12 new unit tests pass; verified they fail without the fix
- All 144 existing tests pass (28 pre-existing failures now fixed)
- Full monorepo build succeeds
- Lint clean (0 errors)

## Checklist
- [x] Tests added/updated
- [ ] Docs updated (API is internal to masonry — no user-facing changes)
- [x] Lint/format passes
- [x] C4GT issue referenced
- [x] Commits signed off
- [x] No unrelated changes bundled in