### PR TITLE
#566 | feat(masonry): create Workspace shell component

### DIFF
--- a/modules/masonry/src/@types/workspace.types.ts
+++ b/modules/masonry/src/@types/workspace.types.ts
@@ -1,0 +1,22 @@
+import type { PaletteConfig } from './palette.types';
+
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Top-level configuration object for the Workspace.
+ *
+ * Currently carries only the Palette's config; later PRs will extend this with config for the
+ * Workspace's other composed pieces.
+ */
+export interface WorkspaceConfig {
+    /** Config for the composed Palette. */
+    palette: PaletteConfig;
+}
+
+/**
+ * Props for the Workspace view component.
+ */
+export interface WorkspaceViewProps {
+    /** Config for the Workspace and its composed pieces. */
+    config: WorkspaceConfig;
+}

--- a/modules/masonry/src/components/Workspace/Workspace.tsx
+++ b/modules/masonry/src/components/Workspace/Workspace.tsx
@@ -1,0 +1,3 @@
+export default function Workspace() {
+  return <div>Workspace</div>;
+}

--- a/modules/masonry/src/components/Workspace/Workspace.tsx
+++ b/modules/masonry/src/components/Workspace/Workspace.tsx
@@ -1,3 +1,17 @@
-export default function Workspace() {
-  return <div>Workspace</div>;
+import type { WorkspaceViewProps } from '@/@types/workspace.types';
+
+import { Palette } from '@/components/Palette/Palette';
+
+export function Workspace({ config }: WorkspaceViewProps) {
+  const { palette } = config;
+
+  return (
+    <div className="flex h-full w-full">
+      <div className="h-full max-w-80">
+        <Palette config={palette} />
+      </div>
+
+      <div className="h-full w-full shrink"></div>
+    </div>
+  );
 }

--- a/modules/masonry/src/index.css
+++ b/modules/masonry/src/index.css
@@ -1,4 +1,4 @@
-@import 'tailwindcss';
+@import 'tailwindcss' source('.');
 @import 'tw-animate-css';
 @import 'shadcn/tailwind.css';
 @import '@fontsource-variable/nunito-sans';

--- a/modules/masonry/src/playground/pages/Workspace.tsx
+++ b/modules/masonry/src/playground/pages/Workspace.tsx
@@ -1,0 +1,11 @@
+import Workspace from '@/components/Workspace/Workspace';
+
+export default function WorkspaceDemo() {
+  return (
+    <div className="h-full w-full bg-indigo-100 px-2">
+      <div className="h-full w-full bg-white">
+        <Workspace />
+      </div>
+    </div>
+  );
+}

--- a/modules/masonry/src/playground/pages/Workspace.tsx
+++ b/modules/masonry/src/playground/pages/Workspace.tsx
@@ -1,10 +1,11 @@
-import Workspace from '@/components/Workspace/Workspace';
+import { Workspace } from '@/components/Workspace/Workspace';
+import { mockPaletteConfig } from '@/mocks/palette';
 
 export default function WorkspaceDemo() {
   return (
-    <div className="h-full w-full bg-indigo-100 px-2">
-      <div className="h-full w-full bg-white">
-        <Workspace />
+    <div className="h-full w-full bg-indigo-100 p-2">
+      <div className="h-full w-full rounded-lg bg-white">
+        <Workspace config={{ palette: mockPaletteConfig }} />
       </div>
     </div>
   );

--- a/modules/masonry/src/playground/pages/index.ts
+++ b/modules/masonry/src/playground/pages/index.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from 'react';
 
 import DragNDrop from './DragNDrop';
+import WorkspaceDemo from './Workspace';
 
 export interface PageDef {
     path: string;
@@ -15,5 +16,11 @@ export const pages: PageDef[] = [
         label: 'Drag & Drop',
         description: 'A simple drag and drop example',
         component: DragNDrop,
+    },
+    {
+        path: 'workspace',
+        label: 'Workspace',
+        description: 'Demonstrates the Workspace in operation',
+        component: WorkspaceDemo,
     },
 ];


### PR DESCRIPTION
- Create Workspace shell component embedding Palette
- Add a harness for Workspace in playground passing down mock Palette config

closes #566 