### PR TITLE
#509 | feat(editor): add hover tooltip to editor toggle button

### DIFF
--- a/@types/components/editor.d.ts
+++ b/@types/components/editor.d.ts
@@ -2,7 +2,7 @@ import type { TAsset } from '../assets';
 
 export type TInjectedEditor = {
     flags: undefined;
-    i18n: Record<'editor.build' | 'editor.help', string>;
+    i18n: Record<'editor.build' | 'editor.help' | 'editor.editor', string>;
     assets: Record<
         | 'image.icon.build'
         | 'image.icon.help'

--- a/app/src/components.ts
+++ b/app/src/components.ts
@@ -13,6 +13,7 @@ const manifest: TComponentManifest = {
             strings: {
                 'editor.build': 'build button - build the program',
                 'editor.help': 'help button - show syntax information',
+                'editor.editor': 'editor button - open or close code editor',
             },
             assets: [
                 'image.icon.build',

--- a/lib/i18n/lang/en.ts
+++ b/lib/i18n/lang/en.ts
@@ -3,6 +3,7 @@ import type { TI18nFile } from '#/@types/i18n';
 const strings: TI18nFile = {
     'editor.build': 'build',
     'editor.help': 'help',
+    'editor.editor': 'Editor',
 
     'menu.reset': 'reset',
     'menu.run': 'run',

--- a/lib/i18n/lang/es.ts
+++ b/lib/i18n/lang/es.ts
@@ -3,6 +3,7 @@ import type { TI18nFile } from '#/@types/i18n';
 const strings: TI18nFile = {
     'editor.build': 'construir',
     'editor.help': 'ayuda',
+    'editor.editor': 'Editor',
 
     'menu.reset': 'reiniciar',
     'menu.run': 'tocar',

--- a/modules/editor/src/view/components/button/index.scss
+++ b/modules/editor/src/view/components/button/index.scss
@@ -1,27 +1,73 @@
 @import '@res/themes/light';
 
 #editor-toolbar-btn {
+  position: relative;
+  display: grid;
+  justify-content: center;
+  align-items: center;
   padding: 0.25rem;
 
-  svg {
+  .editor-btn-img {
     width: 100%;
     height: 100%;
 
-    &.editor-toolbar-btn-img-hidden {
-      display: none;
+    svg {
+      width: 100%;
+      height: 100%;
+
+      &.editor-toolbar-btn-img-hidden {
+        display: none;
+      }
+
+      .path-fill {
+        fill: $mb-accent;
+        transition: all 0.25s ease;
+      }
+    }
+  }
+
+  .editor-btn-label {
+    position: absolute;
+    z-index: 100;
+    left: calc(100% + 0.25rem);
+    display: none;
+    margin: 0;
+    padding: 0 0.375rem 0.125rem 0.25rem;
+    border-radius: 0 0.25rem 0.25rem 0;
+    background-color: $mb-accent-light;
+    white-space: nowrap;
+
+    &::before {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      display: block;
+      content: '';
+      width: 0.25rem;
+      transform: translateX(-100%);
+      clip-path: polygon(0 50%, 100% 0%, 100% 100%);
+      background-color: $mb-accent-light;
     }
 
-    .path-fill {
-      fill: $mb-accent;
-      transition: all 0.25s ease;
+    span {
+      font-size: 0.75rem;
+      font-weight: bold;
+      color: $text-light;
     }
   }
 
   &:hover {
-    svg {
-      .path-fill {
-        fill: $mb-accent-light;
+    .editor-btn-img {
+      svg {
+        .path-fill {
+          fill: $mb-accent-light;
+        }
       }
+    }
+
+    .editor-btn-label {
+      display: block;
     }
   }
 }

--- a/modules/editor/src/view/components/button/index.tsx
+++ b/modules/editor/src/view/components/button/index.tsx
@@ -7,6 +7,7 @@ import './index.scss';
 // -- private variables ----------------------------------------------------------------------------
 
 let _container: HTMLElement;
+let _imgContainer: HTMLElement;
 let _svgCode: string;
 let _svgClose: string;
 
@@ -23,6 +24,17 @@ export function setup(container: HTMLElement): void {
   _svgCode = injected.assets['image.icon.code'].data;
   _svgClose = injected.assets['image.icon.close'].data;
 
+  _imgContainer = document.createElement('div');
+  _imgContainer.classList.add('editor-btn-img');
+  _container.appendChild(_imgContainer);
+
+  const label = document.createElement('p');
+  label.classList.add('editor-btn-label');
+  const span = document.createElement('span');
+  span.innerText = injected.i18n['editor.editor'] || 'Editor';
+  label.appendChild(span);
+  _container.appendChild(label);
+
   setButtonImg('code');
 }
 
@@ -31,5 +43,5 @@ export function setup(container: HTMLElement): void {
  * @param icon icon name
  */
 export function setButtonImg(icon: 'code' | 'cross'): void {
-  _container.innerHTML = icon === 'code' ? _svgCode : _svgClose;
+  _imgContainer.innerHTML = icon === 'code' ? _svgCode : _svgClose;
 }


### PR DESCRIPTION
## Summary

Adds a CSS-based hover tooltip ("Editor") to the editor toggle button in the sidebar, matching the existing tooltip pattern used by the Run, Stop, and Reset buttons in the menu.

Fixes #509

## Changes

### Type Definitions
- Added `editor.editor` translation key to `TInjectedEditor.i18n` in `@types/components/editor.d.ts`

### Component Manifest
- Added `editor.editor: editor button - open or close code editor` to the strings dictionary in `app/src/components.ts`

### Internationalization
- Added `editor.editor: Editor` to English (`lib/i18n/lang/en.ts`) and Spanish (`lib/i18n/lang/es.ts`) translation files

### Editor Button Component
- Refactored `modules/editor/src/view/components/button/index.tsx` to separate the SVG icon into a wrapper div (`.editor-btn-img`) and added a tooltip label element (`.editor-btn-label`)
- Updated `setButtonImg` to target the image wrapper instead of the entire button container, so the tooltip persists when the icon toggles between code/close states

### Tooltip Styles
- Added hover tooltip CSS in `modules/editor/src/view/components/button/index.scss` with absolute positioning, triangle arrow indicator (via `clip-path`), and show/hide on `:hover` — matching the menu button tooltip design

## Verification
- `npm run check` — ✅ All 15 projects passed
- `npm run lint` — ✅ All 17 projects passed
- `npm run build` — ✅ Build successful
- `npm run test` — ✅ All 174 tests passed
- Manual browser testing — ✅ Tooltip appears on hover, editor panel toggles correctly
