### PR TITLE
692 feat(masonry): Add support for being able to move Brick Towers starting from the root Brick

### DIFF
--- a/modules/masonry/src/components/Tower/TowerBrick.tsx
+++ b/modules/masonry/src/components/Tower/TowerBrick.tsx
@@ -1,8 +1,9 @@
-import { memo } from 'react';
+import { memo, useRef } from 'react';
 
 import type { TowerNode } from '@/@types/tower.types';
 
 import { BrickView } from '@/components/Brick/Brick';
+import { useBrickMove } from '@/hooks/useBrickMove';
 import { useBrickLayoutStore } from '@/stores/brick';
 
 export interface TowerBrickViewProps {
@@ -22,6 +23,9 @@ export interface TowerBrickViewProps {
  */
 export const TowerBrickView = memo(function (props: TowerBrickViewProps) {
   const { id, node } = props;
+  const ref = useRef<HTMLDivElement>(null);
+
+  useBrickMove(id, ref);
 
   const { x, y } = useBrickLayoutStore((state) => state.coords[id]);
   const isMounted = useBrickLayoutStore((state) => state.mounted[id]);
@@ -42,6 +46,7 @@ export const TowerBrickView = memo(function (props: TowerBrickViewProps) {
 
   return (
     <div
+      ref={ref}
       data-id={id}
       className="absolute"
       style={{

--- a/modules/masonry/src/hooks/useBrickMove.ts
+++ b/modules/masonry/src/hooks/useBrickMove.ts
@@ -1,0 +1,54 @@
+import type { DragEvent } from '@interactjs/types';
+import interact from 'interactjs';
+import { RefObject, useEffect, useRef } from 'react';
+
+import { useBrickLayoutStore } from '@/stores/brick';
+
+/**
+ * Attaches interact.js drag events to a brick's DOM element.
+ * During a drag, it collects the position delta and updates the target
+ * brick's coordinates in the brick layout store, visually translating it.
+ *
+ * @param id - The unique identifier of the target brick.
+ * @param ref - The DOM ref of the brick's wrapper element.
+ */
+export function useBrickMove(id: string, ref: RefObject<HTMLElement | null>) {
+    const dragPosRef = useRef({ x: 0, y: 0 });
+    const isMounted = useBrickLayoutStore((state) => state.mounted[id]);
+
+    useEffect(() => {
+        const el = ref.current;
+        if (!el) return;
+
+        const interactable = interact(el).draggable({
+            listeners: {
+                start(_event: DragEvent) {
+                    console.log('Drag started on brick:', id);
+                    const { coords } = useBrickLayoutStore.getState();
+                    const current = coords[id];
+                    if (current) {
+                        dragPosRef.current = { x: current.x, y: current.y };
+                    }
+                },
+                move(event: DragEvent) {
+                    console.log('Drag move on brick:', id, 'dx:', event.dx, 'dy:', event.dy);
+                    dragPosRef.current.x += event.dx;
+                    dragPosRef.current.y += event.dy;
+
+                    useBrickLayoutStore.getState().setCoords(id, {
+                        x: dragPosRef.current.x,
+                        y: dragPosRef.current.y,
+                    });
+                },
+                end(_event: DragEvent) {
+                    console.log('Drag ended on brick:', id);
+                    // Placeholder for future drop logic
+                },
+            },
+        });
+
+        return () => {
+            interactable.unset();
+        };
+    }, [id, ref, isMounted]);
+}

--- a/modules/masonry/src/hooks/useBrickMove.ts
+++ b/modules/masonry/src/hooks/useBrickMove.ts
@@ -23,7 +23,6 @@ export function useBrickMove(id: string, ref: RefObject<HTMLElement | null>) {
         const interactable = interact(el).draggable({
             listeners: {
                 start(_event: DragEvent) {
-                    console.log('Drag started on brick:', id);
                     const { coords } = useBrickLayoutStore.getState();
                     const current = coords[id];
                     if (current) {
@@ -31,7 +30,6 @@ export function useBrickMove(id: string, ref: RefObject<HTMLElement | null>) {
                     }
                 },
                 move(event: DragEvent) {
-                    console.log('Drag move on brick:', id, 'dx:', event.dx, 'dy:', event.dy);
                     dragPosRef.current.x += event.dx;
                     dragPosRef.current.y += event.dy;
 
@@ -41,7 +39,6 @@ export function useBrickMove(id: string, ref: RefObject<HTMLElement | null>) {
                     });
                 },
                 end(_event: DragEvent) {
-                    console.log('Drag ended on brick:', id);
                     // Placeholder for future drop logic
                 },
             },


### PR DESCRIPTION
closes #692 
Add support for being able to move Brick Towers starting from the root Brick