### PR TITLE
Add support for connecting Argument Bricks together

### DIFF
--- a/modules/masonry/src/@types/brick.types.ts
+++ b/modules/masonry/src/@types/brick.types.ts
@@ -81,8 +81,8 @@ export interface BrickOutlineOutput {
  *   next       — hasNextNotch
  *   nestedNext — hasNesting (cavity-roof tab)
  *   output     — hasOutputNotch
- * `inputs` is always present: one Point per argument slot whose arg !== null,
- * ordered top-to-bottom; an empty array when the brick has no filled arg slots.
+ * `inputs` is always present: one entry per argument slot (filled and empty),
+ * ordered top-to-bottom; an empty array when the brick has no arg slots.
  */
 export interface BrickConnectorCoords {
     /** Sequence-in connector centroid (top-edge groove). */
@@ -93,8 +93,22 @@ export interface BrickConnectorCoords {
     nestedNext?: Point;
     /** Output connector centroid (left-edge tab). */
     output?: Point;
-    /** Argument-slot connector centroids (right-edge grooves), one per filled slot. */
-    inputs: Point[];
+    /** Argument-slot connector centroids (right-edge grooves), one per slot. */
+    inputs: BrickInputConnector[];
+}
+
+/**
+ * One argument-slot input connector: its centroid plus which slot it belongs to and
+ * whether that slot currently holds a child. Emitted for every slot — filled and empty —
+ * so empty slots can be queried as snap targets.
+ */
+export interface BrickInputConnector {
+    /** Connector centroid (right-edge groove). */
+    point: Point;
+    /** Slot's declaration-order index. */
+    index: number;
+    /** Whether the slot currently holds a child. */
+    filled: boolean;
 }
 
 export interface BrickMinimums {

--- a/modules/masonry/src/components/Path/Path.tsx
+++ b/modules/masonry/src/components/Path/Path.tsx
@@ -177,8 +177,8 @@ export function PathBrickView({ input }: { input: BrickOutlineInput }) {
         {connectors.inputs.map((p, i) => (
           <circle
             key={i}
-            cx={svgToPx(p.x)}
-            cy={svgToPx(p.y)}
+            cx={svgToPx(p.point.x)}
+            cy={svgToPx(p.point.y)}
             r={MARKER_RADIUS}
             fill={CONNECTOR_COLORS.inputs}
             stroke="#fff"

--- a/modules/masonry/src/components/Workspace/Workspace.test.tsx
+++ b/modules/masonry/src/components/Workspace/Workspace.test.tsx
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import type { PaletteConfig } from '@/@types/palette.types';
 
 import { usePaletteDragStore } from '@/stores/palette';
+import { getSnapEngine, resetSnapEngine } from '@/stores/snap';
 import { useWorkspaceStore } from '@/stores/workspace';
 
 import { Workspace } from './Workspace';
@@ -18,6 +19,7 @@ afterEach(() => {
   cleanup();
   usePaletteDragStore.setState({ dragged: null });
   useWorkspaceStore.setState({ towers: {} });
+  resetSnapEngine();
 });
 
 // -------------------------------------------------------------------------------------------------
@@ -115,5 +117,19 @@ describe('Workspace', () => {
     unmount();
 
     expect(usePaletteDragStore.getState().dragged).toBeNull();
+  });
+
+  it('resets the shared snap engine when the Workspace unmounts', () => {
+    const { unmount } = render(<Workspace config={{ palette: paletteConfig }} />);
+
+    // While mounted, a fixed canvas size returns the same cached engine instance.
+    const before = getSnapEngine(800, 600);
+    expect(getSnapEngine(800, 600)).toBe(before);
+
+    unmount();
+
+    // After unmount the singleton is cleared, so the next request builds a fresh engine
+    // rather than reusing one still sized to the previous canvas.
+    expect(getSnapEngine(800, 600)).not.toBe(before);
   });
 });

--- a/modules/masonry/src/components/Workspace/Workspace.tsx
+++ b/modules/masonry/src/components/Workspace/Workspace.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 import type { PaletteBrickConfig } from '@/@types/palette.types';
 import type { WorkspaceViewProps } from '@/@types/workspace.types';
@@ -6,6 +6,7 @@ import type { WorkspaceViewProps } from '@/@types/workspace.types';
 import { Palette } from '@/components/Palette/Palette';
 import { TowerView } from '@/components/Tower/Tower';
 import { useDragFromPalette } from '@/hooks/useDragFromPalette';
+import { resetSnapEngine } from '@/stores/snap';
 import { useWorkspaceStore } from '@/stores/workspace';
 
 import { DragGhost } from './DragGhost';
@@ -37,6 +38,12 @@ export function Workspace({ config }: WorkspaceViewProps) {
   }, [palette]);
 
   useDragFromPalette({ rootRef, canvasRef, ghostRef, bricksById });
+
+  // Clear the shared snap-engine singleton on unmount so a remount starts with a fresh engine
+  // rather than one still sized to (and holding targets from) the previous canvas.
+  useEffect(() => {
+    return () => resetSnapEngine();
+  }, []);
 
   return (
     <div ref={rootRef} className="relative flex h-full w-full">

--- a/modules/masonry/src/hooks/useBrickMove.test.tsx
+++ b/modules/masonry/src/hooks/useBrickMove.test.tsx
@@ -1,0 +1,230 @@
+// Unit test for the whole-tower drag + snap-join hook. interact.js pointer choreography isn't
+// reproducible under jsdom, so we mock the module to capture the drag listeners per bound element
+// and drive start/move/end by hand. jsdom also reports `offsetParent` as null (it computes no
+// layout), so the harness stubs it — the hook reads it to locate the canvas.
+
+import { act, cleanup, render } from '@testing-library/react';
+import { useRef } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Point } from '@/@types/common.types';
+import type { TowerStatementNode } from '@/@types/tower.types';
+import { StatementBrickModel } from '@/models/brick';
+
+import { useBrickLayoutStore } from '@/stores/brick';
+import { resetSnapEngine } from '@/stores/snap';
+import { useWorkspaceStore } from '@/stores/workspace';
+import { listNodes } from '@/utils/tower-traversal';
+
+import { useBrickMove } from './useBrickMove';
+
+interface DragListeners {
+  start: (event: unknown) => void;
+  move: (event: unknown) => void;
+  end: (event: unknown) => void;
+}
+
+// Captures the listeners each `useBrickMove` binds, keyed by the DOM element interact was called on.
+const { listenersByEl } = vi.hoisted(() => ({
+  listenersByEl: new Map<HTMLElement, DragListeners>(),
+}));
+
+vi.mock('interactjs', () => ({
+  default: (el: HTMLElement) => ({
+    draggable: (config: { listeners: DragListeners }) => {
+      listenersByEl.set(el, config.listeners);
+      return { unset: () => listenersByEl.delete(el) };
+    },
+  }),
+}));
+
+// -------------------------------------------------------------------------------------------------
+// Fixtures
+// -------------------------------------------------------------------------------------------------
+
+const colorsDefault = { background: '#3498db', foreground: '#ffffff', border: '#2980b9' };
+
+/** A standalone statement node with both sequence connectors open. */
+function makeStatement(id: string): TowerStatementNode {
+  return {
+    kind: 'statement',
+    model: new StatementBrickModel({
+      id,
+      colorsDefault,
+      tooltipText: '',
+      widget: { type: 'label', text: id },
+      params: [],
+      hasConnectionPrev: true,
+      hasConnectionNext: true,
+      hasNesting: false,
+    }),
+    prev: null,
+    next: null,
+    args: [],
+    nestedNext: undefined,
+  };
+}
+
+/** Links a run of statement nodes head→tail via prev/next; returns the head. */
+function chain(...nodes: TowerStatementNode[]): TowerStatementNode {
+  nodes.forEach((node, i) => {
+    node.prev = nodes[i - 1] ?? null;
+    node.next = nodes[i + 1] ?? null;
+  });
+  return nodes[0];
+}
+
+/** A brick that binds the drag hook and positions itself from the layout store, like TowerBrick. */
+function Brick({ id }: { id: string }) {
+  const ref = useRef<HTMLDivElement>(null);
+  useBrickMove(id, ref);
+  const coord = useBrickLayoutStore((state) => state.coords[id]);
+  return (
+    <div ref={ref} data-id={id} style={{ transform: `translate(${coord.x}px, ${coord.y}px)` }} />
+  );
+}
+
+/** Renders the given bricks inside a positioned canvas and stubs the jsdom layout the hook reads. */
+function renderCanvas(ids: string[]) {
+  const utils = render(
+    <div data-testid="canvas" style={{ position: 'relative' }}>
+      {ids.map((id) => (
+        <Brick key={id} id={id} />
+      ))}
+    </div>,
+  );
+
+  const canvas = utils.getByTestId('canvas');
+  Object.defineProperty(canvas, 'clientWidth', { configurable: true, value: 800 });
+  Object.defineProperty(canvas, 'clientHeight', { configurable: true, value: 600 });
+
+  const brickEl = (id: string) => {
+    const el = canvas.querySelector<HTMLElement>(`[data-id="${id}"]`)!;
+    // The hook uses `el.offsetParent` as the canvas; jsdom returns null, so point it at the canvas.
+    Object.defineProperty(el, 'offsetParent', { configurable: true, value: canvas });
+    return el;
+  };
+  ids.forEach(brickEl);
+
+  return { ...utils, canvas, brickEl };
+}
+
+/** Returns the captured drag listeners for the brick with the given id. */
+function listenersFor(brickEl: (id: string) => HTMLElement, id: string): DragListeners {
+  const listeners = listenersByEl.get(brickEl(id));
+  if (!listeners) throw new Error(`no drag listeners bound for brick ${id}`);
+  return listeners;
+}
+
+// -------------------------------------------------------------------------------------------------
+
+beforeEach(() => {
+  useWorkspaceStore.setState({ towers: {} });
+  useBrickLayoutStore.setState({ coords: {}, mounted: {}, positioned: {} });
+  resetSnapEngine();
+  listenersByEl.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('useBrickMove', () => {
+  it('translates every tower brick via the DOM on move, leaving the store untouched', () => {
+    const root = chain(makeStatement('S1'), makeStatement('S2'));
+    useWorkspaceStore.getState().createTower({ id: 'tw', root, position: { x: 0, y: 0 } });
+    useBrickLayoutStore.getState().setCoords({ S1: { x: 10, y: 20 }, S2: { x: 10, y: 120 } });
+    useBrickLayoutStore.getState().setMounted({ S1: true, S2: true });
+
+    const { brickEl } = renderCanvas(['S1', 'S2']);
+    const listeners = listenersFor(brickEl, 'S1');
+
+    act(() => listeners.start({}));
+    act(() => listeners.move({ dx: 30, dy: 40 }));
+    act(() => listeners.move({ dx: 5, dy: -10 })); // accumulated delta = (35, 30)
+
+    // Both bricks in the tower move together, written straight to the DOM.
+    expect(brickEl('S1').style.transform).toBe('translate(45px, 50px)');
+    expect(brickEl('S2').style.transform).toBe('translate(45px, 150px)');
+
+    // The layout store still holds the START coords — move wrote only to the DOM, so no re-render.
+    expect(useBrickLayoutStore.getState().coords).toEqual({
+      S1: { x: 10, y: 20 },
+      S2: { x: 10, y: 120 },
+    });
+  });
+
+  it('commits the dropped coords and reconciles the tower origin on a drop with no snap', () => {
+    const root = makeStatement('S1');
+    useWorkspaceStore.getState().createTower({ id: 'tw', root, position: { x: 100, y: 100 } });
+    useBrickLayoutStore.getState().setCoords({ S1: { x: 100, y: 100 } });
+    useBrickLayoutStore.getState().setMounted({ S1: true });
+
+    const { brickEl } = renderCanvas(['S1']);
+    const listeners = listenersFor(brickEl, 'S1');
+
+    act(() => listeners.start({}));
+    act(() => listeners.move({ dx: 30, dy: 40 }));
+    act(() => listeners.end({}));
+
+    // The only tower has no snap targets, so it stays free with coords + origin reconciled to the drop.
+    expect(useBrickLayoutStore.getState().coords.S1).toEqual({ x: 130, y: 140 });
+    expect(useWorkspaceStore.getState().towers.tw.position).toEqual({ x: 130, y: 140 });
+    expect(Object.keys(useWorkspaceStore.getState().towers)).toEqual(['tw']);
+  });
+
+  it('snap-joins onto a target connector in range and absorbs the dragged tower', () => {
+    const target = makeStatement('T');
+    const dragged = makeStatement('D');
+    useWorkspaceStore
+      .getState()
+      .createTower({ id: 'target', root: target, position: { x: 0, y: 0 } });
+    useWorkspaceStore
+      .getState()
+      .createTower({ id: 'dragged', root: dragged, position: { x: 0, y: 0 } });
+
+    const pTarget: Point = { x: 200, y: 200 };
+    const pDraggedStart: Point = { x: 400, y: 400 };
+    useBrickLayoutStore.getState().setCoords({ T: pTarget, D: pDraggedStart });
+    useBrickLayoutStore.getState().setMounted({ T: true, D: true });
+
+    // Move the dragged tower so its open `prev` groove lands exactly on the target's open `next` tab:
+    //   (pDraggedStart + delta) + draggedPrev === pTarget + targetNext
+    const targetNext = target.model.getConnectorCoords().next!;
+    const draggedPrev = dragged.model.getConnectorCoords().prev!;
+    const delta: Point = {
+      x: pTarget.x + targetNext.x - draggedPrev.x - pDraggedStart.x,
+      y: pTarget.y + targetNext.y - draggedPrev.y - pDraggedStart.y,
+    };
+
+    const { brickEl } = renderCanvas(['T', 'D']);
+    const listeners = listenersFor(brickEl, 'D');
+
+    act(() => listeners.start({}));
+    act(() => listeners.move({ dx: delta.x, dy: delta.y }));
+    act(() => listeners.end({}));
+
+    const { towers } = useWorkspaceStore.getState();
+    // The dragged tower is absorbed into the target, whose layout is bumped to re-run.
+    expect(towers.dragged).toBeUndefined();
+    expect(towers.target).toBeDefined();
+    expect(towers.target.layoutVersion).toBe(1);
+    // Both bricks are reachable from the survivor's root by forward pointers.
+    const ids = listNodes(towers.target.root).map((node) => node.model.id);
+    expect(ids).toEqual(expect.arrayContaining(['T', 'D']));
+  });
+
+  it('falls back to moving only the grabbed brick via the store when it has no owning tower', () => {
+    // The brick exists in the layout store but belongs to no workspace tower.
+    useBrickLayoutStore.getState().setCoords({ orphan: { x: 50, y: 60 } });
+    useBrickLayoutStore.getState().setMounted({ orphan: true });
+
+    const { brickEl } = renderCanvas(['orphan']);
+    const listeners = listenersFor(brickEl, 'orphan');
+
+    act(() => listeners.start({}));
+    act(() => listeners.move({ dx: 15, dy: 25 }));
+
+    expect(useBrickLayoutStore.getState().coords.orphan).toEqual({ x: 65, y: 85 });
+  });
+});

--- a/modules/masonry/src/hooks/useBrickMove.test.tsx
+++ b/modules/masonry/src/hooks/useBrickMove.test.tsx
@@ -8,8 +8,8 @@ import { useRef } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Point } from '@/@types/common.types';
-import type { TowerStatementNode } from '@/@types/tower.types';
-import { StatementBrickModel } from '@/models/brick';
+import type { TowerExpressionNode, TowerStatementNode, TowerValueNode } from '@/@types/tower.types';
+import { ExpressionBrickModel, StatementBrickModel, ValueBrickModel } from '@/models/brick';
 
 import { useBrickLayoutStore } from '@/stores/brick';
 import { resetSnapEngine } from '@/stores/snap';
@@ -72,6 +72,36 @@ function chain(...nodes: TowerStatementNode[]): TowerStatementNode {
     node.next = nodes[i + 1] ?? null;
   });
   return nodes[0];
+}
+
+/** A free-floating value node — its output tab is the arg-domain probe. */
+function makeValue(id: string): TowerValueNode {
+  return {
+    kind: 'value',
+    model: new ValueBrickModel({
+      id,
+      colorsDefault,
+      tooltipText: '',
+      widget: { type: 'numberbox', value: 0 },
+    }),
+    parent: null,
+  };
+}
+
+/** An expression node with one empty argument slot per `params` entry. */
+function makeExpression(id: string, params: [string, ...string[]]): TowerExpressionNode {
+  return {
+    kind: 'expression',
+    model: new ExpressionBrickModel({
+      id,
+      colorsDefault,
+      tooltipText: '',
+      widget: { type: 'label', text: id },
+      params,
+    }),
+    parent: null,
+    args: params.map(() => null),
+  };
 }
 
 /** A brick that binds the drag hook and positions itself from the layout store, like TowerBrick. */
@@ -212,6 +242,48 @@ describe('useBrickMove', () => {
     // Both bricks are reachable from the survivor's root by forward pointers.
     const ids = listNodes(towers.target.root).map((node) => node.model.id);
     expect(ids).toEqual(expect.arrayContaining(['T', 'D']));
+  });
+
+  it('arg-snaps a dragged value output onto an empty input slot and absorbs the tower', () => {
+    const target = makeExpression('E', ['A']); // one empty argument slot
+    const dragged = makeValue('V');
+    useWorkspaceStore
+      .getState()
+      .createTower({ id: 'target', root: target, position: { x: 0, y: 0 } });
+    useWorkspaceStore
+      .getState()
+      .createTower({ id: 'dragged', root: dragged, position: { x: 0, y: 0 } });
+
+    const pTarget: Point = { x: 200, y: 200 };
+    const pDraggedStart: Point = { x: 400, y: 400 };
+    useBrickLayoutStore.getState().setCoords({ E: pTarget, V: pDraggedStart });
+    useBrickLayoutStore.getState().setMounted({ E: true, V: true });
+
+    // Move the dragged value so its output tab lands exactly on the target's empty input slot:
+    //   (pDraggedStart + delta) + draggedOutput === pTarget + targetInput
+    const targetInput = target.model.getConnectorCoords().inputs[0].point;
+    const draggedOutput = dragged.model.getConnectorCoords().output!;
+    const delta: Point = {
+      x: pTarget.x + targetInput.x - draggedOutput.x - pDraggedStart.x,
+      y: pTarget.y + targetInput.y - draggedOutput.y - pDraggedStart.y,
+    };
+
+    const { brickEl } = renderCanvas(['E', 'V']);
+    const listeners = listenersFor(brickEl, 'V');
+
+    act(() => listeners.start({}));
+    act(() => listeners.move({ dx: delta.x, dy: delta.y }));
+    act(() => listeners.end({}));
+
+    const { towers } = useWorkspaceStore.getState();
+    // The dragged value tower is absorbed into the target, whose layout is bumped to re-run.
+    expect(towers.dragged).toBeUndefined();
+    expect(towers.target).toBeDefined();
+    expect(towers.target.layoutVersion).toBe(1);
+    // The value is now wired into the expression's slot 0, with its parent back-pointer set.
+    const survivor = towers.target.root as TowerExpressionNode;
+    expect(survivor.args[0]).toBe(dragged);
+    expect(dragged.parent).toBe(survivor);
   });
 
   it('falls back to moving only the grabbed brick via the store when it has no owning tower', () => {

--- a/modules/masonry/src/hooks/useBrickMove.ts
+++ b/modules/masonry/src/hooks/useBrickMove.ts
@@ -11,7 +11,13 @@ import { getSnapEngine, refreshSnapTargets } from '@/stores/snap';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { collectProbeConnectors, ORIGIN } from '@/utils/connectors';
 import type { SnapCandidate, SnapEngine } from '@/utils/snap';
-import { joinTowers, type DraggedKind, type JoinParams } from '@/utils/tower-join';
+import {
+    joinArg,
+    joinTowers,
+    type ArgJoinParams,
+    type DraggedKind,
+    type JoinParams,
+} from '@/utils/tower-join';
 import { listNodes } from '@/utils/tower-traversal';
 
 /** A single dragged node: its positioned DOM element and where it started. */
@@ -58,13 +64,14 @@ function findTower(brickId: string): OwningTower | null {
     return null;
 }
 
-/** A validated snap resolved to everything the drop needs: the join to perform and the merge. */
-interface JoinPlan {
-    /** Fully validated parameters for {@link joinTowers}. */
-    params: JoinParams;
-    /** Id of the stationary tower that absorbs the dragged one after the join. */
-    targetTowerId: string;
-}
+/**
+ * A validated snap resolved to everything the drop needs: the join to perform and the merge. A drop
+ * is either a STATEMENT join (sequence snapping, spliced by {@link joinTowers}) or an ARG join
+ * (argument snapping, plugged by {@link joinArg}); both then absorb the dragged tower.
+ */
+type JoinPlan =
+    | { type: 'statement'; params: JoinParams; targetTowerId: string }
+    | { type: 'arg'; params: ArgJoinParams; targetTowerId: string };
 
 /**
  * Resolves the dragged tower's drop into a join plan, or `null` when nothing valid is in range —
@@ -92,15 +99,6 @@ function resolveSnap(
     if (best === null) return null;
     const snap = best;
 
-    // Only a dragged `prev`/`next` is an approved mate (a `nestedNext` or an argument-domain
-    // `input`/`output` is not); narrow to a 'prev' | 'next' with no cast so `joinTowers` only ever
-    // receives a `DraggedKind`.
-    if (snap.draggedKind !== 'prev' && snap.draggedKind !== 'next') return null;
-    const draggedKind: DraggedKind = snap.draggedKind;
-
-    const draggedRoot = tower.root;
-    if (draggedRoot.kind !== 'statement') return null;
-
     const targetTower = towers[snap.targetTowerId];
     if (!targetTower) return null;
 
@@ -108,9 +106,37 @@ function resolveSnap(
     const targetNode = listNodes(targetTower.root).find(
         (node) => node.model.id === snap.targetNodeId,
     );
-    if (!targetNode || targetNode.kind !== 'statement') return null;
+    if (!targetNode) return null;
+
+    // Argument join: a dragged `output` plugs into a target's empty `input` slot. The empty-slot and
+    // kind guards are defensive — `findSnap` already filters occupied inputs and gates the mating.
+    if (snap.draggedKind === 'output') {
+        const draggedRoot = tower.root;
+        if (draggedRoot.kind !== 'value' && draggedRoot.kind !== 'expression') return null;
+        if (snap.targetKind !== 'input' || snap.target.slotIndex === undefined) return null;
+        if (snap.target.occupied) return null;
+        if (targetNode.kind !== 'expression' && targetNode.kind !== 'statement') return null;
+
+        return {
+            type: 'arg',
+            params: { draggedRoot, target: targetNode, slotIndex: snap.target.slotIndex },
+            targetTowerId: snap.targetTowerId,
+        };
+    }
+
+    // Statement join: only a dragged `prev`/`next` is an approved mate (a `nestedNext` or an
+    // argument-domain `input` is not); narrow to a 'prev' | 'next' with no cast so `joinTowers` only
+    // ever receives a `DraggedKind`.
+    if (snap.draggedKind !== 'prev' && snap.draggedKind !== 'next') return null;
+    const draggedKind: DraggedKind = snap.draggedKind;
+
+    const draggedRoot = tower.root;
+    if (draggedRoot.kind !== 'statement') return null;
+
+    if (targetNode.kind !== 'statement') return null;
 
     return {
+        type: 'statement',
         params: { draggedRoot, target: targetNode, draggedKind, targetKind: snap.targetKind },
         targetTowerId: snap.targetTowerId,
     };
@@ -258,8 +284,10 @@ export function useBrickMove(id: string, ref: RefObject<HTMLElement | null>) {
                     // A valid mate was found: mutate the node pointers in place, then drop the
                     // absorbed tower and bump the target's layoutVersion so useTowerLayout re-runs
                     // and positions everything flush from the target origin (snap-align falls out
-                    // of the re-layout).
-                    joinTowers(plan.params);
+                    // of the re-layout). A statement join splices the sequence; an arg join plugs
+                    // the output into the target slot.
+                    if (plan.type === 'statement') joinTowers(plan.params);
+                    else joinArg(plan.params);
                     useWorkspaceStore.getState().absorbTower(drag.towerId, plan.targetTowerId);
                 },
             },

--- a/modules/masonry/src/hooks/useBrickMove.ts
+++ b/modules/masonry/src/hooks/useBrickMove.ts
@@ -14,14 +14,22 @@ import type { SnapCandidate, SnapEngine } from '@/utils/snap';
 import { joinTowers, type DraggedKind, type JoinParams } from '@/utils/tower-join';
 import { listNodes } from '@/utils/tower-traversal';
 
+/** A single dragged node: its positioned DOM element and where it started. */
+interface DraggedNode {
+    /** The brick's positioned DOM element, translated straight to the DOM during `move`. */
+    el: HTMLElement;
+    /** The brick's top-left position at drag start. */
+    start: Point;
+}
+
 /** Per-drag bookkeeping, captured at `start` and consumed through `move` and `end`. */
 interface DragState {
     /** Id of the tower the grabbed brick belongs to. */
     towerId: string;
     /** The tower's origin at drag start, used to reconcile its final position on drop. */
     towerStart: Point;
-    /** Each dragged node's top-left position at drag start, keyed by brick id. */
-    nodeStarts: Record<string, Point>;
+    /** Every dragged node's DOM element and start position, keyed by brick id. */
+    nodes: Record<string, DraggedNode>;
     /** The shared snap engine — already sized to the canvas and targeted at every other tower. */
     engine: SnapEngine;
 }
@@ -109,8 +117,9 @@ function resolveSnap(
 
 /**
  * Attaches interact.js drag events to a brick's DOM element. A tower moves as a unit: grabbing any
- * brick drags the WHOLE tower, translating every node together via a batched layout-store update.
- * On release the tower's two open ends are probed against the shared snap engine for a valid mate.
+ * brick drags the WHOLE tower, translating every node by writing transforms straight to the DOM so
+ * no brick re-renders mid-drag; the layout store is reconciled once on release. On release the
+ * tower's two open ends are probed against the shared snap engine for a valid mate.
  *
  * @param id - The unique identifier of the grabbed brick.
  * @param ref - The DOM ref of the brick's wrapper element.
@@ -138,18 +147,6 @@ export function useBrickMove(id: string, ref: RefObject<HTMLElement | null>) {
                     }
                     const { tower, nodes } = owning;
 
-                    // Snapshot the start position of every node in the tower so `move` can
-                    // translate them all by the accumulated delta. Reuse the node list `findTower`
-                    // already computed rather than walking the graph again.
-                    const { coords } = useBrickLayoutStore.getState();
-                    const nodeStarts: Record<string, Point> = {};
-                    for (const node of nodes) {
-                        const current = coords[node.model.id];
-                        if (current) {
-                            nodeStarts[node.model.id] = { x: current.x, y: current.y };
-                        }
-                    }
-
                     // Size the shared snap space to the canvas (the brick's positioned ancestor)
                     // and rebuild its targets from every tower EXCEPT this one.
                     const canvas = el.offsetParent as HTMLElement | null;
@@ -158,10 +155,37 @@ export function useBrickMove(id: string, ref: RefObject<HTMLElement | null>) {
                     const engine = getSnapEngine(width, height);
                     refreshSnapTargets(tower.id);
 
+                    // Index every positioned brick element on the canvas by its `data-id`, in one
+                    // static-selector query (no per-node lookup, no id escaping).
+                    const elById = new Map<string, HTMLElement>();
+                    canvas?.querySelectorAll<HTMLElement>('[data-id]').forEach((brickEl) => {
+                        const dataId = brickEl.dataset.id;
+                        if (dataId) elById.set(dataId, brickEl);
+                    });
+
+                    // Snapshot each node's start position AND its DOM element, so `move` can
+                    // translate the whole tower by writing transforms straight to the DOM — no
+                    // per-frame store write means no brick re-renders mid-drag (mirroring the
+                    // palette-ghost drag). Reuse the node list `findTower` already computed rather
+                    // than walking the graph again.
+                    const { coords } = useBrickLayoutStore.getState();
+                    const dragNodes: Record<string, DraggedNode> = {};
+                    for (const node of nodes) {
+                        const nodeId = node.model.id;
+                        const current = coords[nodeId];
+                        const nodeEl = elById.get(nodeId) ?? null;
+                        if (current && nodeEl) {
+                            dragNodes[nodeId] = {
+                                el: nodeEl,
+                                start: { x: current.x, y: current.y },
+                            };
+                        }
+                    }
+
                     dragStateRef.current = {
                         towerId: tower.id,
                         towerStart: { x: tower.position.x, y: tower.position.y },
-                        nodeStarts,
+                        nodes: dragNodes,
                         engine,
                     };
                 },
@@ -170,10 +194,11 @@ export function useBrickMove(id: string, ref: RefObject<HTMLElement | null>) {
                     deltaRef.current.y += event.dy;
 
                     const drag = dragStateRef.current;
-                    const { coords, setCoords } = useBrickLayoutStore.getState();
 
                     if (!drag) {
-                        // Fallback: no resolved tower — translate only the grabbed brick.
+                        // Fallback: no resolved tower — translate only the grabbed brick via the
+                        // store. It's a single brick, so the re-render cost is negligible here.
+                        const { coords, setCoords } = useBrickLayoutStore.getState();
                         const current = coords[id];
                         if (current) {
                             setCoords(id, {
@@ -184,15 +209,13 @@ export function useBrickMove(id: string, ref: RefObject<HTMLElement | null>) {
                         return;
                     }
 
-                    // Translate every node of the tower by the accumulated delta in one batch.
-                    const batch: Record<string, Point> = {};
-                    for (const [nodeId, start] of Object.entries(drag.nodeStarts)) {
-                        batch[nodeId] = {
-                            x: start.x + deltaRef.current.x,
-                            y: start.y + deltaRef.current.y,
-                        };
+                    // Translate every node of the tower by writing its transform straight to the
+                    // DOM. This bypasses the layout store, so no brick re-renders mid-drag; the
+                    // store is reconciled once on `end`.
+                    const { x: dx, y: dy } = deltaRef.current;
+                    for (const { el: nodeEl, start } of Object.values(drag.nodes)) {
+                        nodeEl.style.transform = `translate(${start.x + dx}px, ${start.y + dy}px)`;
                     }
-                    setCoords(batch);
                 },
                 end(_event: DragEvent) {
                     const drag = dragStateRef.current;
@@ -203,15 +226,26 @@ export function useBrickMove(id: string, ref: RefObject<HTMLElement | null>) {
                     const tower = towers[drag.towerId];
                     if (!tower) return;
 
+                    const { x: dx, y: dy } = deltaRef.current;
+
+                    // The move handler wrote only to the DOM, so the store still holds each brick's
+                    // START position. Compute the dropped positions and commit them ONCE — the sole
+                    // re-render of the whole drag — so the post-drop render reads the dropped (not
+                    // the stale start) coords, and the snap probe below measures the real drop.
+                    const finalCoords: Record<string, Point> = {};
+                    for (const [nodeId, node] of Object.entries(drag.nodes)) {
+                        finalCoords[nodeId] = { x: node.start.x + dx, y: node.start.y + dy };
+                    }
+                    useBrickLayoutStore.getState().setCoords(finalCoords);
+
                     const finalPosition: Point = {
-                        x: drag.towerStart.x + deltaRef.current.x,
-                        y: drag.towerStart.y + deltaRef.current.y,
+                        x: drag.towerStart.x + dx,
+                        y: drag.towerStart.y + dy,
                     };
 
                     // Resolve the drop into a validated join plan (probe → findSnap → resolve target
                     // → validate) in one step, so there is a single fallback path.
-                    const { coords } = useBrickLayoutStore.getState();
-                    const plan = resolveSnap(tower, coords, drag.engine, towers);
+                    const plan = resolveSnap(tower, finalCoords, drag.engine, towers);
 
                     if (plan === null) {
                         // No valid mate: the tower stays free. Reconcile its origin with where it

--- a/modules/masonry/src/hooks/useBrickMove.ts
+++ b/modules/masonry/src/hooks/useBrickMove.ts
@@ -92,9 +92,10 @@ function resolveSnap(
     if (best === null) return null;
     const snap = best;
 
-    // A dragged `nestedNext` is never an approved mate; narrow to a 'prev' | 'next' with no cast so
-    // `joinTowers` only ever receives a `DraggedKind`.
-    if (snap.draggedKind === 'nestedNext') return null;
+    // Only a dragged `prev`/`next` is an approved mate (a `nestedNext` or an argument-domain
+    // `input`/`output` is not); narrow to a 'prev' | 'next' with no cast so `joinTowers` only ever
+    // receives a `DraggedKind`.
+    if (snap.draggedKind !== 'prev' && snap.draggedKind !== 'next') return null;
     const draggedKind: DraggedKind = snap.draggedKind;
 
     const draggedRoot = tower.root;

--- a/modules/masonry/src/models/brick.test.ts
+++ b/modules/masonry/src/models/brick.test.ts
@@ -106,7 +106,30 @@ describe('BrickModelBase.getConnectorCoords', () => {
 
         // Single filled slot: first-row groove y = H_NOTCH_OFFSET_Y (svg) * brickScale (=1 here).
         expect(coords.inputs).toHaveLength(1);
-        expect(coords.inputs[0]!.y).toBeCloseTo(
+        expect(coords.inputs[0]!.index).toBe(0);
+        expect(coords.inputs[0]!.filled).toBe(true);
+        expect(coords.inputs[0]!.point.y).toBeCloseTo(
+            H_NOTCH_OFFSET_Y * SCALE_LEVEL_CONFIG[2].brickScale,
+        );
+    });
+
+    it('emits an empty input slot for a param with no argument', () => {
+        const brick = new StatementBrickModel({
+            colorsDefault,
+            tooltipText: '',
+            widget: { type: 'label', text: 'St' },
+            scaleLevel: 2,
+            params: ['A'],
+            argDims: [null],
+        });
+
+        const coords = brick.getConnectorCoords();
+
+        // The slot is declared but holds no child: still emitted, tagged empty at index 0.
+        expect(coords.inputs).toHaveLength(1);
+        expect(coords.inputs[0]!.index).toBe(0);
+        expect(coords.inputs[0]!.filled).toBe(false);
+        expect(coords.inputs[0]!.point.y).toBeCloseTo(
             H_NOTCH_OFFSET_Y * SCALE_LEVEL_CONFIG[2].brickScale,
         );
     });

--- a/modules/masonry/src/models/brick.ts
+++ b/modules/masonry/src/models/brick.ts
@@ -111,7 +111,8 @@ abstract class BrickModelBase {
      * returns unscaled SVG-space coords; each Point is multiplied by `brickScale` here.
      *
      * Optional connectors (prev/next/nestedNext/output) are present only when their feature is
-     * enabled; `inputs` is always an array with one entry per filled argument slot, top-to-bottom.
+     * enabled; `inputs` is always an array with one entry per argument slot (filled and empty),
+     * top-to-bottom, tagged with the slot index and its filled state.
      */
     public getConnectorCoords(): BrickConnectorCoords {
         const raw = this.outlineGenerator.getConnectorCoords(this._buildOutlineInput());
@@ -119,7 +120,13 @@ abstract class BrickModelBase {
             x: this.svgToPx(point.x),
             y: this.svgToPx(point.y),
         });
-        const scaled: BrickConnectorCoords = { inputs: raw.inputs.map(scalePoint) };
+        const scaled: BrickConnectorCoords = {
+            inputs: raw.inputs.map((s) => ({
+                point: scalePoint(s.point),
+                index: s.index,
+                filled: s.filled,
+            })),
+        };
         if (raw.prev) scaled.prev = scalePoint(raw.prev);
         if (raw.next) scaled.next = scalePoint(raw.next);
         if (raw.nestedNext) scaled.nestedNext = scalePoint(raw.nestedNext);

--- a/modules/masonry/src/stores/snap.test.ts
+++ b/modules/masonry/src/stores/snap.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import type { Point } from '@/@types/common.types';
-import type { TowerStatementNode } from '@/@types/tower.types';
-import { StatementBrickModel } from '@/models/brick';
-import { collectConnectors, type OpenConnector } from '@/utils/connectors';
+import type { TowerStatementNode, TowerValueNode } from '@/@types/tower.types';
+import { StatementBrickModel, ValueBrickModel } from '@/models/brick';
+import { collectArgConnectors, collectConnectors, type OpenConnector } from '@/utils/connectors';
 
 import { useBrickLayoutStore } from './brick';
 import { getSnapEngine, refreshSnapTargets } from './snap';
@@ -125,6 +125,70 @@ describe('stores/snap', () => {
             expect(hit).not.toBeNull();
             expect(hit!.targetNodeId).toBe('head');
             expect(hit!.target.occupied).toBe(true);
+        });
+
+        it('adds argument connectors to the target set without disturbing statement snapping', () => {
+            // A statement carrying one value arg, so the tower exposes argument-domain connectors
+            // (the slot input + the value's output) alongside its statement-sequence connectors.
+            const child: TowerValueNode = {
+                kind: 'value',
+                model: new ValueBrickModel({
+                    id: 'C',
+                    colorsDefault,
+                    tooltipText: '',
+                    widget: { type: 'numberbox', value: 0 },
+                }),
+                parent: null,
+            };
+            const host: TowerStatementNode = {
+                kind: 'statement',
+                model: new StatementBrickModel({
+                    id: 'H',
+                    colorsDefault,
+                    tooltipText: '',
+                    widget: { type: 'label', text: 'H' },
+                    params: ['A'],
+                    hasConnectionPrev: true,
+                    hasConnectionNext: true,
+                    hasNesting: false,
+                }),
+                prev: null,
+                next: null,
+                args: [child],
+                nestedNext: undefined,
+            };
+            child.parent = host;
+
+            const pos: Point = { x: 300, y: 300 };
+            useWorkspaceStore.setState({
+                towers: { host: { id: 'host', root: host, position: pos } },
+            });
+            useBrickLayoutStore.getState().setCoords({ H: pos, C: { x: 420, y: 300 } });
+
+            const coords = useBrickLayoutStore.getState().coords;
+            const origin: Point = { x: 0, y: 0 };
+            const args = collectArgConnectors(host, origin, coords, 'host');
+            // Sanity: the tower really does expose argument connectors that must reach the space.
+            expect(args.some((c) => c.kind === 'output')).toBe(true);
+            expect(args.some((c) => c.kind === 'input')).toBe(true);
+
+            const hostNext = collectConnectors(host, origin, coords, 'host').find(
+                (c) => c.kind === 'next',
+            )!;
+            const valueOutput = args.find((c) => c.kind === 'output')!;
+
+            const engine = getSnapEngine(1000, 1000);
+            refreshSnapTargets('dragged');
+
+            // Statement snapping still resolves against the arg-bearing tower.
+            const hit = engine.findSnap(probe('prev', hostNext.point));
+            expect(hit).not.toBeNull();
+            expect(hit!.targetNodeId).toBe('H');
+            expect(hit!.targetKind).toBe('next');
+
+            // Argument connectors are in the space but never cross-match a statement probe
+            // (isValidMate rejects the argument domain until join lands), so no false snap.
+            expect(engine.findSnap(probe('prev', valueOutput.point))).toBeNull();
         });
     });
 });

--- a/modules/masonry/src/stores/snap.ts
+++ b/modules/masonry/src/stores/snap.ts
@@ -1,4 +1,9 @@
-import { collectConnectors, ORIGIN, type Connector } from '@/utils/connectors';
+import {
+    collectArgConnectors,
+    collectConnectors,
+    ORIGIN,
+    type Connector,
+} from '@/utils/connectors';
 import { SnapEngine } from '@/utils/snap';
 
 import { useBrickLayoutStore } from './brick';
@@ -36,8 +41,9 @@ export function getSnapEngine(width: number, height: number): SnapEngine {
 
 /**
  * Rebuilds the shared engine's target set from every tower EXCEPT the dragged one (so a tower can
- * never snap to itself), using live coords from the brick layout store. Targets include open and
- * occupied connectors so mid-chain insertion is reachable. No-ops if the engine does not exist yet.
+ * never snap to itself), using live coords from the brick layout store. Targets include both
+ * statement-sequence and argument-slot connectors, open and occupied, so mid-chain insertion and
+ * arg snapping are both reachable. No-ops if the engine does not exist yet.
  */
 export function refreshSnapTargets(draggedTowerId: string): void {
     if (engine === null) return;
@@ -48,7 +54,10 @@ export function refreshSnapTargets(draggedTowerId: string): void {
     const targets: Connector[] = [];
     for (const tower of Object.values(towers)) {
         if (tower.id === draggedTowerId) continue;
+        // Both snapping domains share one engine: statement-sequence connectors and argument-slot
+        // connectors go into the same target set. isValidMate keeps the domains from cross-matching.
         targets.push(...collectConnectors(tower.root, ORIGIN, coords, tower.id));
+        targets.push(...collectArgConnectors(tower.root, ORIGIN, coords, tower.id));
     }
 
     engine.setTargets(targets);

--- a/modules/masonry/src/utils/brick-shape.test.ts
+++ b/modules/masonry/src/utils/brick-shape.test.ts
@@ -744,9 +744,11 @@ describe('getConnectorCoords', () => {
         expect(full.nestedNext).toBeDefined();
         expect(full.output).toBeDefined();
         expect(full.inputs).toHaveLength(1);
+        expect(full.inputs[0]!.index).toBe(0);
+        expect(full.inputs[0]!.filled).toBe(true);
     });
 
-    it('inputs has one entry per filled arg slot, ordered top-to-bottom', () => {
+    it('inputs has one entry per slot (filled and empty), ordered top-to-bottom', () => {
         const paramArgDims = [
             { param: null, arg: { w: 50, h: 40 } },
             { param: { w: 50, h: 20 }, arg: null },
@@ -758,13 +760,33 @@ describe('getConnectorCoords', () => {
             paramArgDims,
         });
 
-        // Derive the expected count from the input itself — param-only rows contribute nothing.
-        const expected = paramArgDims.filter((r) => r.arg !== null).length;
-        expect(inputs).toHaveLength(expected);
-        expect(expected).toBe(2);
+        // One entry per slot now — the middle param-only row is emitted as an empty slot.
+        expect(inputs).toHaveLength(paramArgDims.length);
+        expect(inputs.map((s) => s.index)).toEqual([0, 1, 2]);
+        expect(inputs.map((s) => s.filled)).toEqual([true, false, true]);
 
         // Ordered top-to-bottom: y values strictly increasing.
-        expect(inputs[1]!.y).toBeGreaterThan(inputs[0]!.y);
+        expect(inputs[1]!.point.y).toBeGreaterThan(inputs[0]!.point.y);
+        expect(inputs[2]!.point.y).toBeGreaterThan(inputs[1]!.point.y);
+    });
+
+    it('an empty arg slot is emitted with filled:false at the right y', () => {
+        const paramArgDims = [
+            { param: null, arg: { w: 50, h: 40 } },
+            { param: { w: 50, h: 20 }, arg: null },
+        ];
+        const { inputs } = brickOutlineGenerator.getConnectorCoords({
+            strokeWidth,
+            widgetDims: { w: 100, h: 20 },
+            paramArgDims,
+        });
+
+        // The second slot holds no child: still emitted, tagged empty, seated one row down.
+        const empty = inputs[1]!;
+        expect(empty.filled).toBe(false);
+        expect(empty.index).toBe(1);
+        const firstRowH = Math.max(40, MINIMUMS.minArgHeight);
+        expect(empty.point.y).toBe(firstRowH + BrickOutlineGeneratorTest.H_NOTCH_OFFSET_Y);
     });
 
     it('inputs align with the rendered arg grooves from generate()', () => {
@@ -780,13 +802,15 @@ describe('getConnectorCoords', () => {
         const { bounds, width } = brickOutlineGenerator.generate(input);
         const argGrooves = bounds.args!.filter((a): a is NonNullable<typeof a> => a !== null);
 
-        inputs.forEach((p, k) => {
+        // Both slots are filled here, so every input entry lines up with a rendered groove.
+        const filled = inputs.filter((s) => s.filled);
+        filled.forEach((s, k) => {
             const a = argGrooves[k]!;
-            expect(p.y).toBe(a.y + BrickOutlineGeneratorTest.H_NOTCH_OFFSET_Y);
-            expect(p.x).toBe(a.x - strokeWidth / 2);
+            expect(s.point.y).toBe(a.y + BrickOutlineGeneratorTest.H_NOTCH_OFFSET_Y);
+            expect(s.point.x).toBe(a.x - strokeWidth / 2);
         });
         // Grooves sit at the right edge (x = width); the connector is inset by half the stroke.
-        expect(inputs[0]!.x).toBe(width - strokeWidth / 2);
+        expect(inputs[0]!.point.x).toBe(width - strokeWidth / 2);
     });
 
     it("next connector sits on the brick's bottom edge (height branch)", () => {
@@ -854,7 +878,7 @@ describe('getConnectorCoords', () => {
             widgetDims: { w: 100, h: 20 },
             paramArgDims: [{ param: null, arg: { w: 50, h: 40 } }],
         };
-        const parentInput = brickOutlineGenerator.getConnectorCoords(parent).inputs[0]!;
+        const parentInput = brickOutlineGenerator.getConnectorCoords(parent).inputs[0]!.point;
         const parentArg = brickOutlineGenerator.generate(parent).bounds.args![0]!;
 
         const output = brickOutlineGenerator.getConnectorCoords({
@@ -882,7 +906,7 @@ describe('getConnectorCoords', () => {
         };
         const { width, height } = brickOutlineGenerator.generate(input);
         const c = brickOutlineGenerator.getConnectorCoords(input);
-        const pts = [c.prev!, c.next!, c.nestedNext!, c.output!, ...c.inputs];
+        const pts = [c.prev!, c.next!, c.nestedNext!, c.output!, ...c.inputs.map((s) => s.point)];
 
         pts.forEach((p) => {
             expect(p.x).toBeGreaterThanOrEqual(0);

--- a/modules/masonry/src/utils/brick-shape.ts
+++ b/modules/masonry/src/utils/brick-shape.ts
@@ -33,6 +33,7 @@
 import type {
     BrickComputedDimensions,
     BrickConnectorCoords,
+    BrickInputConnector,
     BrickMinimums,
     BrickOutlineInput,
     BrickOutlineOutput,
@@ -883,7 +884,8 @@ export class BrickOutlineGenerator {
      * unscaled SVG space as `generate`'s path/bounds and relative to the brick's top-left origin.
      *
      * Optional connectors (prev/next/nestedNext/output) are present only when their feature is
-     * enabled; `inputs` is always an array with one entry per filled argument slot, top-to-bottom.
+     * enabled; `inputs` is always an array with one entry per argument slot (filled and empty),
+     * top-to-bottom, tagged with the slot index and its filled state.
      *
      * @param input - Same input shape as `generate` / `computeDimensions`.
      * @returns Connector centroids, keyed by connector kind.
@@ -900,19 +902,23 @@ export class BrickOutlineGenerator {
         const { width, headHeight, height } = this.dimensions;
         const { hasPrevNotch, hasNextNotch, hasNesting, hasOutputNotch } = this.input;
 
-        // Right-edge grooves: one centroid per filled arg slot, using the same slotTop
-        // accumulation as segHeadRight so the coords line up with the rendered grooves.
-        const inputs: Point[] = [];
+        // Right-edge grooves: one centroid per arg slot (filled and empty), using the same
+        // slotTop accumulation as segHeadRight so the coords line up with the rendered grooves.
+        const inputs: BrickInputConnector[] = [];
         let slotTop = 0;
+        let index = 0;
         for (const { arg } of this.input.paramArgDims) {
             const rowH = Math.max(arg?.h ?? 0, this.minimums.minArgHeight);
-            if (arg !== null) {
-                inputs.push({
+            inputs.push({
+                point: {
                     x: width - strokeWidth / 2,
                     y: slotTop + BrickOutlineGenerator.H_NOTCH_OFFSET_Y,
-                });
-            }
+                },
+                index,
+                filled: arg !== null,
+            });
             slotTop += rowH;
+            index += 1;
         }
 
         const coords: BrickConnectorCoords = { inputs };

--- a/modules/masonry/src/utils/connectors.test.ts
+++ b/modules/masonry/src/utils/connectors.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Point } from '@/@types/common.types';
-import type { TowerNode, TowerStatementNode } from '@/@types/tower.types';
-import { StatementBrickModel } from '@/models/brick';
+import type {
+    TowerExpressionNode,
+    TowerNode,
+    TowerStatementNode,
+    TowerValueNode,
+} from '@/@types/tower.types';
+import { ExpressionBrickModel, StatementBrickModel, ValueBrickModel } from '@/models/brick';
 import { statementTreeNoNesting, statementTreeWithNesting, valueTree } from '@/mocks/tower';
 
 import {
+    collectArgConnectors,
     collectConnectors,
     collectOpenConnectors,
     collectProbeConnectors,
@@ -337,5 +343,135 @@ describe('collectProbeConnectors', () => {
     it('returns nothing for a non-statement root', () => {
         const coords: Record<string, Point> = { [valueTree.model.id]: { x: 0, y: 0 } };
         expect(collectProbeConnectors(valueTree, { x: 0, y: 0 }, coords, 't')).toEqual([]);
+    });
+});
+
+/** A free-floating value node; pass a parent to mark it plugged in. */
+function makeValue(id: string, parent: TowerNode | null = null): TowerValueNode {
+    return {
+        kind: 'value',
+        model: new ValueBrickModel({
+            id,
+            colorsDefault,
+            tooltipText: '',
+            widget: { type: 'numberbox', value: 0 },
+        }),
+        parent,
+    };
+}
+
+/** An expression node with `params.length` argument slots, all empty unless `args` is supplied. */
+function makeExpression(
+    id: string,
+    params: [string | null, ...(string | null)[]],
+    args?: (TowerNode | null)[],
+): TowerExpressionNode {
+    return {
+        kind: 'expression',
+        model: new ExpressionBrickModel({
+            id,
+            colorsDefault,
+            tooltipText: '',
+            widget: { type: 'label', text: id },
+            params,
+        }),
+        parent: null,
+        args: args ?? params.map(() => null),
+    };
+}
+
+describe('collectArgConnectors', () => {
+    it('emits one input per slot with correct slotIndex, occupancy, and world point', () => {
+        // Two slots: slot 0 holds a child (occupied), slot 1 is empty (open).
+        const expr = makeExpression('E', ['A', 'B']);
+        const child = makeValue('E.child', expr);
+        expr.args = [child, null];
+
+        const origin: Point = { x: 5, y: 7 };
+        const topLeft: Point = { x: 40, y: 400 };
+        const coords: Record<string, Point> = { 'E': topLeft, 'E.child': { x: 60, y: 400 } };
+
+        const result = collectArgConnectors(expr, origin, coords, 'tower-1');
+        const inputs = result.filter((c) => c.kind === 'input');
+        const offsets = expr.model.getConnectorCoords();
+
+        expect(inputs).toHaveLength(2);
+        expect(offsets.inputs).toHaveLength(2);
+
+        const slot0 = inputs.find((c) => c.slotIndex === 0)!;
+        expect(slot0).toBeDefined();
+        expect(slot0.towerId).toBe('tower-1');
+        expect(slot0.nodeId).toBe('E');
+        expect(slot0.occupied).toBe(true); // node.args[0] is the child
+        expect(slot0.point).toEqual({
+            x: origin.x + topLeft.x + offsets.inputs[0].point.x,
+            y: origin.y + topLeft.y + offsets.inputs[0].point.y,
+        });
+
+        const slot1 = inputs.find((c) => c.slotIndex === 1)!;
+        expect(slot1.occupied).toBe(false); // node.args[1] is null
+        expect(slot1.point).toEqual({
+            x: origin.x + topLeft.x + offsets.inputs[1].point.x,
+            y: origin.y + topLeft.y + offsets.inputs[1].point.y,
+        });
+    });
+
+    it('derives input occupancy from the node graph, not the model filled flag', () => {
+        // args say occupied, but argDims (model filled flag) are left empty — the graph wins.
+        const expr = makeExpression('E', ['A']);
+        expr.args = [makeValue('E.child', expr)];
+        const result = collectArgConnectors(expr, { x: 0, y: 0 }, { E: { x: 0, y: 0 } }, 't');
+
+        const input = result.filter((c) => c.kind === 'input');
+        expect(input).toHaveLength(1);
+        expect(input[0].occupied).toBe(true);
+        expect(expr.model.getConnectorCoords().inputs[0].filled).toBe(false);
+    });
+
+    it('emits an output for a value brick, occupancy reflecting its parent', () => {
+        const free = makeValue('V');
+        const freeResult = collectArgConnectors(free, { x: 3, y: 9 }, { V: { x: 10, y: 20 } }, 't');
+        expect(freeResult).toHaveLength(1);
+
+        const output = freeResult[0];
+        const offsets = free.model.getConnectorCoords();
+        expect(output.kind).toBe('output');
+        expect(output.occupied).toBe(false); // parent === null
+        expect(output.slotIndex).toBeUndefined();
+        expect(output.point).toEqual({
+            x: 3 + 10 + offsets.output!.x,
+            y: 9 + 20 + offsets.output!.y,
+        });
+
+        // A value plugged into a parent reports its output as occupied.
+        const parent = makeExpression('P', ['A']);
+        const plugged = makeValue('P.child', parent);
+        parent.args = [plugged];
+        const pluggedResult = collectArgConnectors(
+            plugged,
+            { x: 0, y: 0 },
+            { 'P.child': { x: 0, y: 0 } },
+            't',
+        );
+        expect(pluggedResult).toHaveLength(1);
+        expect(pluggedResult[0].occupied).toBe(true);
+    });
+
+    it('emits BOTH the output and the input slots of an expression brick', () => {
+        const expr = makeExpression('E', ['A', 'B']);
+        const result = collectArgConnectors(expr, { x: 0, y: 0 }, { E: { x: 0, y: 0 } }, 't');
+
+        const inputs = result.filter((c) => c.kind === 'input');
+        const outputs = result.filter((c) => c.kind === 'output');
+        expect(inputs).toHaveLength(2);
+        expect(outputs).toHaveLength(1);
+        // Its own output is open (no parent), both slots open (no args).
+        expect(outputs[0].occupied).toBe(false);
+        expect(inputs.every((c) => !c.occupied)).toBe(true);
+    });
+
+    it('skips nodes whose top-left coordinate is missing from the coords map', () => {
+        const expr = makeExpression('E', ['A']);
+        expect(collectArgConnectors(expr, { x: 0, y: 0 }, {}, 't')).toEqual([]);
     });
 });

--- a/modules/masonry/src/utils/connectors.test.ts
+++ b/modules/masonry/src/utils/connectors.test.ts
@@ -340,9 +340,50 @@ describe('collectProbeConnectors', () => {
         expect(find(result, 'S', 'prev')).toHaveLength(0);
     });
 
-    it('returns nothing for a non-statement root', () => {
-        const coords: Record<string, Point> = { [valueTree.model.id]: { x: 0, y: 0 } };
-        expect(collectProbeConnectors(valueTree, { x: 0, y: 0 }, coords, 't')).toEqual([]);
+    it('probes a free value root by its single output tab, at the correct world point', () => {
+        const origin: Point = { x: 5, y: 7 };
+        const topLeft: Point = { x: 40, y: 400 };
+        const coords: Record<string, Point> = { [valueTree.model.id]: topLeft };
+
+        const result = collectProbeConnectors(valueTree, origin, coords, 't');
+        const output = valueTree.model.getConnectorCoords().output!;
+
+        expect(result).toHaveLength(1);
+        expect(result[0].kind).toBe('output');
+        expect(result[0].nodeId).toBe(valueTree.model.id);
+        expect(result[0].towerId).toBe('t');
+        expect(result[0].point).toEqual({
+            x: origin.x + topLeft.x + output.x,
+            y: origin.y + topLeft.y + output.y,
+        });
+    });
+
+    it('probes a free expression root by its output tab (not its input slots)', () => {
+        const expr = makeExpression('E', ['A', 'B']);
+        const result = collectProbeConnectors(expr, { x: 0, y: 0 }, { E: { x: 0, y: 0 } }, 't');
+
+        // A dragged tower snaps by its own output only; its input slots are targets, never probes.
+        expect(result).toHaveLength(1);
+        expect(result[0].kind).toBe('output');
+        expect(find(result, 'E', 'input')).toHaveLength(0);
+    });
+
+    it('probes nothing when the value/expression root is already plugged into a parent', () => {
+        const parent = makeExpression('P', ['A']);
+        const plugged = makeValue('P.child', parent);
+        parent.args = [plugged];
+
+        const result = collectProbeConnectors(
+            plugged,
+            { x: 0, y: 0 },
+            { 'P.child': { x: 0, y: 0 } },
+            't',
+        );
+        expect(result).toEqual([]);
+    });
+
+    it('probes nothing for a value/expression root missing from the coords map', () => {
+        expect(collectProbeConnectors(valueTree, { x: 0, y: 0 }, {}, 't')).toEqual([]);
     });
 });
 

--- a/modules/masonry/src/utils/connectors.ts
+++ b/modules/masonry/src/utils/connectors.ts
@@ -13,10 +13,13 @@ import { findTail, listNodes } from './tower-traversal';
 export const ORIGIN: Point = { x: 0, y: 0 };
 
 /**
- * Statement-domain connector kinds that participate in sequence snapping. Argument-domain
- * `inputs`/`output` connectors are handled separately and are out of scope here.
+ * Every connector kind a tower can expose, across both snapping domains:
+ *   - Statement domain (sequence snapping): `prev` | `next` | `nestedNext`.
+ *   - Argument domain (arg snapping): `output` — the left-edge tab on a value/expression brick that
+ *     plugs into a parent's argument slot; `input` — an argument slot on an expression/statement
+ *     brick that accepts such a tab.
  */
-export type ConnectorKind = 'prev' | 'next' | 'nestedNext';
+export type ConnectorKind = 'prev' | 'next' | 'nestedNext' | 'output' | 'input';
 
 /**
  * An OPEN connector on a tower, resolved into absolute canvas (world) space. "Open" means the
@@ -34,6 +37,11 @@ export interface OpenConnector {
     kind: ConnectorKind;
     /** Connector centroid in absolute canvas (world) pixels. */
     point: Point;
+    /**
+     * Present only on `input` connectors: the declaration-order index of the argument slot, used to
+     * resolve the connector back to `node.args[slotIndex]`.
+     */
+    slotIndex?: number;
 }
 
 /**
@@ -126,6 +134,77 @@ export function collectConnectors(
                 point: toWorld(origin, topLeft, offsets.nestedNext),
                 occupied: node.nestedNext !== null,
             });
+        }
+    }
+
+    return connectors;
+}
+
+/**
+ * Collects every argument-domain connector in a tower (open AND occupied), resolved to absolute
+ * canvas space, so the result is suitable as the SNAP TARGET set for arg snapping. Mirrors
+ * {@link collectConnectors} but over the argument domain:
+ *   - `input`  — one per argument slot on an expression/statement node (filled and empty), tagged
+ *                with its `slotIndex`; occupied when `node.args[slotIndex]` already holds a child.
+ *   - `output` — the left-edge tab on a value/expression node; occupied when the node already has a
+ *                `parent`.
+ *
+ * Both open and occupied connectors are emitted — #698 populates the space with ALL argument
+ * connectors; filtering to empty slots is the join step's concern.
+ *
+ * Pure: the caller supplies per-brick top-lefts via `coords`; this never reads a store. A
+ * connector's world point is the sum of three offsets:
+ *   `origin` + brick top-left px (`coords[nodeId]`) + connector px offset (`getConnectorCoords()`)
+ *
+ * Occupancy is derived from the NODE GRAPH (`node.args` / `node.parent`), the authoritative source,
+ * not from the model's `filled` flag. A node missing from `coords` is skipped (it cannot be placed
+ * in world space yet).
+ *
+ * @param root    - Root node of the tower tree.
+ * @param origin  - The tower's origin in canvas px; every connector is measured relative to it.
+ * @param coords  - Map of brick id → the brick's top-left position in canvas px.
+ * @param towerId - Id of the tower, passed through onto every emitted connector.
+ */
+export function collectArgConnectors(
+    root: TowerNode,
+    origin: Point,
+    coords: Record<string, Point>,
+    towerId: string,
+): Connector[] {
+    const connectors: Connector[] = [];
+
+    for (const node of listNodes(root)) {
+        const topLeft = coords[node.model.id];
+        if (!topLeft) continue;
+
+        const offsets = node.model.getConnectorCoords();
+
+        // input grooves — one per argument slot; occupied when the slot already holds a child.
+        if (node.kind === 'expression' || node.kind === 'statement') {
+            for (const input of offsets.inputs) {
+                connectors.push({
+                    towerId,
+                    nodeId: node.model.id,
+                    kind: 'input',
+                    point: toWorld(origin, topLeft, input.point),
+                    slotIndex: input.index,
+                    occupied: node.args[input.index] !== null,
+                });
+            }
+        }
+
+        // output tab — present only when the node can produce a value; occupied when already plugged
+        // into a parent.
+        if (node.kind === 'value' || node.kind === 'expression') {
+            if (offsets.output) {
+                connectors.push({
+                    towerId,
+                    nodeId: node.model.id,
+                    kind: 'output',
+                    point: toWorld(origin, topLeft, offsets.output),
+                    occupied: node.parent !== null,
+                });
+            }
         }
     }
 

--- a/modules/masonry/src/utils/connectors.ts
+++ b/modules/masonry/src/utils/connectors.ts
@@ -234,13 +234,15 @@ export function collectOpenConnectors(
 }
 
 /**
- * Collects the DRAGGED tower's two probe connectors — its ROOT `prev` groove and its outer TAIL
- * `next` tab — resolved to absolute canvas space, keeping only the open ones. These are the only
- * connectors a moving tower snaps WITH (per the approved spec): a tower snaps by an END of its
- * outer sequence, not by its middle or an inner cavity. A value/expression root yields nothing.
+ * Collects the DRAGGED tower's probe connectors — the connectors a moving tower snaps WITH (per the
+ * approved spec: a tower snaps by an outer END, never by its middle or an inner cavity), resolved to
+ * absolute canvas space and kept only when open:
+ *   - Statement root: its ROOT `prev` groove and its outer TAIL `next` tab (up to two).
+ *   - Value/expression root: its single `output` tab — the argument-domain mirror of the "outer
+ *     ends only" rule (such a tower has no sequence ends, only an output to plug into a parent).
  *
- * See {@link collectConnectors} for parameter meanings. Returns up to two connectors (each omitted
- * when absent or already occupied).
+ * See {@link collectConnectors} for parameter meanings. Returns the open probes (each omitted when
+ * absent or already occupied).
  */
 export function collectProbeConnectors(
     root: TowerNode,
@@ -248,6 +250,24 @@ export function collectProbeConnectors(
     coords: Record<string, Point>,
     towerId: string,
 ): OpenConnector[] {
+    // Argument-domain probe: a value/expression tower probes by its own `output` tab, emitted only
+    // when the root is free (no parent), placed, and the model exposes an output offset.
+    if (root.kind === 'value' || root.kind === 'expression') {
+        const rootTopLeft = coords[root.model.id];
+        const rootOutput = root.model.getConnectorCoords().output;
+        if (root.parent === null && rootTopLeft && rootOutput) {
+            return [
+                {
+                    towerId,
+                    nodeId: root.model.id,
+                    kind: 'output',
+                    point: toWorld(origin, rootTopLeft, rootOutput),
+                },
+            ];
+        }
+        return [];
+    }
+
     if (root.kind !== 'statement') return [];
 
     const tail = findTail(root);

--- a/modules/masonry/src/utils/connectors.ts
+++ b/modules/masonry/src/utils/connectors.ts
@@ -50,6 +50,18 @@ export interface Connector extends OpenConnector {
 }
 
 /**
+ * Resolves a connector to absolute canvas (world) space as the sum of three offsets:
+ *   `origin` + brick top-left px + connector px offset (from `getConnectorCoords()`).
+ * Shared by every connector collector so they all measure connectors the same way.
+ */
+function toWorld(origin: Point, topLeft: Point, offset: Point): Point {
+    return {
+        x: origin.x + topLeft.x + offset.x,
+        y: origin.y + topLeft.y + offset.y,
+    };
+}
+
+/**
  * Collects every statement-domain sequence connector in a tower (open AND occupied), resolved to
  * absolute canvas space, so the result is suitable as the SNAP TARGET set — snapping onto an
  * occupied connector is how mid-chain insertion is expressed.
@@ -82,18 +94,13 @@ export function collectConnectors(
 
         const offsets = node.model.getConnectorCoords();
 
-        const worldPoint = (offset: Point): Point => ({
-            x: origin.x + topLeft.x + offset.x,
-            y: origin.y + topLeft.y + offset.y,
-        });
-
         // prev groove — occupied when the node already has a predecessor.
         if (offsets.prev) {
             connectors.push({
                 towerId,
                 nodeId: node.model.id,
                 kind: 'prev',
-                point: worldPoint(offsets.prev),
+                point: toWorld(origin, topLeft, offsets.prev),
                 occupied: node.prev !== null,
             });
         }
@@ -104,7 +111,7 @@ export function collectConnectors(
                 towerId,
                 nodeId: node.model.id,
                 kind: 'next',
-                point: worldPoint(offsets.next),
+                point: toWorld(origin, topLeft, offsets.next),
                 occupied: node.next !== null,
             });
         }
@@ -116,7 +123,7 @@ export function collectConnectors(
                 towerId,
                 nodeId: node.model.id,
                 kind: 'nestedNext',
-                point: worldPoint(offsets.nestedNext),
+                point: toWorld(origin, topLeft, offsets.nestedNext),
                 occupied: node.nestedNext !== null,
             });
         }
@@ -175,10 +182,7 @@ export function collectProbeConnectors(
             towerId,
             nodeId: root.model.id,
             kind: 'prev',
-            point: {
-                x: origin.x + rootTopLeft.x + rootPrev.x,
-                y: origin.y + rootTopLeft.y + rootPrev.y,
-            },
+            point: toWorld(origin, rootTopLeft, rootPrev),
         });
     }
 
@@ -190,10 +194,7 @@ export function collectProbeConnectors(
             towerId,
             nodeId: tail.model.id,
             kind: 'next',
-            point: {
-                x: origin.x + tailTopLeft.x + tailNext.x,
-                y: origin.y + tailTopLeft.y + tailNext.y,
-            },
+            point: toWorld(origin, tailTopLeft, tailNext),
         });
     }
 

--- a/modules/masonry/src/utils/snap.test.ts
+++ b/modules/masonry/src/utils/snap.test.ts
@@ -10,9 +10,10 @@ import { SNAP_DISTANCE, SnapEngine } from './snap';
 const CANVAS: Point = { x: 1000, y: 1000 };
 
 /**
- * Builds a statement-domain connector at an absolute canvas point. Defaults to open (`occupied`
- * false); pass `occupied` to model a connector that already links a neighbour (an insertion
- * target). A `Connector` is also a valid dragged probe, since it extends `OpenConnector`.
+ * Builds a connector at an absolute canvas point. Defaults to open (`occupied` false); pass
+ * `occupied` to model a connector that already links a neighbour (an insertion target) or fills an
+ * argument slot. Pass `slotIndex` for an argument-domain `input`. A `Connector` is also a valid
+ * dragged probe, since it extends `OpenConnector`.
  */
 function connector(
     towerId: string,
@@ -20,8 +21,9 @@ function connector(
     kind: ConnectorKind,
     point: Point,
     occupied = false,
+    slotIndex?: number,
 ): Connector {
-    return { towerId, nodeId, kind, point, occupied };
+    return { towerId, nodeId, kind, point, occupied, slotIndex };
 }
 
 function makeEngine(targets: Connector[]): SnapEngine {
@@ -241,5 +243,73 @@ describe('SnapEngine.findSnap', () => {
         const engine = makeEngine([]);
         const dragged = connector('dragged', 'D', 'prev', { x: 300, y: 300 });
         expect(engine.findSnap(dragged)).toBeNull();
+    });
+
+    describe('argument domain (dragged output → target input slot)', () => {
+        it('snaps a dragged output onto an empty input slot, carrying its slotIndex', () => {
+            // slot 2 of the target expression, empty (occupied false).
+            const target = connector('target', 'E', 'input', { x: 300, y: 300 }, false, 2);
+            const engine = makeEngine([target]);
+
+            const dragged = connector('dragged', 'V', 'output', { x: 303, y: 300 }); // distance 3
+
+            const result = engine.findSnap(dragged);
+            expect(result).not.toBeNull();
+            expect(result!.targetKind).toBe('input');
+            expect(result!.draggedKind).toBe('output');
+            expect(result!.target.slotIndex).toBe(2);
+            expect(result!.distance).toBeCloseTo(3);
+        });
+
+        it('skips an OCCUPIED input slot (empty-only: no displace/replace)', () => {
+            // The only target slot already holds a child, so nothing valid is in range.
+            const target = connector('target', 'E', 'input', { x: 300, y: 300 }, true, 0);
+            const engine = makeEngine([target]);
+
+            const dragged = connector('dragged', 'V', 'output', { x: 300, y: 300 }); // coincident
+            expect(engine.findSnap(dragged)).toBeNull();
+        });
+
+        it('picks the nearest EMPTY slot when an occupied slot is closer', () => {
+            const occupiedNear = connector('target', 'E', 'input', { x: 300, y: 300 }, true, 0);
+            const emptyFar = connector('target', 'E', 'input', { x: 300, y: 308 }, false, 1);
+            const engine = makeEngine([occupiedNear, emptyFar]);
+
+            const dragged = connector('dragged', 'V', 'output', { x: 300, y: 301 });
+
+            const result = engine.findSnap(dragged);
+            expect(result).not.toBeNull();
+            expect(result!.target.slotIndex).toBe(1);
+        });
+
+        it('rejects a dragged output against a statement prev/next (domains never cross)', () => {
+            const asNext = connector('target', 'T', 'next', { x: 300, y: 300 });
+            const asPrev = connector('target', 'T', 'prev', { x: 400, y: 400 });
+            const engine = makeEngine([asNext, asPrev]);
+
+            expect(
+                engine.findSnap(connector('dragged', 'V', 'output', { x: 300, y: 300 })),
+            ).toBeNull();
+            expect(
+                engine.findSnap(connector('dragged', 'V', 'output', { x: 400, y: 400 })),
+            ).toBeNull();
+        });
+
+        it('resolves a dragged output through the shared engine onto an arg-push input target', () => {
+            // Mirrors refreshSnapTargets: statement-sequence AND argument-slot connectors share one
+            // target set. The output must resolve only against the arg-push input (isValidMate keeps
+            // the domains apart), proving the arg push is reachable through the engine.
+            const seqNext = connector('target', 'S', 'next', { x: 100, y: 100 });
+            const argInput = connector('target', 'E', 'input', { x: 300, y: 300 }, false, 0);
+            const engine = makeEngine([seqNext, argInput]);
+
+            const dragged = connector('dragged', 'V', 'output', { x: 302, y: 300 });
+
+            const result = engine.findSnap(dragged);
+            expect(result).not.toBeNull();
+            expect(result!.targetNodeId).toBe('E');
+            expect(result!.targetKind).toBe('input');
+            expect(result!.target.slotIndex).toBe(0);
+        });
     });
 });

--- a/modules/masonry/src/utils/snap.ts
+++ b/modules/masonry/src/utils/snap.ts
@@ -56,11 +56,15 @@ export interface SnapCandidate {
  *   - S2 nest in clamp: dragged `prev` ← target `nestedNext`
  *   - S3 attach above:  dragged `next` → target `prev`
  *
- * A dragged `nestedNext` is not an approved case and is rejected.
+ * The argument domain adds one more case: a dragged `output` tab plugs into a target `input` slot.
+ *
+ * A dragged `nestedNext` (statement domain) or `input` (argument domain) is not an approved case and
+ * is rejected.
  */
 function isValidMate(draggedKind: ConnectorKind, targetKind: ConnectorKind): boolean {
     if (draggedKind === 'prev') return targetKind === 'next' || targetKind === 'nestedNext';
     if (draggedKind === 'next') return targetKind === 'prev';
+    if (draggedKind === 'output') return targetKind === 'input';
     return false;
 }
 
@@ -141,6 +145,11 @@ export class SnapEngine {
 
             // Tab/groove compatibility per the approved spec.
             if (!isValidMate(dragged.kind, target.kind)) continue;
+
+            // Argument domain is EMPTY-ONLY: an occupied `input` slot is skipped so findSnap picks
+            // the nearest EMPTY slot (no displace/replace). Statement mates keep occupied targets,
+            // where snapping onto one expresses mid-chain insertion.
+            if (target.kind === 'input' && target.occupied) continue;
 
             const distance = Math.hypot(
                 target.point.x - dragged.point.x,

--- a/modules/masonry/src/utils/tower-join.test.ts
+++ b/modules/masonry/src/utils/tower-join.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import type { TowerStatementNode } from '@/@types/tower.types';
-import { StatementBrickModel } from '@/models/brick';
+import type {
+    TowerExpressionNode,
+    TowerNode,
+    TowerStatementNode,
+    TowerValueNode,
+} from '@/@types/tower.types';
+import { ExpressionBrickModel, StatementBrickModel, ValueBrickModel } from '@/models/brick';
 
-import { joinTowers } from './tower-join';
+import { joinArg, joinTowers } from './tower-join';
 
 const colorsDefault = { background: '#3498db', foreground: '#ffffff', border: '#2980b9' };
 
@@ -161,5 +166,76 @@ describe('joinTowers', () => {
         expect(() =>
             joinTowers({ draggedRoot, target, draggedKind: 'next', targetKind: 'next' }),
         ).toThrow(/unsupported mating/);
+    });
+});
+
+/** A free-floating value node. */
+function makeValue(id: string): TowerValueNode {
+    return {
+        kind: 'value',
+        model: new ValueBrickModel({
+            id,
+            colorsDefault,
+            tooltipText: '',
+            widget: { type: 'numberbox', value: 0 },
+        }),
+        parent: null,
+    };
+}
+
+/** An expression node with one arg slot per `params` entry, all empty unless `args` is supplied. */
+function makeExpression(
+    id: string,
+    params: [string | null, ...(string | null)[]],
+    args?: (TowerNode | null)[],
+): TowerExpressionNode {
+    return {
+        kind: 'expression',
+        model: new ExpressionBrickModel({
+            id,
+            colorsDefault,
+            tooltipText: '',
+            widget: { type: 'label', text: id },
+            params,
+        }),
+        parent: null,
+        args: args ?? params.map(() => null),
+    };
+}
+
+describe('joinArg', () => {
+    it('plugs a value into an empty expression slot, leaving other slots untouched', () => {
+        const target = makeExpression('E', ['A', 'B']); // two empty slots
+        const draggedRoot = makeValue('V');
+
+        joinArg({ draggedRoot, target, slotIndex: 1 });
+
+        // Slot 1 now references the value; its parent back-pointer targets the expression.
+        expect(target.args[1]).toBe(draggedRoot);
+        expect(draggedRoot.parent).toBe(target);
+        // The other slot is left alone.
+        expect(target.args[0]).toBeNull();
+    });
+
+    it('plugs an expression into another expression slot (output child)', () => {
+        const target = makeExpression('outer', ['A']);
+        const draggedRoot = makeExpression('inner', ['X']);
+
+        joinArg({ draggedRoot, target, slotIndex: 0 });
+
+        expect(target.args[0]).toBe(draggedRoot);
+        expect(draggedRoot.parent).toBe(target);
+    });
+
+    it('plugs a value into a statement target argument slot', () => {
+        const target = makeStatement('S');
+        target.args = [null, null];
+        const draggedRoot = makeValue('V');
+
+        joinArg({ draggedRoot, target, slotIndex: 0 });
+
+        expect(target.args[0]).toBe(draggedRoot);
+        expect(draggedRoot.parent).toBe(target);
+        expect(target.args[1]).toBeNull();
     });
 });

--- a/modules/masonry/src/utils/tower-join.ts
+++ b/modules/masonry/src/utils/tower-join.ts
@@ -1,4 +1,4 @@
-import type { TowerStatementNode } from '@/@types/tower.types';
+import type { TowerExpressionNode, TowerStatementNode, TowerValueNode } from '@/@types/tower.types';
 
 import type { ConnectorKind } from './connectors';
 import { findTail } from './tower-traversal';
@@ -100,4 +100,28 @@ export function joinTowers(params: JoinParams): void {
     throw new Error(
         `joinTowers: unsupported mating dragged '${draggedKind}' → target '${targetKind}'`,
     );
+}
+
+/** Parameters describing a single validated argument-join between two towers. */
+export interface ArgJoinParams {
+    /** Root of the dragged tower — the value/expression whose output plugs in. */
+    draggedRoot: TowerValueNode | TowerExpressionNode;
+    /** The target node whose empty argument slot receives the dragged root. */
+    target: TowerExpressionNode | TowerStatementNode;
+    /** Index of the target's argument slot being filled. */
+    slotIndex: number;
+}
+
+/**
+ * Plugs the dragged value/expression tower into a target's empty argument slot by mutating tower-node
+ * pointers in place. Pure with respect to stores and layout — it only edits the node graph (the slot
+ * reference and the dragged root's `parent` back-pointer); the caller merges the towers in the store
+ * and triggers a re-layout, which sets `argDims`. Arguments carry no notch flags.
+ *
+ * The caller guarantees the slot is empty (`SnapEngine.findSnap` filters out occupied slots) and that
+ * the two towers differ.
+ */
+export function joinArg({ draggedRoot, target, slotIndex }: ArgJoinParams): void {
+    target.args[slotIndex] = draggedRoot;
+    draggedRoot.parent = target;
 }


### PR DESCRIPTION
Connects Value/Expression Bricks into the Argument slots of other Bricks in the Workspace: drop a Value/Expression Brick so its Output tab overlaps another Tower's empty Argument slot and, on release, it snaps in and the two Towers merge into one.

Closes #698 - adds all Argument connector points (each Brick's Output tab and its per-slot Inputs, including empty slots) to the Workspace Collision space, with book-keeping to resolve every connector back to its Brick and Tower.

Closes #699 - on drop, queries the Argument Collision space for the nearest empty Argument slot within snap distance, validates the connection (empty slot on a Brick in a different Tower), plugs the Output into the slot, links it as that slot's argument, merges the Towers, and re-runs the layout (the parent Brick's shape recomputes automatically).

Also includes the enabling change to the Brick path utility so empty Argument slots expose an input connector coordinate (previously only filled slots did).

Stacked on #720 - base is `695-connect-bricks-in-workspace` until that merges.
