### PR TITLE
#679 | Improve Palette component styling

### DIFF
--- a/modules/masonry/src/components/Palette/BrickSlot.tsx
+++ b/modules/masonry/src/components/Palette/BrickSlot.tsx
@@ -44,7 +44,7 @@ export function BrickSlot({ brick }: BrickSlotProps) {
         <div
           title={brick.description}
           data-brick-id={brick.id}
-          className="palette-brick-slot flex min-h-11 cursor-grab touch-none items-center px-1 py-1 transition-colors select-none hover:brightness-110 active:cursor-grabbing"
+          className="palette-brick-slot flex min-h-11 cursor-grab touch-none items-center py-1 transition-colors select-none hover:brightness-110 active:cursor-grabbing"
         >
           <div className="pointer-events-none">
             <BrickView {...viewProps} />

--- a/modules/masonry/src/components/Palette/Palette.test.tsx
+++ b/modules/masonry/src/components/Palette/Palette.test.tsx
@@ -111,7 +111,7 @@ const configSingle: PaletteConfig = {
 
 /** Types into the search input. */
 const search = (value: string) =>
-  fireEvent.change(screen.getByPlaceholderText('Search bricks'), { target: { value } });
+  fireEvent.change(screen.getByPlaceholderText('Search'), { target: { value } });
 
 // -------------------------------------------------------------------------------------------------
 
@@ -137,10 +137,10 @@ describe('Palette', () => {
       expect(within(musicTab).getByTestId('stub-icon')).toBeTruthy();
     });
 
-    it('renders the search input with placeholder "Search bricks"', () => {
+    it('renders the search input with placeholder "Search"', () => {
       render(<Palette config={config} />);
 
-      const input = screen.getByPlaceholderText('Search bricks');
+      const input = screen.getByPlaceholderText('Search');
       expect(input.nodeName).toBe('INPUT');
       expect((input as HTMLInputElement).value).toBe('');
     });
@@ -151,6 +151,28 @@ describe('Palette', () => {
       // Music is active by default; disambiguated from same-named headings via role='button'.
       expect(screen.getByRole('button', { name: 'Rhythm' })).toBeTruthy();
       expect(screen.getByRole('button', { name: 'Meter' })).toBeTruthy();
+    });
+
+    it('applies the balanced Palette density and scoped button states', () => {
+      const { container } = render(<Palette config={config} />);
+
+      const root = container.firstElementChild;
+      const sidebar = screen.getByRole('navigation');
+      const categoryButton = screen.getByRole('button', { name: 'Rhythm' });
+      const inactiveTab = screen.getByRole('button', { name: 'Logic' });
+
+      expect(root?.classList.contains('font-sans')).toBe(true);
+      expect(root?.classList.contains('text-xs')).toBe(true);
+      expect(root?.classList.contains('border-border')).toBe(true);
+      expect(sidebar.classList.contains('w-18')).toBe(true);
+      expect(sidebar.classList.contains('px-1')).toBe(true);
+      expect(sidebar.classList.contains('border-border')).toBe(true);
+      expect(categoryButton.classList.contains('text-xs')).toBe(true);
+      expect(categoryButton.classList.contains('active:not-aria-[haspopup]:translate-y-0')).toBe(
+        true,
+      );
+      expect(inactiveTab.classList.contains('hover:bg-muted/60')).toBe(true);
+      expect(inactiveTab.classList.contains('active:not-aria-[haspopup]:translate-y-0')).toBe(true);
     });
 
     it('renders a section heading (h3) for each active-classification category', () => {
@@ -300,10 +322,10 @@ describe('Palette', () => {
 
       search('note');
       fireEvent.click(screen.getByRole('button', { name: 'Logic' }));
-      expect((screen.getByPlaceholderText('Search bricks') as HTMLInputElement).value).toBe('');
+      expect((screen.getByPlaceholderText('Search') as HTMLInputElement).value).toBe('');
 
       fireEvent.click(screen.getByRole('button', { name: 'Music' }));
-      expect((screen.getByPlaceholderText('Search bricks') as HTMLInputElement).value).toBe('');
+      expect((screen.getByPlaceholderText('Search') as HTMLInputElement).value).toBe('');
       // The query was reset, not just the view: all Music bricks are back.
       expect(screen.getByText('Note')).toBeTruthy();
       expect(screen.getByText('Rest')).toBeTruthy();
@@ -366,7 +388,7 @@ describe('Palette', () => {
     it('exposes the search field as a textbox reachable by its placeholder', () => {
       render(<Palette config={config} />);
 
-      const byPlaceholder = screen.getByPlaceholderText('Search bricks');
+      const byPlaceholder = screen.getByPlaceholderText('Search');
       expect(screen.getByRole('textbox')).toBe(byPlaceholder);
     });
 

--- a/modules/masonry/src/components/Palette/Palette.test.tsx
+++ b/modules/masonry/src/components/Palette/Palette.test.tsx
@@ -142,6 +142,7 @@ describe('Palette', () => {
 
       const input = screen.getByPlaceholderText('Search');
       expect(input.nodeName).toBe('INPUT');
+      expect(screen.getByRole('textbox', { name: 'Search bricks' })).toBe(input);
       expect((input as HTMLInputElement).value).toBe('');
     });
 

--- a/modules/masonry/src/components/Palette/Palette.test.tsx
+++ b/modules/masonry/src/components/Palette/Palette.test.tsx
@@ -211,6 +211,8 @@ describe('Palette', () => {
       // touch-action must be disabled so touch drags reach interact.js instead of scrolling.
       expect(note?.classList.contains('palette-brick-slot')).toBe(true);
       expect(note?.classList.contains('touch-none')).toBe(true);
+      expect(note?.classList.contains('px-1')).toBe(false);
+      expect(note?.classList.contains('py-1')).toBe(true);
       // Every slot carries the markup, not just the first.
       expect(container.querySelectorAll('.palette-brick-slot')).toHaveLength(3);
     });

--- a/modules/masonry/src/components/Palette/Palette.tsx
+++ b/modules/masonry/src/components/Palette/Palette.tsx
@@ -83,9 +83,9 @@ export function Palette({ config }: PaletteViewProps) {
   };
 
   return (
-    <div className="border-border bg-background text-foreground flex h-full min-h-0 w-full overflow-hidden rounded-lg border">
+    <div className="border-border bg-background text-foreground flex h-full w-full overflow-hidden border font-sans text-xs">
       {/* Category sidebar: one button per (filtered) category of the active classification. */}
-      <nav className="border-border bg-muted/40 flex w-20 shrink-0 flex-col gap-1 overflow-y-auto border-r px-2 pt-[104px] pb-2">
+      <nav className="border-border bg-card flex w-18 shrink-0 flex-col gap-1 overflow-y-auto border-r px-1 pt-[104px] pb-2">
         {visibleCategories.map(({ category, index }) => {
           const Icon = category.icon;
           return (
@@ -94,7 +94,7 @@ export function Palette({ config }: PaletteViewProps) {
               variant="ghost"
               size="default"
               onClick={() => scrollToCategory(index)}
-              className="h-auto flex-col gap-1 px-1 py-2 text-[0.7rem]"
+              className="hover:bg-muted/60 focus-visible:bg-muted/60 active:bg-muted h-auto flex-col gap-1 px-0.5 py-1.5 text-xs active:not-aria-[haspopup]:translate-y-0"
             >
               <Icon className="size-5" style={{ color: category.color }} />
               <span className="w-full truncate text-center">{category.name}</span>
@@ -117,7 +117,10 @@ export function Palette({ config }: PaletteViewProps) {
                 aria-pressed={isActive}
                 title={classification.name}
                 onClick={() => selectClassification(index)}
-                className="h-9 flex-1"
+                className={cn(
+                  'h-9 flex-1 active:not-aria-[haspopup]:translate-y-0',
+                  !isActive && 'hover:bg-muted/60 focus-visible:bg-muted/60',
+                )}
               >
                 <Icon className="size-5" />
                 <span className="sr-only">{classification.name}</span>
@@ -126,13 +129,14 @@ export function Palette({ config }: PaletteViewProps) {
           })}
         </div>
 
-        <div className="border-border flex h-14 shrink-0 items-center border-b px-3">
+        <div className="border-border border-b px-2 py-2">
           <div className="relative w-full">
             <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
             <Input
+              aria-label="Search bricks"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search bricks"
+              placeholder="Search"
               className="pl-8"
             />
           </div>
@@ -140,16 +144,11 @@ export function Palette({ config }: PaletteViewProps) {
 
         {/* Main list: every visible category of the active classification stacked in one container. */}
         {visibleCategories.length === 0 ? (
-          <div className="flex-1 overflow-y-auto p-4">
-            <p className="text-muted-foreground text-sm">No bricks match your search.</p>
+          <div className="text-muted-foreground px-2 py-3 text-center">
+            <p>No bricks match your search.</p>
           </div>
         ) : (
-          <div
-            className={cn(
-              'flex-1 overflow-y-auto p-4 transition-[padding-bottom] duration-500',
-              isDragging && 'pb-32',
-            )}
-          >
+          <div className={cn('min-h-0 flex-1 overflow-y-auto px-2 py-3', isDragging && 'pb-32')}>
             {visibleCategories.map(({ category, index }) => {
               const Icon = category.icon;
               return (
@@ -158,15 +157,15 @@ export function Palette({ config }: PaletteViewProps) {
                   ref={(el) => {
                     categoryRefs.current[index] = el;
                   }}
-                  className="mb-6 scroll-mt-4"
+                  className="mb-4 scroll-mt-3"
                 >
-                  <div className="mb-2 flex items-center gap-2">
-                    <Icon className="size-4" style={{ color: category.color }} />
-                    <h3 className="text-sm font-semibold" style={{ color: category.color }}>
+                  <div className="mb-1.5 flex items-center gap-1.5">
+                    <Icon className="h-4 w-4" style={{ color: category.color }} />
+                    <h3 className="text-xs font-semibold" style={{ color: category.color }}>
                       {category.name}
                     </h3>
                   </div>
-                  <div className="flex flex-col gap-2">
+                  <div className="flex flex-col gap-1">
                     {category.bricks.map((brick) => (
                       <BrickSlot key={brick.id} brick={brick} />
                     ))}


### PR DESCRIPTION
## Summary

- compact the Palette with a 72px category sidebar, tighter section/list spacing, and consistent small typography
- use theme border tokens and distinct hover, focus, and selected states
- cancel the shared button press translation only inside the Palette
- align Brick slots by removing horizontal wrapper padding while preserving animation and drag behavior
- shorten the visual search placeholder to `Search` while retaining the `Search bricks` accessible name

Closes #679.

## Impact

The Palette fits more blocks without losing label readability, no longer shifts its controls when pressed, and remains consistent across light and dark themes. Filtering, category scrolling, and drag-and-drop behavior are unchanged.

## Screenshots

| Before | After |
| --- | --- |
| ![Palette before](https://raw.githubusercontent.com/AlgoArtist06/musicblocks-v4/pr-assets-679-palette/docs/pr-assets/679/before.png) | ![Palette after](https://raw.githubusercontent.com/AlgoArtist06/musicblocks-v4/pr-assets-679-palette/docs/pr-assets/679/after.png) |

<details>
<summary>Dark theme and drag verification</summary>

![Palette dark theme](https://raw.githubusercontent.com/AlgoArtist06/musicblocks-v4/pr-assets-679-palette/docs/pr-assets/679/after-dark.png)

![Palette drag verification](https://raw.githubusercontent.com/AlgoArtist06/musicblocks-v4/pr-assets-679-palette/docs/pr-assets/679/after-drag.png)

</details>

## Verification

- `npm run test --workspace @sugarlabs/mb4-module-masonry`
- `npm run test`
- `npm run check`
- `npm run lint`
- `npm run build`
- live playground QA: light/dark borders, pointer press, hover/focus/selected states, filtering, category scrolling, and drag/drop

All commands exit successfully. Full-repository lint retains two pre-existing warnings in `app/src/index.ts`; this change adds no warnings.
