### PR TITLE
#700 | Add support for connecting Statement Bricks together

### DIFF
--- a/modules/masonry/src/@types/tower.types.ts
+++ b/modules/masonry/src/@types/tower.types.ts
@@ -112,4 +112,10 @@ export interface TowerViewProps {
     origin?: Point;
     /** If true, renders bricks directly without a wrapping container; defaults to false. */
     asChild?: boolean;
+    /**
+     * Monotonic re-layout trigger. `useTowerLayout` keys off this to re-run after the node graph is
+     * mutated in place (e.g. a snap-join) while `root`/`origin` stay referentially equal. Treated as 0
+     * when undefined.
+     */
+    layoutVersion?: number;
 }

--- a/modules/masonry/src/@types/workspace.types.ts
+++ b/modules/masonry/src/@types/workspace.types.ts
@@ -33,4 +33,10 @@ export interface TowerState {
     root: TowerNode;
     /** The absolute position of the tower in the workspace */
     position: Point;
+    /**
+     * Monotonic counter bumped to force a re-layout after the node graph is mutated in place (e.g. a
+     * snap-join) while `root`/`position` stay referentially equal. `useTowerLayout` keys off it.
+     * Treated as 0 when undefined.
+     */
+    layoutVersion?: number;
 }

--- a/modules/masonry/src/components/Tower/Tower.tsx
+++ b/modules/masonry/src/components/Tower/Tower.tsx
@@ -17,9 +17,9 @@ import { TowerBrickView } from './TowerBrick';
  * letting the parent supply the positioning context instead.
  */
 export const TowerView = memo(function (props: TowerViewProps) {
-  const { origin = { x: 0, y: 0 }, asChild = false } = props;
+  const { origin = { x: 0, y: 0 }, asChild = false, layoutVersion } = props;
 
-  const nodes = useTowerLayout(props.root, origin);
+  const nodes = useTowerLayout(props.root, origin, layoutVersion);
 
   const bricks = nodes.map((node) => (
     <TowerBrickView key={node.model.id} id={node.model.id} node={node} />

--- a/modules/masonry/src/components/Tower/TowerBrick.tsx
+++ b/modules/masonry/src/components/Tower/TowerBrick.tsx
@@ -1,8 +1,9 @@
-import { memo } from 'react';
+import { memo, useRef } from 'react';
 
 import type { TowerNode } from '@/@types/tower.types';
 
 import { BrickView } from '@/components/Brick/Brick';
+import { useBrickMove } from '@/hooks/useBrickMove';
 import { useBrickLayoutStore } from '@/stores/brick';
 
 export interface TowerBrickViewProps {
@@ -22,6 +23,9 @@ export interface TowerBrickViewProps {
  */
 export const TowerBrickView = memo(function (props: TowerBrickViewProps) {
   const { id, node } = props;
+  const ref = useRef<HTMLDivElement>(null);
+
+  useBrickMove(id, ref);
 
   const { x, y } = useBrickLayoutStore((state) => state.coords[id]);
   const isMounted = useBrickLayoutStore((state) => state.mounted[id]);
@@ -42,6 +46,7 @@ export const TowerBrickView = memo(function (props: TowerBrickViewProps) {
 
   return (
     <div
+      ref={ref}
       data-id={id}
       className="absolute"
       style={{

--- a/modules/masonry/src/components/Workspace/Workspace.test.tsx
+++ b/modules/masonry/src/components/Workspace/Workspace.test.tsx
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import type { PaletteConfig } from '@/@types/palette.types';
 
 import { usePaletteDragStore } from '@/stores/palette';
+import { getSnapEngine, resetSnapEngine } from '@/stores/snap';
 import { useWorkspaceStore } from '@/stores/workspace';
 
 import { Workspace } from './Workspace';
@@ -18,6 +19,7 @@ afterEach(() => {
   cleanup();
   usePaletteDragStore.setState({ dragged: null });
   useWorkspaceStore.setState({ towers: {} });
+  resetSnapEngine();
 });
 
 // -------------------------------------------------------------------------------------------------
@@ -115,5 +117,19 @@ describe('Workspace', () => {
     unmount();
 
     expect(usePaletteDragStore.getState().dragged).toBeNull();
+  });
+
+  it('resets the shared snap engine when the Workspace unmounts', () => {
+    const { unmount } = render(<Workspace config={{ palette: paletteConfig }} />);
+
+    // While mounted, a fixed canvas size returns the same cached engine instance.
+    const before = getSnapEngine(800, 600);
+    expect(getSnapEngine(800, 600)).toBe(before);
+
+    unmount();
+
+    // After unmount the singleton is cleared, so the next request builds a fresh engine
+    // rather than reusing one still sized to the previous canvas.
+    expect(getSnapEngine(800, 600)).not.toBe(before);
   });
 });

--- a/modules/masonry/src/components/Workspace/Workspace.tsx
+++ b/modules/masonry/src/components/Workspace/Workspace.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 import type { PaletteBrickConfig } from '@/@types/palette.types';
 import type { WorkspaceViewProps } from '@/@types/workspace.types';
@@ -6,6 +6,7 @@ import type { WorkspaceViewProps } from '@/@types/workspace.types';
 import { Palette } from '@/components/Palette/Palette';
 import { TowerView } from '@/components/Tower/Tower';
 import { useDragFromPalette } from '@/hooks/useDragFromPalette';
+import { resetSnapEngine } from '@/stores/snap';
 import { useWorkspaceStore } from '@/stores/workspace';
 
 import { DragGhost } from './DragGhost';
@@ -37,6 +38,12 @@ export function Workspace({ config }: WorkspaceViewProps) {
   }, [palette]);
 
   useDragFromPalette({ rootRef, canvasRef, ghostRef, bricksById });
+
+  // Clear the shared snap-engine singleton on unmount so a remount starts with a fresh engine
+  // rather than one still sized to (and holding targets from) the previous canvas.
+  useEffect(() => {
+    return () => resetSnapEngine();
+  }, []);
 
   return (
     <div ref={rootRef} className="relative flex h-full w-full">

--- a/modules/masonry/src/components/Workspace/Workspace.tsx
+++ b/modules/masonry/src/components/Workspace/Workspace.tsx
@@ -51,6 +51,7 @@ export function Workspace({ config }: WorkspaceViewProps) {
             id={tower.id}
             root={tower.root}
             origin={tower.position}
+            layoutVersion={tower.layoutVersion}
             asChild
           />
         ))}

--- a/modules/masonry/src/hooks/useBrickMove.test.tsx
+++ b/modules/masonry/src/hooks/useBrickMove.test.tsx
@@ -1,0 +1,230 @@
+// Unit test for the whole-tower drag + snap-join hook. interact.js pointer choreography isn't
+// reproducible under jsdom, so we mock the module to capture the drag listeners per bound element
+// and drive start/move/end by hand. jsdom also reports `offsetParent` as null (it computes no
+// layout), so the harness stubs it — the hook reads it to locate the canvas.
+
+import { act, cleanup, render } from '@testing-library/react';
+import { useRef } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Point } from '@/@types/common.types';
+import type { TowerStatementNode } from '@/@types/tower.types';
+import { StatementBrickModel } from '@/models/brick';
+
+import { useBrickLayoutStore } from '@/stores/brick';
+import { resetSnapEngine } from '@/stores/snap';
+import { useWorkspaceStore } from '@/stores/workspace';
+import { listNodes } from '@/utils/tower-traversal';
+
+import { useBrickMove } from './useBrickMove';
+
+interface DragListeners {
+  start: (event: unknown) => void;
+  move: (event: unknown) => void;
+  end: (event: unknown) => void;
+}
+
+// Captures the listeners each `useBrickMove` binds, keyed by the DOM element interact was called on.
+const { listenersByEl } = vi.hoisted(() => ({
+  listenersByEl: new Map<HTMLElement, DragListeners>(),
+}));
+
+vi.mock('interactjs', () => ({
+  default: (el: HTMLElement) => ({
+    draggable: (config: { listeners: DragListeners }) => {
+      listenersByEl.set(el, config.listeners);
+      return { unset: () => listenersByEl.delete(el) };
+    },
+  }),
+}));
+
+// -------------------------------------------------------------------------------------------------
+// Fixtures
+// -------------------------------------------------------------------------------------------------
+
+const colorsDefault = { background: '#3498db', foreground: '#ffffff', border: '#2980b9' };
+
+/** A standalone statement node with both sequence connectors open. */
+function makeStatement(id: string): TowerStatementNode {
+  return {
+    kind: 'statement',
+    model: new StatementBrickModel({
+      id,
+      colorsDefault,
+      tooltipText: '',
+      widget: { type: 'label', text: id },
+      params: [],
+      hasConnectionPrev: true,
+      hasConnectionNext: true,
+      hasNesting: false,
+    }),
+    prev: null,
+    next: null,
+    args: [],
+    nestedNext: undefined,
+  };
+}
+
+/** Links a run of statement nodes head→tail via prev/next; returns the head. */
+function chain(...nodes: TowerStatementNode[]): TowerStatementNode {
+  nodes.forEach((node, i) => {
+    node.prev = nodes[i - 1] ?? null;
+    node.next = nodes[i + 1] ?? null;
+  });
+  return nodes[0];
+}
+
+/** A brick that binds the drag hook and positions itself from the layout store, like TowerBrick. */
+function Brick({ id }: { id: string }) {
+  const ref = useRef<HTMLDivElement>(null);
+  useBrickMove(id, ref);
+  const coord = useBrickLayoutStore((state) => state.coords[id]);
+  return (
+    <div ref={ref} data-id={id} style={{ transform: `translate(${coord.x}px, ${coord.y}px)` }} />
+  );
+}
+
+/** Renders the given bricks inside a positioned canvas and stubs the jsdom layout the hook reads. */
+function renderCanvas(ids: string[]) {
+  const utils = render(
+    <div data-testid="canvas" style={{ position: 'relative' }}>
+      {ids.map((id) => (
+        <Brick key={id} id={id} />
+      ))}
+    </div>,
+  );
+
+  const canvas = utils.getByTestId('canvas');
+  Object.defineProperty(canvas, 'clientWidth', { configurable: true, value: 800 });
+  Object.defineProperty(canvas, 'clientHeight', { configurable: true, value: 600 });
+
+  const brickEl = (id: string) => {
+    const el = canvas.querySelector<HTMLElement>(`[data-id="${id}"]`)!;
+    // The hook uses `el.offsetParent` as the canvas; jsdom returns null, so point it at the canvas.
+    Object.defineProperty(el, 'offsetParent', { configurable: true, value: canvas });
+    return el;
+  };
+  ids.forEach(brickEl);
+
+  return { ...utils, canvas, brickEl };
+}
+
+/** Returns the captured drag listeners for the brick with the given id. */
+function listenersFor(brickEl: (id: string) => HTMLElement, id: string): DragListeners {
+  const listeners = listenersByEl.get(brickEl(id));
+  if (!listeners) throw new Error(`no drag listeners bound for brick ${id}`);
+  return listeners;
+}
+
+// -------------------------------------------------------------------------------------------------
+
+beforeEach(() => {
+  useWorkspaceStore.setState({ towers: {} });
+  useBrickLayoutStore.setState({ coords: {}, mounted: {}, positioned: {} });
+  resetSnapEngine();
+  listenersByEl.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('useBrickMove', () => {
+  it('translates every tower brick via the DOM on move, leaving the store untouched', () => {
+    const root = chain(makeStatement('S1'), makeStatement('S2'));
+    useWorkspaceStore.getState().createTower({ id: 'tw', root, position: { x: 0, y: 0 } });
+    useBrickLayoutStore.getState().setCoords({ S1: { x: 10, y: 20 }, S2: { x: 10, y: 120 } });
+    useBrickLayoutStore.getState().setMounted({ S1: true, S2: true });
+
+    const { brickEl } = renderCanvas(['S1', 'S2']);
+    const listeners = listenersFor(brickEl, 'S1');
+
+    act(() => listeners.start({}));
+    act(() => listeners.move({ dx: 30, dy: 40 }));
+    act(() => listeners.move({ dx: 5, dy: -10 })); // accumulated delta = (35, 30)
+
+    // Both bricks in the tower move together, written straight to the DOM.
+    expect(brickEl('S1').style.transform).toBe('translate(45px, 50px)');
+    expect(brickEl('S2').style.transform).toBe('translate(45px, 150px)');
+
+    // The layout store still holds the START coords — move wrote only to the DOM, so no re-render.
+    expect(useBrickLayoutStore.getState().coords).toEqual({
+      S1: { x: 10, y: 20 },
+      S2: { x: 10, y: 120 },
+    });
+  });
+
+  it('commits the dropped coords and reconciles the tower origin on a drop with no snap', () => {
+    const root = makeStatement('S1');
+    useWorkspaceStore.getState().createTower({ id: 'tw', root, position: { x: 100, y: 100 } });
+    useBrickLayoutStore.getState().setCoords({ S1: { x: 100, y: 100 } });
+    useBrickLayoutStore.getState().setMounted({ S1: true });
+
+    const { brickEl } = renderCanvas(['S1']);
+    const listeners = listenersFor(brickEl, 'S1');
+
+    act(() => listeners.start({}));
+    act(() => listeners.move({ dx: 30, dy: 40 }));
+    act(() => listeners.end({}));
+
+    // The only tower has no snap targets, so it stays free with coords + origin reconciled to the drop.
+    expect(useBrickLayoutStore.getState().coords.S1).toEqual({ x: 130, y: 140 });
+    expect(useWorkspaceStore.getState().towers.tw.position).toEqual({ x: 130, y: 140 });
+    expect(Object.keys(useWorkspaceStore.getState().towers)).toEqual(['tw']);
+  });
+
+  it('snap-joins onto a target connector in range and absorbs the dragged tower', () => {
+    const target = makeStatement('T');
+    const dragged = makeStatement('D');
+    useWorkspaceStore
+      .getState()
+      .createTower({ id: 'target', root: target, position: { x: 0, y: 0 } });
+    useWorkspaceStore
+      .getState()
+      .createTower({ id: 'dragged', root: dragged, position: { x: 0, y: 0 } });
+
+    const pTarget: Point = { x: 200, y: 200 };
+    const pDraggedStart: Point = { x: 400, y: 400 };
+    useBrickLayoutStore.getState().setCoords({ T: pTarget, D: pDraggedStart });
+    useBrickLayoutStore.getState().setMounted({ T: true, D: true });
+
+    // Move the dragged tower so its open `prev` groove lands exactly on the target's open `next` tab:
+    //   (pDraggedStart + delta) + draggedPrev === pTarget + targetNext
+    const targetNext = target.model.getConnectorCoords().next!;
+    const draggedPrev = dragged.model.getConnectorCoords().prev!;
+    const delta: Point = {
+      x: pTarget.x + targetNext.x - draggedPrev.x - pDraggedStart.x,
+      y: pTarget.y + targetNext.y - draggedPrev.y - pDraggedStart.y,
+    };
+
+    const { brickEl } = renderCanvas(['T', 'D']);
+    const listeners = listenersFor(brickEl, 'D');
+
+    act(() => listeners.start({}));
+    act(() => listeners.move({ dx: delta.x, dy: delta.y }));
+    act(() => listeners.end({}));
+
+    const { towers } = useWorkspaceStore.getState();
+    // The dragged tower is absorbed into the target, whose layout is bumped to re-run.
+    expect(towers.dragged).toBeUndefined();
+    expect(towers.target).toBeDefined();
+    expect(towers.target.layoutVersion).toBe(1);
+    // Both bricks are reachable from the survivor's root by forward pointers.
+    const ids = listNodes(towers.target.root).map((node) => node.model.id);
+    expect(ids).toEqual(expect.arrayContaining(['T', 'D']));
+  });
+
+  it('falls back to moving only the grabbed brick via the store when it has no owning tower', () => {
+    // The brick exists in the layout store but belongs to no workspace tower.
+    useBrickLayoutStore.getState().setCoords({ orphan: { x: 50, y: 60 } });
+    useBrickLayoutStore.getState().setMounted({ orphan: true });
+
+    const { brickEl } = renderCanvas(['orphan']);
+    const listeners = listenersFor(brickEl, 'orphan');
+
+    act(() => listeners.start({}));
+    act(() => listeners.move({ dx: 15, dy: 25 }));
+
+    expect(useBrickLayoutStore.getState().coords.orphan).toEqual({ x: 65, y: 85 });
+  });
+});

--- a/modules/masonry/src/hooks/useBrickMove.ts
+++ b/modules/masonry/src/hooks/useBrickMove.ts
@@ -14,14 +14,22 @@ import type { SnapCandidate, SnapEngine } from '@/utils/snap';
 import { joinTowers, type DraggedKind, type JoinParams } from '@/utils/tower-join';
 import { listNodes } from '@/utils/tower-traversal';
 
+/** A single dragged node: its positioned DOM element and where it started. */
+interface DraggedNode {
+    /** The brick's positioned DOM element, translated straight to the DOM during `move`. */
+    el: HTMLElement;
+    /** The brick's top-left position at drag start. */
+    start: Point;
+}
+
 /** Per-drag bookkeeping, captured at `start` and consumed through `move` and `end`. */
 interface DragState {
     /** Id of the tower the grabbed brick belongs to. */
     towerId: string;
     /** The tower's origin at drag start, used to reconcile its final position on drop. */
     towerStart: Point;
-    /** Each dragged node's top-left position at drag start, keyed by brick id. */
-    nodeStarts: Record<string, Point>;
+    /** Every dragged node's DOM element and start position, keyed by brick id. */
+    nodes: Record<string, DraggedNode>;
     /** The shared snap engine — already sized to the canvas and targeted at every other tower. */
     engine: SnapEngine;
 }
@@ -109,8 +117,9 @@ function resolveSnap(
 
 /**
  * Attaches interact.js drag events to a brick's DOM element. A tower moves as a unit: grabbing any
- * brick drags the WHOLE tower, translating every node together via a batched layout-store update.
- * On release the tower's two open ends are probed against the shared snap engine for a valid mate.
+ * brick drags the WHOLE tower, translating every node by writing transforms straight to the DOM so
+ * no brick re-renders mid-drag; the layout store is reconciled once on release. On release the
+ * tower's two open ends are probed against the shared snap engine for a valid mate.
  *
  * @param id - The unique identifier of the grabbed brick.
  * @param ref - The DOM ref of the brick's wrapper element.
@@ -138,18 +147,6 @@ export function useBrickMove(id: string, ref: RefObject<HTMLElement | null>) {
                     }
                     const { tower, nodes } = owning;
 
-                    // Snapshot the start position of every node in the tower so `move` can
-                    // translate them all by the accumulated delta. Reuse the node list `findTower`
-                    // already computed rather than walking the graph again.
-                    const { coords } = useBrickLayoutStore.getState();
-                    const nodeStarts: Record<string, Point> = {};
-                    for (const node of nodes) {
-                        const current = coords[node.model.id];
-                        if (current) {
-                            nodeStarts[node.model.id] = { x: current.x, y: current.y };
-                        }
-                    }
-
                     // Size the shared snap space to the canvas (the brick's positioned ancestor)
                     // and rebuild its targets from every tower EXCEPT this one.
                     const canvas = el.offsetParent as HTMLElement | null;
@@ -158,10 +155,37 @@ export function useBrickMove(id: string, ref: RefObject<HTMLElement | null>) {
                     const engine = getSnapEngine(width, height);
                     refreshSnapTargets(tower.id);
 
+                    // Index every positioned brick element on the canvas by its `data-id`, in one
+                    // static-selector query (no per-node lookup, no id escaping).
+                    const elById = new Map<string, HTMLElement>();
+                    canvas?.querySelectorAll<HTMLElement>('[data-id]').forEach((brickEl) => {
+                        const dataId = brickEl.dataset.id;
+                        if (dataId) elById.set(dataId, brickEl);
+                    });
+
+                    // Snapshot each node's start position AND its DOM element, so `move` can
+                    // translate the whole tower by writing transforms straight to the DOM — no
+                    // per-frame store write means no brick re-renders mid-drag (mirroring the
+                    // palette-ghost drag). Reuse the node list `findTower` already computed rather
+                    // than walking the graph again.
+                    const { coords } = useBrickLayoutStore.getState();
+                    const dragNodes: Record<string, DraggedNode> = {};
+                    for (const node of nodes) {
+                        const nodeId = node.model.id;
+                        const current = coords[nodeId];
+                        const nodeEl = elById.get(nodeId) ?? null;
+                        if (current && nodeEl) {
+                            dragNodes[nodeId] = {
+                                el: nodeEl,
+                                start: { x: current.x, y: current.y },
+                            };
+                        }
+                    }
+
                     dragStateRef.current = {
                         towerId: tower.id,
                         towerStart: { x: tower.position.x, y: tower.position.y },
-                        nodeStarts,
+                        nodes: dragNodes,
                         engine,
                     };
                 },
@@ -170,10 +194,11 @@ export function useBrickMove(id: string, ref: RefObject<HTMLElement | null>) {
                     deltaRef.current.y += event.dy;
 
                     const drag = dragStateRef.current;
-                    const { coords, setCoords } = useBrickLayoutStore.getState();
 
                     if (!drag) {
-                        // Fallback: no resolved tower — translate only the grabbed brick.
+                        // Fallback: no resolved tower — translate only the grabbed brick via the
+                        // store. It's a single brick, so the re-render cost is negligible here.
+                        const { coords, setCoords } = useBrickLayoutStore.getState();
                         const current = coords[id];
                         if (current) {
                             setCoords(id, {
@@ -184,15 +209,13 @@ export function useBrickMove(id: string, ref: RefObject<HTMLElement | null>) {
                         return;
                     }
 
-                    // Translate every node of the tower by the accumulated delta in one batch.
-                    const batch: Record<string, Point> = {};
-                    for (const [nodeId, start] of Object.entries(drag.nodeStarts)) {
-                        batch[nodeId] = {
-                            x: start.x + deltaRef.current.x,
-                            y: start.y + deltaRef.current.y,
-                        };
+                    // Translate every node of the tower by writing its transform straight to the
+                    // DOM. This bypasses the layout store, so no brick re-renders mid-drag; the
+                    // store is reconciled once on `end`.
+                    const { x: dx, y: dy } = deltaRef.current;
+                    for (const { el: nodeEl, start } of Object.values(drag.nodes)) {
+                        nodeEl.style.transform = `translate(${start.x + dx}px, ${start.y + dy}px)`;
                     }
-                    setCoords(batch);
                 },
                 end(_event: DragEvent) {
                     const drag = dragStateRef.current;
@@ -203,15 +226,26 @@ export function useBrickMove(id: string, ref: RefObject<HTMLElement | null>) {
                     const tower = towers[drag.towerId];
                     if (!tower) return;
 
+                    const { x: dx, y: dy } = deltaRef.current;
+
+                    // The move handler wrote only to the DOM, so the store still holds each brick's
+                    // START position. Compute the dropped positions and commit them ONCE — the sole
+                    // re-render of the whole drag — so the post-drop render reads the dropped (not
+                    // the stale start) coords, and the snap probe below measures the real drop.
+                    const finalCoords: Record<string, Point> = {};
+                    for (const [nodeId, node] of Object.entries(drag.nodes)) {
+                        finalCoords[nodeId] = { x: node.start.x + dx, y: node.start.y + dy };
+                    }
+                    useBrickLayoutStore.getState().setCoords(finalCoords);
+
                     const finalPosition: Point = {
-                        x: drag.towerStart.x + deltaRef.current.x,
-                        y: drag.towerStart.y + deltaRef.current.y,
+                        x: drag.towerStart.x + dx,
+                        y: drag.towerStart.y + dy,
                     };
 
                     // Resolve the drop into a validated join plan (probe → findSnap → resolve target
                     // → validate) in one step, so there is a single fallback path.
-                    const { coords } = useBrickLayoutStore.getState();
-                    const plan = resolveSnap(tower, coords, drag.engine, towers);
+                    const plan = resolveSnap(tower, finalCoords, drag.engine, towers);
 
                     if (plan === null) {
                         // No valid mate: the tower stays free. Reconcile its origin with where it

--- a/modules/masonry/src/hooks/useBrickMove.ts
+++ b/modules/masonry/src/hooks/useBrickMove.ts
@@ -1,0 +1,237 @@
+import type { DragEvent } from '@interactjs/types';
+import interact from 'interactjs';
+import { RefObject, useEffect, useRef } from 'react';
+
+import type { Point } from '@/@types/common.types';
+import type { TowerNode } from '@/@types/tower.types';
+import type { TowerState } from '@/@types/workspace.types';
+
+import { useBrickLayoutStore } from '@/stores/brick';
+import { getSnapEngine, refreshSnapTargets } from '@/stores/snap';
+import { useWorkspaceStore } from '@/stores/workspace';
+import { collectProbeConnectors, ORIGIN } from '@/utils/connectors';
+import type { SnapCandidate, SnapEngine } from '@/utils/snap';
+import { joinTowers, type DraggedKind, type JoinParams } from '@/utils/tower-join';
+import { listNodes } from '@/utils/tower-traversal';
+
+/** Per-drag bookkeeping, captured at `start` and consumed through `move` and `end`. */
+interface DragState {
+    /** Id of the tower the grabbed brick belongs to. */
+    towerId: string;
+    /** The tower's origin at drag start, used to reconcile its final position on drop. */
+    towerStart: Point;
+    /** Each dragged node's top-left position at drag start, keyed by brick id. */
+    nodeStarts: Record<string, Point>;
+    /** The shared snap engine — already sized to the canvas and targeted at every other tower. */
+    engine: SnapEngine;
+}
+
+/** A resolved owning tower together with the node list already computed while locating the brick. */
+interface OwningTower {
+    /** The tower whose node graph contains the searched-for brick. */
+    tower: TowerState;
+    /** Every node in that tower — reused so the caller need not walk the graph again. */
+    nodes: TowerNode[];
+}
+
+/**
+ * Finds the workspace tower whose node graph contains the brick with the given id, returning both
+ * the tower AND the node list computed while searching so the caller can reuse it (rather than
+ * walking the graph a second time).
+ */
+function findTower(brickId: string): OwningTower | null {
+    const { towers } = useWorkspaceStore.getState();
+    for (const tower of Object.values(towers)) {
+        const nodes = listNodes(tower.root);
+        for (const node of nodes) {
+            if (node.model.id === brickId) return { tower, nodes };
+        }
+    }
+    return null;
+}
+
+/** A validated snap resolved to everything the drop needs: the join to perform and the merge. */
+interface JoinPlan {
+    /** Fully validated parameters for {@link joinTowers}. */
+    params: JoinParams;
+    /** Id of the stationary tower that absorbs the dragged one after the join. */
+    targetTowerId: string;
+}
+
+/**
+ * Resolves the dragged tower's drop into a join plan, or `null` when nothing valid is in range —
+ * probe the two open ends, find the nearest snap, resolve the matched target node by id, validate
+ * the mating. The snap layer keeps its id-only boundary: `engine.findSnap` sees only connector
+ * probes, and this function reads the store to turn the matched ids back into nodes.
+ */
+function resolveSnap(
+    tower: TowerState,
+    coords: Record<string, Point>,
+    engine: SnapEngine,
+    towers: Record<string, TowerState>,
+): JoinPlan | null {
+    // Probe the two open ends against the targets built at drag start; keep the nearest valid mate.
+    const probes = collectProbeConnectors(tower.root, ORIGIN, coords, tower.id);
+
+    let best: SnapCandidate | null = null;
+    for (const probe of probes) {
+        const candidate = engine.findSnap(probe);
+        if (candidate && (best === null || candidate.distance < best.distance)) {
+            best = candidate;
+        }
+    }
+
+    if (best === null) return null;
+    const snap = best;
+
+    // A dragged `nestedNext` is never an approved mate; narrow to a 'prev' | 'next' with no cast so
+    // `joinTowers` only ever receives a `DraggedKind`.
+    if (snap.draggedKind === 'nestedNext') return null;
+    const draggedKind: DraggedKind = snap.draggedKind;
+
+    const draggedRoot = tower.root;
+    if (draggedRoot.kind !== 'statement') return null;
+
+    const targetTower = towers[snap.targetTowerId];
+    if (!targetTower) return null;
+
+    // Resolve the matched target node (by id) within the target tower's graph.
+    const targetNode = listNodes(targetTower.root).find(
+        (node) => node.model.id === snap.targetNodeId,
+    );
+    if (!targetNode || targetNode.kind !== 'statement') return null;
+
+    return {
+        params: { draggedRoot, target: targetNode, draggedKind, targetKind: snap.targetKind },
+        targetTowerId: snap.targetTowerId,
+    };
+}
+
+/**
+ * Attaches interact.js drag events to a brick's DOM element. A tower moves as a unit: grabbing any
+ * brick drags the WHOLE tower, translating every node together via a batched layout-store update.
+ * On release the tower's two open ends are probed against the shared snap engine for a valid mate.
+ *
+ * @param id - The unique identifier of the grabbed brick.
+ * @param ref - The DOM ref of the brick's wrapper element.
+ */
+export function useBrickMove(id: string, ref: RefObject<HTMLElement | null>) {
+    const dragStateRef = useRef<DragState | null>(null);
+    const deltaRef = useRef<Point>({ x: 0, y: 0 });
+    const isMounted = useBrickLayoutStore((state) => state.mounted[id]);
+
+    useEffect(() => {
+        const el = ref.current;
+        if (!el) return;
+
+        const interactable = interact(el).draggable({
+            listeners: {
+                start(_event: DragEvent) {
+                    deltaRef.current = { x: 0, y: 0 };
+
+                    const owning = findTower(id);
+                    if (!owning) {
+                        // No owning tower (shouldn't happen for a mounted brick) — fall back to
+                        // moving just the grabbed brick in `move`.
+                        dragStateRef.current = null;
+                        return;
+                    }
+                    const { tower, nodes } = owning;
+
+                    // Snapshot the start position of every node in the tower so `move` can
+                    // translate them all by the accumulated delta. Reuse the node list `findTower`
+                    // already computed rather than walking the graph again.
+                    const { coords } = useBrickLayoutStore.getState();
+                    const nodeStarts: Record<string, Point> = {};
+                    for (const node of nodes) {
+                        const current = coords[node.model.id];
+                        if (current) {
+                            nodeStarts[node.model.id] = { x: current.x, y: current.y };
+                        }
+                    }
+
+                    // Size the shared snap space to the canvas (the brick's positioned ancestor)
+                    // and rebuild its targets from every tower EXCEPT this one.
+                    const canvas = el.offsetParent as HTMLElement | null;
+                    const width = canvas?.clientWidth ?? el.clientWidth;
+                    const height = canvas?.clientHeight ?? el.clientHeight;
+                    const engine = getSnapEngine(width, height);
+                    refreshSnapTargets(tower.id);
+
+                    dragStateRef.current = {
+                        towerId: tower.id,
+                        towerStart: { x: tower.position.x, y: tower.position.y },
+                        nodeStarts,
+                        engine,
+                    };
+                },
+                move(event: DragEvent) {
+                    deltaRef.current.x += event.dx;
+                    deltaRef.current.y += event.dy;
+
+                    const drag = dragStateRef.current;
+                    const { coords, setCoords } = useBrickLayoutStore.getState();
+
+                    if (!drag) {
+                        // Fallback: no resolved tower — translate only the grabbed brick.
+                        const current = coords[id];
+                        if (current) {
+                            setCoords(id, {
+                                x: current.x + event.dx,
+                                y: current.y + event.dy,
+                            });
+                        }
+                        return;
+                    }
+
+                    // Translate every node of the tower by the accumulated delta in one batch.
+                    const batch: Record<string, Point> = {};
+                    for (const [nodeId, start] of Object.entries(drag.nodeStarts)) {
+                        batch[nodeId] = {
+                            x: start.x + deltaRef.current.x,
+                            y: start.y + deltaRef.current.y,
+                        };
+                    }
+                    setCoords(batch);
+                },
+                end(_event: DragEvent) {
+                    const drag = dragStateRef.current;
+                    dragStateRef.current = null;
+                    if (!drag) return;
+
+                    const { towers, updateTowerPosition } = useWorkspaceStore.getState();
+                    const tower = towers[drag.towerId];
+                    if (!tower) return;
+
+                    const finalPosition: Point = {
+                        x: drag.towerStart.x + deltaRef.current.x,
+                        y: drag.towerStart.y + deltaRef.current.y,
+                    };
+
+                    // Resolve the drop into a validated join plan (probe → findSnap → resolve target
+                    // → validate) in one step, so there is a single fallback path.
+                    const { coords } = useBrickLayoutStore.getState();
+                    const plan = resolveSnap(tower, coords, drag.engine, towers);
+
+                    if (plan === null) {
+                        // No valid mate: the tower stays free. Reconcile its origin with where it
+                        // was dropped so `position` and the per-brick coords stay consistent.
+                        updateTowerPosition(drag.towerId, finalPosition);
+                        return;
+                    }
+
+                    // A valid mate was found: mutate the node pointers in place, then drop the
+                    // absorbed tower and bump the target's layoutVersion so useTowerLayout re-runs
+                    // and positions everything flush from the target origin (snap-align falls out
+                    // of the re-layout).
+                    joinTowers(plan.params);
+                    useWorkspaceStore.getState().absorbTower(drag.towerId, plan.targetTowerId);
+                },
+            },
+        });
+
+        return () => {
+            interactable.unset();
+        };
+    }, [id, ref, isMounted]);
+}

--- a/modules/masonry/src/hooks/useTowerLayout.ts
+++ b/modules/masonry/src/hooks/useTowerLayout.ts
@@ -15,7 +15,7 @@ import { listNodes, traverseBottomUp, traverseTopDown } from '@/utils/tower-trav
  *
  * Returns the tower's node list.
  */
-export function useTowerLayout(root: TowerNode, origin: Point) {
+export function useTowerLayout(root: TowerNode, origin: Point, layoutVersion?: number) {
     const { setCoords, setMounted, setPositioned } = useBrickLayoutStore.getState();
 
     const isInitialized = useRef(false);
@@ -112,15 +112,15 @@ export function useTowerLayout(root: TowerNode, origin: Point) {
             }
         }
 
-        // We run the async process once per root/layoutVersion change
         processLayout();
 
         return () => {
             isCancelled = true;
         };
-        // Depend on the primitive co-ordinates, not the origin object — callers may pass a fresh
-        // object literal each render, which would re-trigger the layout on every render.
-    }, [root, origin.x, origin.y, setCoords, setMounted, setPositioned]);
+        // Depend on the primitive co-ordinates, not the `origin` object — a fresh literal each
+        // render would re-layout every render. `layoutVersion` is bumped after an in-place graph
+        // mutation (a snap-join) to force a re-layout when `root`/`origin` are referentially equal.
+    }, [root, origin.x, origin.y, layoutVersion, setCoords, setMounted, setPositioned]);
 
     return nodes;
 }

--- a/modules/masonry/src/models/brick.test.ts
+++ b/modules/masonry/src/models/brick.test.ts
@@ -1,0 +1,127 @@
+import { StatementBrickModel } from '@/models/brick';
+import { statementTreeNoNesting } from '@/mocks/tower';
+import { SCALE_LEVEL_CONFIG } from '@/utils/constants';
+
+// Generator geometry constants that the connector centroids are derived from (unscaled SVG units).
+// Mirrored from BrickOutlineGenerator so the expected canvas-px values can be computed independently.
+const V_NOTCH_OFFSET_X = 18;
+const H_NOTCH_OFFSET_Y = 16;
+const TAIL_INDENT_W = 8;
+const STROKE_WIDTH_PX = 2;
+
+const colorsDefault = { background: '#3498db', foreground: '#ffffff', border: '#2980b9' };
+
+function makeStatement(config: {
+    scaleLevel: 1 | 2 | 3;
+    hasConnectionPrev?: boolean;
+    hasConnectionNext?: boolean;
+    hasNesting?: boolean;
+}): StatementBrickModel {
+    return new StatementBrickModel({
+        colorsDefault,
+        tooltipText: '',
+        widget: { type: 'label', text: 'St' },
+        scaleLevel: config.scaleLevel,
+        hasConnectionPrev: config.hasConnectionPrev,
+        hasConnectionNext: config.hasConnectionNext,
+        hasNesting: config.hasNesting,
+    });
+}
+
+describe('BrickModelBase.getConnectorCoords', () => {
+    it('returns connector centroids in canvas px, scaled by brickScale', () => {
+        const scaleLevel = 3 as const;
+        const brickScale = SCALE_LEVEL_CONFIG[scaleLevel].brickScale; // 1.25
+        const brick = makeStatement({
+            scaleLevel,
+            hasConnectionPrev: true,
+            hasConnectionNext: true,
+            hasNesting: true,
+        });
+
+        const coords = brick.getConnectorCoords();
+
+        // prev sits on the top edge: x = V_NOTCH_OFFSET_X (svg) * brickScale.
+        // Its svg y is strokeWidth_svg/2 = (STROKE_WIDTH_PX / brickScale) / 2, so the scaled
+        // y collapses back to STROKE_WIDTH_PX / 2 regardless of scale level.
+        expect(coords.prev).toBeDefined();
+        expect(coords.prev!.x).toBeCloseTo(V_NOTCH_OFFSET_X * brickScale); // 22.5
+        expect(coords.prev!.y).toBeCloseTo(STROKE_WIDTH_PX / 2); // 1
+
+        // next shares prev's x (vertical stacking alignment) and lives on the bottom edge.
+        expect(coords.next).toBeDefined();
+        expect(coords.next!.x).toBeCloseTo(V_NOTCH_OFFSET_X * brickScale); // 22.5
+        expect(coords.next!.y).toBeGreaterThan(coords.prev!.y);
+
+        // nestedNext x = (TAIL_INDENT_W + strokeWidth_svg + V_NOTCH_OFFSET_X) * brickScale
+        //             = (TAIL_INDENT_W + V_NOTCH_OFFSET_X) * brickScale + STROKE_WIDTH_PX.
+        expect(coords.nestedNext).toBeDefined();
+        expect(coords.nestedNext!.x).toBeCloseTo(
+            (TAIL_INDENT_W + V_NOTCH_OFFSET_X) * brickScale + STROKE_WIDTH_PX,
+        ); // 34.5
+
+        expect(coords.inputs).toEqual([]);
+    });
+
+    it('scales every connector coordinate up with the brick scale level', () => {
+        const small = makeStatement({ scaleLevel: 2, hasConnectionPrev: true, hasNesting: true });
+        const large = makeStatement({ scaleLevel: 3, hasConnectionPrev: true, hasNesting: true });
+
+        const ratio = SCALE_LEVEL_CONFIG[3].brickScale / SCALE_LEVEL_CONFIG[2].brickScale; // 1.25
+
+        // prev.x is a pure V_NOTCH_OFFSET_X * brickScale term, so its ratio is exactly brickScale's.
+        expect(large.getConnectorCoords().prev!.x / small.getConnectorCoords().prev!.x).toBeCloseTo(
+            ratio,
+        );
+    });
+
+    it('omits connectors whose feature flags are off', () => {
+        const brick = makeStatement({
+            scaleLevel: 2,
+            hasConnectionPrev: false,
+            hasConnectionNext: false,
+            hasNesting: false,
+        });
+
+        const coords = brick.getConnectorCoords();
+
+        expect(coords.prev).toBeUndefined();
+        expect(coords.next).toBeUndefined();
+        expect(coords.nestedNext).toBeUndefined();
+        expect(coords.output).toBeUndefined();
+        expect(coords.inputs).toEqual([]);
+    });
+
+    it('places an input centroid per filled argument slot', () => {
+        const brick = new StatementBrickModel({
+            colorsDefault,
+            tooltipText: '',
+            widget: { type: 'label', text: 'St' },
+            scaleLevel: 2,
+            params: ['A'],
+            argDims: [{ w: 50, h: 40 }],
+        });
+
+        const coords = brick.getConnectorCoords();
+
+        // Single filled slot: first-row groove y = H_NOTCH_OFFSET_Y (svg) * brickScale (=1 here).
+        expect(coords.inputs).toHaveLength(1);
+        expect(coords.inputs[0]!.y).toBeCloseTo(
+            H_NOTCH_OFFSET_Y * SCALE_LEVEL_CONFIG[2].brickScale,
+        );
+    });
+
+    it('works on a mock tower statement brick (default scale level)', () => {
+        // St1 is the chain root: no prev connection, but chains into St2 via next, no args, no nesting.
+        const root = statementTreeNoNesting;
+        const coords = root.model.getConnectorCoords();
+
+        expect(root.model.hasConnectionPrev).toBe(false);
+        expect(coords.prev).toBeUndefined();
+        expect(coords.next).toBeDefined();
+        expect(coords.next!.x).toBeCloseTo(
+            V_NOTCH_OFFSET_X * SCALE_LEVEL_CONFIG[root.model.scaleLevel].brickScale,
+        );
+        expect(coords.inputs).toEqual([]);
+    });
+});

--- a/modules/masonry/src/models/brick.ts
+++ b/modules/masonry/src/models/brick.ts
@@ -1,4 +1,5 @@
 import type {
+    BrickConnectorCoords,
     BrickOutlineInput,
     BrickOutlineOutput,
     WidgetDisplay,
@@ -78,6 +79,11 @@ abstract class BrickModelBase {
         return px / SCALE_LEVEL_CONFIG[this._scaleLevel].brickScale;
     }
 
+    /** Converts an SVG-unit value to canvas pixels for the current scale level. */
+    protected svgToPx(svg: number): number {
+        return svg * SCALE_LEVEL_CONFIG[this._scaleLevel].brickScale;
+    }
+
     /** Assembles the generator input from this brick's current state. */
     protected abstract _buildOutlineInput(): BrickOutlineInput;
 
@@ -97,6 +103,28 @@ abstract class BrickModelBase {
         this._dims = { w: width, h: height };
         this._path = path;
         this._bounds = bounds;
+    }
+
+    /**
+     * Reports the centroid of every connector this brick has, in CANVAS PX (scaled for the
+     * current scale level) relative to the brick's top-left origin. The underlying generator
+     * returns unscaled SVG-space coords; each Point is multiplied by `brickScale` here.
+     *
+     * Optional connectors (prev/next/nestedNext/output) are present only when their feature is
+     * enabled; `inputs` is always an array with one entry per filled argument slot, top-to-bottom.
+     */
+    public getConnectorCoords(): BrickConnectorCoords {
+        const raw = this.outlineGenerator.getConnectorCoords(this._buildOutlineInput());
+        const scalePoint = (point: Point): Point => ({
+            x: this.svgToPx(point.x),
+            y: this.svgToPx(point.y),
+        });
+        const scaled: BrickConnectorCoords = { inputs: raw.inputs.map(scalePoint) };
+        if (raw.prev) scaled.prev = scalePoint(raw.prev);
+        if (raw.next) scaled.next = scalePoint(raw.next);
+        if (raw.nestedNext) scaled.nestedNext = scalePoint(raw.nestedNext);
+        if (raw.output) scaled.output = scalePoint(raw.output);
+        return scaled;
     }
 
     private static _buildOutlineGenerator(level: 1 | 2 | 3): BrickOutlineGenerator {

--- a/modules/masonry/src/stores/snap.test.ts
+++ b/modules/masonry/src/stores/snap.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import type { Point } from '@/@types/common.types';
+import type { TowerStatementNode } from '@/@types/tower.types';
+import { StatementBrickModel } from '@/models/brick';
+import { collectConnectors, type OpenConnector } from '@/utils/connectors';
+
+import { useBrickLayoutStore } from './brick';
+import { getSnapEngine, refreshSnapTargets } from './snap';
+import { useWorkspaceStore } from './workspace';
+
+const colorsDefault = { background: '#3498db', foreground: '#ffffff', border: '#2980b9' };
+
+/** A standalone statement node whose prev/next are both open (null). */
+function makeStatement(id: string): TowerStatementNode {
+    return {
+        kind: 'statement',
+        model: new StatementBrickModel({
+            id,
+            colorsDefault,
+            tooltipText: '',
+            widget: { type: 'label', text: id },
+            params: [],
+            hasConnectionPrev: true,
+            hasConnectionNext: true,
+            hasNesting: false,
+        }),
+        prev: null,
+        next: null,
+        args: [],
+        nestedNext: undefined,
+    };
+}
+
+/** A dragged probe connector; a different tower id than the target so the cycle guard passes. */
+function probe(kind: OpenConnector['kind'], point: Point): OpenConnector {
+    return { towerId: 'dragged', nodeId: 'P', kind, point };
+}
+
+describe('stores/snap', () => {
+    beforeEach(() => {
+        useWorkspaceStore.setState({ towers: {} });
+        useBrickLayoutStore.setState({ coords: {}, mounted: {}, positioned: {} });
+    });
+
+    describe('getSnapEngine', () => {
+        it('returns the same instance for the same canvas size and a new one on resize', () => {
+            const a = getSnapEngine(800, 600);
+            const b = getSnapEngine(800, 600);
+            expect(b).toBe(a);
+
+            const c = getSnapEngine(1000, 600);
+            expect(c).not.toBe(a);
+        });
+    });
+
+    describe('refreshSnapTargets', () => {
+        it('builds targets from every tower except the dragged one', () => {
+            const towerA = makeStatement('A');
+            const towerB = makeStatement('B');
+
+            const posA: Point = { x: 100, y: 100 };
+            const posB: Point = { x: 500, y: 100 };
+
+            useWorkspaceStore.setState({
+                towers: {
+                    'tower-a': { id: 'tower-a', root: towerA, position: posA },
+                    'tower-b': { id: 'tower-b', root: towerB, position: posB },
+                },
+            });
+            // Layout coords are ABSOLUTE (origin baked in), so seed each brick at its tower's
+            // position — the connector origin is (0, 0), matching `refreshSnapTargets`.
+            useBrickLayoutStore.getState().setCoords({ A: posA, B: posB });
+
+            const coords = useBrickLayoutStore.getState().coords;
+            const origin: Point = { x: 0, y: 0 };
+            const bNext = collectConnectors(towerB, origin, coords, 'tower-b').find(
+                (c) => c.kind === 'next',
+            )!;
+            const aNext = collectConnectors(towerA, origin, coords, 'tower-a').find(
+                (c) => c.kind === 'next',
+            )!;
+
+            const engine = getSnapEngine(1000, 1000);
+            // Drag tower A → its connectors must be excluded, tower B's must be present.
+            refreshSnapTargets('tower-a');
+
+            // A dragged prev groove over tower B's next tab snaps.
+            const hitB = engine.findSnap(probe('prev', bNext.point));
+            expect(hitB).not.toBeNull();
+            expect(hitB!.targetTowerId).toBe('tower-b');
+            expect(hitB!.targetNodeId).toBe('B');
+            expect(hitB!.targetKind).toBe('next');
+
+            // The same probe over tower A's (excluded) next tab finds nothing.
+            expect(engine.findSnap(probe('prev', aNext.point))).toBeNull();
+        });
+
+        it('includes occupied connectors as targets (insertion reachable)', () => {
+            const head = makeStatement('head');
+            const tail = makeStatement('tail');
+            head.next = tail;
+            tail.prev = head;
+
+            const pos: Point = { x: 200, y: 200 };
+            useWorkspaceStore.setState({
+                towers: { chain: { id: 'chain', root: head, position: pos } },
+            });
+            // Absolute coords: head at the tower origin, tail flush below it.
+            useBrickLayoutStore
+                .getState()
+                .setCoords({ head: { x: 200, y: 200 }, tail: { x: 200, y: 320 } });
+
+            const coords = useBrickLayoutStore.getState().coords;
+            const origin: Point = { x: 0, y: 0 };
+            const headNext = collectConnectors(head, origin, coords, 'chain').find(
+                (c) => c.nodeId === 'head' && c.kind === 'next',
+            )!;
+            expect(headNext.occupied).toBe(true);
+
+            const engine = getSnapEngine(1000, 1000);
+            refreshSnapTargets('other');
+
+            const hit = engine.findSnap(probe('prev', headNext.point));
+            expect(hit).not.toBeNull();
+            expect(hit!.targetNodeId).toBe('head');
+            expect(hit!.target.occupied).toBe(true);
+        });
+    });
+});

--- a/modules/masonry/src/stores/snap.ts
+++ b/modules/masonry/src/stores/snap.ts
@@ -1,0 +1,66 @@
+import { collectConnectors, ORIGIN, type Connector } from '@/utils/connectors';
+import { SnapEngine } from '@/utils/snap';
+
+import { useBrickLayoutStore } from './brick';
+import { useWorkspaceStore } from './workspace';
+
+/**
+ * Shared, non-React access point for a single {@link SnapEngine} instance.
+ *
+ * The interact.js drag handlers in `useBrickMove` run outside React, so — like the zustand stores
+ * reached via `.getState()` — the engine is held as a module singleton rather than a hook. There is
+ * one snap space for the whole workspace, (re)sized to the canvas on demand and rebuilt each drag.
+ *
+ * SINGLE-WORKSPACE ASSUMPTION: a second concurrent workspace would share and clobber this same
+ * engine. Tests (or a torn-down workspace) should call {@link resetSnapEngine} for a clean slate.
+ */
+
+let engine: SnapEngine | null = null;
+let engineWidth = 0;
+let engineHeight = 0;
+
+/**
+ * Returns the shared snap engine, sized to the given canvas dimensions. Created lazily and
+ * re-created whenever the canvas size changes so the collision space always spans the full canvas
+ * (boxes outside `[0, width] × [0, height]` are dropped). Re-creating clears the target set, which
+ * is fine — it is rebuilt each drag via {@link refreshSnapTargets}.
+ */
+export function getSnapEngine(width: number, height: number): SnapEngine {
+    if (engine === null || width !== engineWidth || height !== engineHeight) {
+        engine = new SnapEngine(width, height);
+        engineWidth = width;
+        engineHeight = height;
+    }
+    return engine;
+}
+
+/**
+ * Rebuilds the shared engine's target set from every tower EXCEPT the dragged one (so a tower can
+ * never snap to itself), using live coords from the brick layout store. Targets include open and
+ * occupied connectors so mid-chain insertion is reachable. No-ops if the engine does not exist yet.
+ */
+export function refreshSnapTargets(draggedTowerId: string): void {
+    if (engine === null) return;
+
+    const { towers } = useWorkspaceStore.getState();
+    const { coords } = useBrickLayoutStore.getState();
+
+    const targets: Connector[] = [];
+    for (const tower of Object.values(towers)) {
+        if (tower.id === draggedTowerId) continue;
+        targets.push(...collectConnectors(tower.root, ORIGIN, coords, tower.id));
+    }
+
+    engine.setTargets(targets);
+}
+
+/**
+ * Clears the shared snap engine singleton (engine, cached size, and target set). Intended for
+ * teardown and tests, where the module-level singleton would otherwise leak state across cases and
+ * remounts (see the single-workspace assumption above).
+ */
+export function resetSnapEngine(): void {
+    engine = null;
+    engineWidth = 0;
+    engineHeight = 0;
+}

--- a/modules/masonry/src/stores/workspace.test.ts
+++ b/modules/masonry/src/stores/workspace.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import type { Point } from '@/@types/common.types';
+import type { TowerStatementNode } from '@/@types/tower.types';
+import { StatementBrickModel } from '@/models/brick';
+import { joinTowers } from '@/utils/tower-join';
+import { listNodes } from '@/utils/tower-traversal';
+
+import { useWorkspaceStore } from './workspace';
+
+const colorsDefault = { background: '#3498db', foreground: '#ffffff', border: '#2980b9' };
+
+/** A standalone statement node whose prev/next are both open (null). */
+function makeStatement(id: string): TowerStatementNode {
+    return {
+        kind: 'statement',
+        model: new StatementBrickModel({
+            id,
+            colorsDefault,
+            tooltipText: '',
+            widget: { type: 'label', text: id },
+            params: [],
+            hasConnectionPrev: true,
+            hasConnectionNext: true,
+            hasNesting: false,
+        }),
+        prev: null,
+        next: null,
+        args: [],
+        nestedNext: undefined,
+    };
+}
+
+/** Links a run of statement nodes head→tail via prev/next; returns the head. */
+function chain(...nodes: TowerStatementNode[]): TowerStatementNode {
+    nodes.forEach((node, i) => {
+        node.prev = nodes[i - 1] ?? null;
+        node.next = nodes[i + 1] ?? null;
+    });
+    return nodes[0];
+}
+
+const position: Point = { x: 0, y: 0 };
+
+describe('stores/workspace absorbTower', () => {
+    beforeEach(() => {
+        useWorkspaceStore.setState({ towers: {} });
+    });
+
+    it('drops the dragged tower and bumps the target layoutVersion', () => {
+        const target = makeStatement('T');
+        const draggedRoot = makeStatement('D');
+
+        const { createTower, absorbTower } = useWorkspaceStore.getState();
+        createTower({ id: 'target', root: target, position });
+        createTower({ id: 'dragged', root: draggedRoot, position });
+
+        // S1 stack-below: dragged root prev ← target next. Head stays the target root.
+        joinTowers({ draggedRoot, target, draggedKind: 'prev', targetKind: 'next' });
+        absorbTower('dragged', 'target');
+
+        const { towers } = useWorkspaceStore.getState();
+        expect(towers.dragged).toBeUndefined();
+        expect(towers.target.layoutVersion).toBe(1);
+        expect(towers.target.root).toBe(target);
+        // Both nodes are reachable from the surviving root by forward pointers.
+        const ids = listNodes(towers.target.root).map((n) => n.model.id);
+        expect(ids).toEqual(expect.arrayContaining(['T', 'D']));
+    });
+
+    it('re-roots at the new head for S3 attach-above onto the target root (reachability)', () => {
+        // Target tower is a single free node R; dragged tower is D1 → D2.
+        const target = makeStatement('R');
+        const draggedRoot = chain(makeStatement('D1'), makeStatement('D2'));
+
+        const { createTower, absorbTower } = useWorkspaceStore.getState();
+        createTower({ id: 'target', root: target, position });
+        createTower({ id: 'dragged', root: draggedRoot, position });
+
+        // S3: dragged tail (D2) next → target (R) prev. This prepends D1 → D2 ABOVE R, so the
+        // dragged root D1 becomes the new head of the merged graph.
+        joinTowers({ draggedRoot, target, draggedKind: 'next', targetKind: 'prev' });
+        absorbTower('dragged', 'target');
+
+        const { towers } = useWorkspaceStore.getState();
+        expect(towers.dragged).toBeUndefined();
+
+        // The surviving tower must be re-rooted at the new head D1 (not the old, now non-head R),
+        // otherwise the prepended dragged bricks are unreachable and never repositioned/rendered.
+        expect(towers.target.root).toBe(draggedRoot);
+
+        const ids = listNodes(towers.target.root).map((n) => n.model.id);
+        expect(ids).toEqual(expect.arrayContaining(['D1', 'D2', 'R']));
+        expect(ids).toHaveLength(3);
+    });
+
+    it('keeps the stored root for S3 insert-above mid-chain (head unchanged)', () => {
+        // Target tower head P → R; dragged tower D snaps onto R's occupied prev (insert above R).
+        const oldPrev = makeStatement('P');
+        const target = chain(oldPrev, makeStatement('R')).next as TowerStatementNode;
+        const draggedRoot = makeStatement('D');
+
+        const { createTower, absorbTower } = useWorkspaceStore.getState();
+        createTower({ id: 'target', root: oldPrev, position });
+        createTower({ id: 'dragged', root: draggedRoot, position });
+
+        joinTowers({ draggedRoot, target, draggedKind: 'next', targetKind: 'prev' });
+        absorbTower('dragged', 'target');
+
+        const { towers } = useWorkspaceStore.getState();
+        // The tower head P was never displaced, so the root stays P.
+        expect(towers.target.root).toBe(oldPrev);
+        const ids = listNodes(towers.target.root).map((n) => n.model.id);
+        expect(ids).toEqual(expect.arrayContaining(['P', 'D', 'R']));
+        expect(ids).toHaveLength(3);
+    });
+});

--- a/modules/masonry/src/stores/workspace.ts
+++ b/modules/masonry/src/stores/workspace.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
 
 import type { Point } from '@/@types/common.types';
+import type { TowerNode } from '@/@types/tower.types';
 import type { TowerState } from '@/@types/workspace.types';
 
 export interface WorkspaceStore {
@@ -14,6 +15,28 @@ export interface WorkspaceStore {
     removeTower: (id: string) => void;
     /** Updates the position of an existing tower. */
     updateTowerPosition: (id: string, position: Point) => void;
+    /**
+     * Completes a snap-join whose node splicing was already done by `joinTowers`: drops the absorbed
+     * dragged tower and bumps the target's `layoutVersion` to force a re-layout of the merged graph.
+     *
+     * It also re-roots the survivor at the merged graph's topmost node. This matters for S3
+     * attach-above onto the target's root: `joinTowers` prepends the dragged chain via `prev`
+     * back-pointers, so the dragged root becomes the new head. Layout traversal only follows FORWARD
+     * pointers, so keeping the old root would leave the prepended bricks unreachable.
+     */
+    absorbTower: (draggedId: string, targetId: string) => void;
+}
+
+/**
+ * Walks `prev` back-pointers up to the head of the merged graph. Only statement nodes carry a
+ * `prev`, so the walk stops at a null `prev` (a free head) or a non-statement node.
+ */
+function findTopmost(node: TowerNode): TowerNode {
+    let head = node;
+    while (head.kind === 'statement' && head.prev !== null) {
+        head = head.prev;
+    }
+    return head;
 }
 
 /**
@@ -48,6 +71,22 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
                         [id]: { ...state.towers[id], position },
                     },
                 };
+            });
+        },
+
+        absorbTower: (draggedId, targetId) => {
+            set((state) => {
+                const target = state.towers[targetId];
+                if (!target) return state;
+
+                const towers = { ...state.towers };
+                delete towers[draggedId];
+                towers[targetId] = {
+                    ...target,
+                    root: findTopmost(target.root),
+                    layoutVersion: (target.layoutVersion ?? 0) + 1,
+                };
+                return { towers };
             });
         },
     })),

--- a/modules/masonry/src/utils/connectors.test.ts
+++ b/modules/masonry/src/utils/connectors.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Point } from '@/@types/common.types';
+import type { TowerNode, TowerStatementNode } from '@/@types/tower.types';
+import { StatementBrickModel } from '@/models/brick';
+import { statementTreeNoNesting, statementTreeWithNesting, valueTree } from '@/mocks/tower';
+
+import {
+    collectConnectors,
+    collectOpenConnectors,
+    collectProbeConnectors,
+    type Connector,
+    type OpenConnector,
+} from './connectors';
+import { listNodes } from './tower-traversal';
+
+const colorsDefault = { background: '#3498db', foreground: '#ffffff', border: '#2980b9' };
+
+function makeStatement(
+    id: string,
+    options: {
+        hasNesting?: boolean;
+        hasConnectionPrev?: boolean;
+        hasConnectionNext?: boolean;
+    } = {},
+): TowerStatementNode {
+    return {
+        kind: 'statement',
+        model: new StatementBrickModel({
+            id,
+            colorsDefault,
+            tooltipText: '',
+            widget: { type: 'label', text: id },
+            params: [],
+            hasConnectionPrev: options.hasConnectionPrev ?? true,
+            hasConnectionNext: options.hasConnectionNext ?? true,
+            hasNesting: options.hasNesting ?? false,
+        }),
+        prev: null,
+        next: null,
+        args: [],
+        nestedNext: options.hasNesting ? null : undefined,
+    };
+}
+
+/** Builds a coords map assigning every statement node in the tower a distinct top-left px point. */
+function buildCoords(root: TowerNode): Record<string, Point> {
+    const coords: Record<string, Point> = {};
+    let step = 0;
+    for (const node of listNodes(root)) {
+        if (node.kind === 'statement') {
+            coords[node.model.id] = { x: step * 10, y: step * 100 };
+            step += 1;
+        }
+    }
+    return coords;
+}
+
+/** Convenience: find a single connector by node id + kind. */
+function find(connectors: OpenConnector[], nodeId: string, kind: OpenConnector['kind']) {
+    return connectors.filter((c) => c.nodeId === nodeId && c.kind === kind);
+}
+
+/** Convenience: find one occupancy-tagged connector by node id + kind. */
+function findC(connectors: Connector[], nodeId: string, kind: Connector['kind']) {
+    return connectors.filter((c) => c.nodeId === nodeId && c.kind === kind);
+}
+
+describe('collectOpenConnectors', () => {
+    it('emits prev and next for a standalone statement, at the correct world points', () => {
+        const node = makeStatement('S');
+        const origin: Point = { x: 5, y: 7 };
+        const topLeft: Point = { x: 40, y: 400 };
+        const coords: Record<string, Point> = { S: topLeft };
+
+        const result = collectOpenConnectors(node, origin, coords, 'tower-1');
+        const offsets = node.model.getConnectorCoords();
+
+        expect(result).toHaveLength(2);
+
+        const prev = find(result, 'S', 'prev')[0];
+        expect(prev).toBeDefined();
+        expect(prev.towerId).toBe('tower-1');
+        expect(prev.point).toEqual({
+            x: origin.x + topLeft.x + offsets.prev!.x,
+            y: origin.y + topLeft.y + offsets.prev!.y,
+        });
+
+        const next = find(result, 'S', 'next')[0];
+        expect(next.point).toEqual({
+            x: origin.x + topLeft.x + offsets.next!.x,
+            y: origin.y + topLeft.y + offsets.next!.y,
+        });
+    });
+
+    it('does not emit prev/next when the model lacks those connectors', () => {
+        const node = makeStatement('S', { hasConnectionPrev: false, hasConnectionNext: false });
+        const result = collectOpenConnectors(node, { x: 0, y: 0 }, { S: { x: 0, y: 0 } }, 't');
+        expect(result).toHaveLength(0);
+    });
+
+    it('treats occupied prev/next pointers as closed (only chain ends are open)', () => {
+        const head = makeStatement('head');
+        const tail = makeStatement('tail');
+        head.next = tail;
+        tail.prev = head;
+
+        const coords: Record<string, Point> = { head: { x: 0, y: 0 }, tail: { x: 0, y: 50 } };
+        const result = collectOpenConnectors(head, { x: 0, y: 0 }, coords, 't');
+
+        // Open: head.prev and tail.next. Closed: head.next (=tail) and tail.prev (=head).
+        expect(result).toHaveLength(2);
+        expect(find(result, 'head', 'prev')).toHaveLength(1);
+        expect(find(result, 'tail', 'next')).toHaveLength(1);
+        expect(find(result, 'head', 'next')).toHaveLength(0);
+        expect(find(result, 'tail', 'prev')).toHaveLength(0);
+    });
+
+    it('emits nestedNext only for an empty cavity, not a filled one', () => {
+        const empty = makeStatement('empty', { hasNesting: true }); // nestedNext === null
+        const emptyResult = collectOpenConnectors(
+            empty,
+            { x: 0, y: 0 },
+            { empty: { x: 0, y: 0 } },
+            't',
+        );
+        expect(find(emptyResult, 'empty', 'nestedNext')).toHaveLength(1);
+
+        const filled = makeStatement('filled', { hasNesting: true });
+        const child = makeStatement('child');
+        filled.nestedNext = child;
+        child.prev = filled;
+        const filledCoords: Record<string, Point> = {
+            filled: { x: 0, y: 0 },
+            child: { x: 10, y: 30 },
+        };
+        const filledResult = collectOpenConnectors(filled, { x: 0, y: 0 }, filledCoords, 't');
+        expect(find(filledResult, 'filled', 'nestedNext')).toHaveLength(0);
+    });
+
+    it('does not emit nestedNext for a statement without a cavity', () => {
+        const node = makeStatement('S'); // nestedNext === undefined
+        const result = collectOpenConnectors(node, { x: 0, y: 0 }, { S: { x: 0, y: 0 } }, 't');
+        expect(find(result, 'S', 'nestedNext')).toHaveLength(0);
+    });
+
+    it('skips nodes whose top-left coordinate is missing from the coords map', () => {
+        const node = makeStatement('S');
+        const result = collectOpenConnectors(node, { x: 0, y: 0 }, {}, 't');
+        expect(result).toHaveLength(0);
+    });
+
+    describe('collectConnectors (open + occupied targets)', () => {
+        it('tags a standalone statement prev/next as unoccupied', () => {
+            const node = makeStatement('S');
+            const result = collectConnectors(node, { x: 0, y: 0 }, { S: { x: 0, y: 0 } }, 't');
+
+            expect(result).toHaveLength(2);
+            expect(findC(result, 'S', 'prev')[0].occupied).toBe(false);
+            expect(findC(result, 'S', 'next')[0].occupied).toBe(false);
+        });
+
+        it('emits occupied AND open connectors along a two-brick chain', () => {
+            const head = makeStatement('head');
+            const tail = makeStatement('tail');
+            head.next = tail;
+            tail.prev = head;
+
+            const coords: Record<string, Point> = { head: { x: 0, y: 0 }, tail: { x: 0, y: 50 } };
+            const result = collectConnectors(head, { x: 0, y: 0 }, coords, 't');
+
+            // Every sequence connector is emitted (4 total), unlike collectOpenConnectors (2).
+            expect(result).toHaveLength(4);
+            // Interior seam is occupied; the two chain ends are open.
+            expect(findC(result, 'head', 'next')[0].occupied).toBe(true);
+            expect(findC(result, 'tail', 'prev')[0].occupied).toBe(true);
+            expect(findC(result, 'head', 'prev')[0].occupied).toBe(false);
+            expect(findC(result, 'tail', 'next')[0].occupied).toBe(false);
+        });
+
+        it('tags a filled nesting cavity nestedNext as occupied and an empty one as open', () => {
+            const filled = makeStatement('filled', { hasNesting: true });
+            const child = makeStatement('child');
+            filled.nestedNext = child;
+            child.prev = filled;
+            const filledCoords: Record<string, Point> = {
+                filled: { x: 0, y: 0 },
+                child: { x: 10, y: 30 },
+            };
+            const filledResult = collectConnectors(filled, { x: 0, y: 0 }, filledCoords, 't');
+            expect(findC(filledResult, 'filled', 'nestedNext')[0].occupied).toBe(true);
+
+            const empty = makeStatement('empty', { hasNesting: true });
+            const emptyResult = collectConnectors(
+                empty,
+                { x: 0, y: 0 },
+                { empty: { x: 0, y: 0 } },
+                't',
+            );
+            expect(findC(emptyResult, 'empty', 'nestedNext')[0].occupied).toBe(false);
+        });
+
+        it('collectOpenConnectors is exactly the unoccupied subset of collectConnectors', () => {
+            const coords = buildCoords(statementTreeWithNesting);
+            const all = collectConnectors(statementTreeWithNesting, { x: 0, y: 0 }, coords, 'nest');
+            const open = collectOpenConnectors(
+                statementTreeWithNesting,
+                { x: 0, y: 0 },
+                coords,
+                'nest',
+            );
+
+            const openFromAll = all.filter((c) => !c.occupied);
+            expect(open).toHaveLength(openFromAll.length);
+            // The occupied tag is stripped from the open-only result.
+            expect(open.every((c) => !('occupied' in c))).toBe(true);
+        });
+    });
+
+    describe('mocks/tower.ts', () => {
+        it('statementTreeNoNesting has no open connectors (both chain ends are capped)', () => {
+            const coords = buildCoords(statementTreeNoNesting);
+            const result = collectOpenConnectors(
+                statementTreeNoNesting,
+                { x: 0, y: 0 },
+                coords,
+                'no-nest',
+            );
+            expect(result).toEqual([]);
+        });
+
+        it('statementTreeWithNesting exposes the open ends of each cavity chain', () => {
+            const coords = buildCoords(statementTreeWithNesting);
+            const result = collectOpenConnectors(
+                statementTreeWithNesting,
+                { x: 0, y: 0 },
+                coords,
+                'nest',
+            );
+
+            // Cavity heads have prev === null (open prev); cavity tails have next === null (open next).
+            const prevIds = result
+                .filter((c) => c.kind === 'prev')
+                .map((c) => c.nodeId)
+                .sort();
+            const nextIds = result
+                .filter((c) => c.kind === 'next')
+                .map((c) => c.nodeId)
+                .sort();
+            const nestedIds = result.filter((c) => c.kind === 'nestedNext').map((c) => c.nodeId);
+
+            expect(prevIds).toEqual(
+                [
+                    'Nesting Statement 1.Statement 6',
+                    'Nesting Statement 1.Nesting Statement 2.Statement 7',
+                    'Nesting Statement 3.Statement 8',
+                ].sort(),
+            );
+            expect(nextIds).toEqual(
+                [
+                    'Nesting Statement 1.Nesting Statement 2',
+                    'Nesting Statement 1.Nesting Statement 2.Statement 7',
+                    'Nesting Statement 3.Statement 9',
+                ].sort(),
+            );
+            // Every cavity in this tree is occupied, so no nestedNext is open.
+            expect(nestedIds).toEqual([]);
+            expect(result.every((c) => c.towerId === 'nest')).toBe(true);
+        });
+    });
+});
+
+describe('collectProbeConnectors', () => {
+    it("returns a standalone statement's prev and next (root is also the tail)", () => {
+        const node = makeStatement('S');
+        const result = collectProbeConnectors(node, { x: 0, y: 0 }, { S: { x: 0, y: 0 } }, 't');
+
+        expect(result).toHaveLength(2);
+        expect(find(result, 'S', 'prev')).toHaveLength(1);
+        expect(find(result, 'S', 'next')).toHaveLength(1);
+        expect(result.every((c) => c.towerId === 't')).toBe(true);
+    });
+
+    it('probes the ROOT prev and the outer TAIL next of a chain, and nothing in between', () => {
+        const head = makeStatement('head');
+        const mid = makeStatement('mid');
+        const tail = makeStatement('tail');
+        head.next = mid;
+        mid.prev = head;
+        mid.next = tail;
+        tail.prev = mid;
+
+        const coords: Record<string, Point> = {
+            head: { x: 0, y: 0 },
+            mid: { x: 0, y: 50 },
+            tail: { x: 0, y: 100 },
+        };
+        const result = collectProbeConnectors(head, { x: 0, y: 0 }, coords, 't');
+
+        // Only the two outer ends: head.prev and tail.next.
+        expect(result).toHaveLength(2);
+        expect(find(result, 'head', 'prev')).toHaveLength(1);
+        expect(find(result, 'tail', 'next')).toHaveLength(1);
+        // The interior seam and the head's/tail's occupied ends are never probed.
+        expect(find(result, 'mid', 'prev')).toHaveLength(0);
+        expect(find(result, 'mid', 'next')).toHaveLength(0);
+        expect(find(result, 'head', 'next')).toHaveLength(0);
+        expect(find(result, 'tail', 'prev')).toHaveLength(0);
+    });
+
+    it('excludes an open nested cavity — a tower snaps by an end, not by an inner tab', () => {
+        const clamp = makeStatement('clamp', { hasNesting: true }); // open nestedNext
+        const below = makeStatement('below');
+        clamp.next = below;
+        below.prev = clamp;
+
+        const coords: Record<string, Point> = { clamp: { x: 0, y: 0 }, below: { x: 0, y: 80 } };
+        const result = collectProbeConnectors(clamp, { x: 0, y: 0 }, coords, 't');
+
+        // clamp.prev (root) and below.next (tail) are probed; the empty cavity's nestedNext is not.
+        expect(result).toHaveLength(2);
+        expect(find(result, 'clamp', 'prev')).toHaveLength(1);
+        expect(find(result, 'below', 'next')).toHaveLength(1);
+        expect(find(result, 'clamp', 'nestedNext')).toHaveLength(0);
+    });
+
+    it('omits a capped end (no prev/next connector on the model)', () => {
+        const node = makeStatement('S', { hasConnectionPrev: false });
+        const result = collectProbeConnectors(node, { x: 0, y: 0 }, { S: { x: 0, y: 0 } }, 't');
+
+        // Only the (present) next end is probed; the missing prev is simply absent.
+        expect(result).toHaveLength(1);
+        expect(find(result, 'S', 'next')).toHaveLength(1);
+        expect(find(result, 'S', 'prev')).toHaveLength(0);
+    });
+
+    it('returns nothing for a non-statement root', () => {
+        const coords: Record<string, Point> = { [valueTree.model.id]: { x: 0, y: 0 } };
+        expect(collectProbeConnectors(valueTree, { x: 0, y: 0 }, coords, 't')).toEqual([]);
+    });
+});

--- a/modules/masonry/src/utils/connectors.ts
+++ b/modules/masonry/src/utils/connectors.ts
@@ -50,6 +50,18 @@ export interface Connector extends OpenConnector {
 }
 
 /**
+ * Resolves a connector to absolute canvas (world) space as the sum of three offsets:
+ *   `origin` + brick top-left px + connector px offset (from `getConnectorCoords()`).
+ * Shared by every connector collector so they all measure connectors the same way.
+ */
+function toWorld(origin: Point, topLeft: Point, offset: Point): Point {
+    return {
+        x: origin.x + topLeft.x + offset.x,
+        y: origin.y + topLeft.y + offset.y,
+    };
+}
+
+/**
  * Collects every statement-domain sequence connector in a tower (open AND occupied), resolved to
  * absolute canvas space, so the result is suitable as the SNAP TARGET set — snapping onto an
  * occupied connector is how mid-chain insertion is expressed.
@@ -82,18 +94,13 @@ export function collectConnectors(
 
         const offsets = node.model.getConnectorCoords();
 
-        const worldPoint = (offset: Point): Point => ({
-            x: origin.x + topLeft.x + offset.x,
-            y: origin.y + topLeft.y + offset.y,
-        });
-
         // prev groove — occupied when the node already has a predecessor.
         if (offsets.prev) {
             connectors.push({
                 towerId,
                 nodeId: node.model.id,
                 kind: 'prev',
-                point: worldPoint(offsets.prev),
+                point: toWorld(origin, topLeft, offsets.prev),
                 occupied: node.prev !== null,
             });
         }
@@ -104,7 +111,7 @@ export function collectConnectors(
                 towerId,
                 nodeId: node.model.id,
                 kind: 'next',
-                point: worldPoint(offsets.next),
+                point: toWorld(origin, topLeft, offsets.next),
                 occupied: node.next !== null,
             });
         }
@@ -116,7 +123,7 @@ export function collectConnectors(
                 towerId,
                 nodeId: node.model.id,
                 kind: 'nestedNext',
-                point: worldPoint(offsets.nestedNext),
+                point: toWorld(origin, topLeft, offsets.nestedNext),
                 occupied: node.nestedNext !== null,
             });
         }
@@ -175,10 +182,7 @@ export function collectProbeConnectors(
             towerId,
             nodeId: root.model.id,
             kind: 'prev',
-            point: {
-                x: origin.x + rootTopLeft.x + rootPrev.x,
-                y: origin.y + rootTopLeft.y + rootPrev.y,
-            },
+            point: toWorld(origin, rootTopLeft, rootPrev),
         });
     }
 
@@ -190,10 +194,7 @@ export function collectProbeConnectors(
             towerId,
             nodeId: tail.model.id,
             kind: 'next',
-            point: {
-                x: origin.x + tailTopLeft.x + tailNext.x,
-                y: origin.y + tailTopLeft.y + tailNext.y,
-            },
+            point: toWorld(origin, tailTopLeft, tailNext),
         });
     }
 

--- a/modules/masonry/src/utils/connectors.ts
+++ b/modules/masonry/src/utils/connectors.ts
@@ -1,0 +1,201 @@
+import type { Point } from '@/@types/common.types';
+import type { TowerNode } from '@/@types/tower.types';
+
+import { findTail, listNodes } from './tower-traversal';
+
+/**
+ * Connector origin for resolving connectors from the brick layout store, whose `coords` are already
+ * absolute canvas positions (`useTowerLayout` bakes each tower's origin into every brick's
+ * top-left). So the origin is (0, 0) — adding the tower `position` again would double-count it.
+ * Shared by the drag probe collection (`useBrickMove`) and the snap target build (`stores/snap`) so
+ * both measure connectors the same way.
+ */
+export const ORIGIN: Point = { x: 0, y: 0 };
+
+/**
+ * Statement-domain connector kinds that participate in sequence snapping. Argument-domain
+ * `inputs`/`output` connectors are handled separately and are out of scope here.
+ */
+export type ConnectorKind = 'prev' | 'next' | 'nestedNext';
+
+/**
+ * An OPEN connector on a tower, resolved into absolute canvas (world) space. "Open" means the
+ * corresponding model pointer is unoccupied, so the connector is free to mate with another tower's:
+ *   - `prev`       — no predecessor (`prev === null`)
+ *   - `next`       — no successor (`next === null`)
+ *   - `nestedNext` — an empty nesting cavity (`nestedNext === null`)
+ */
+export interface OpenConnector {
+    /** Id of the tower this connector belongs to. */
+    towerId: string;
+    /** Id of the node (brick) the connector sits on. */
+    nodeId: string;
+    /** Which sequence connector this is. */
+    kind: ConnectorKind;
+    /** Connector centroid in absolute canvas (world) pixels. */
+    point: Point;
+}
+
+/**
+ * A statement-domain sequence connector in absolute canvas space, tagged with whether its model
+ * pointer is already occupied. This is the shape used for SNAP TARGETS, where both matter:
+ *   - `occupied === false` — a free chain end, available to mate directly.
+ *   - `occupied === true`  — already linked; still a valid target, but snapping onto it means
+ *     MID-CHAIN INSERTION (the join step splices the dragged tower in and reconnects the displaced
+ *     neighbour to its tail).
+ */
+export interface Connector extends OpenConnector {
+    /** Whether this connector's model pointer already points at a neighbour. */
+    occupied: boolean;
+}
+
+/**
+ * Collects every statement-domain sequence connector in a tower (open AND occupied), resolved to
+ * absolute canvas space, so the result is suitable as the SNAP TARGET set — snapping onto an
+ * occupied connector is how mid-chain insertion is expressed.
+ *
+ * Pure: the caller supplies per-brick top-lefts via `coords`; this never reads a store. A
+ * connector's world point is the sum of three offsets:
+ *   `origin` + brick top-left px (`coords[nodeId]`) + connector px offset (`getConnectorCoords()`)
+ *
+ * Only statement nodes carry sequence connectors; a node missing from `coords` is skipped (it
+ * cannot be placed in world space yet).
+ *
+ * @param root    - Root node of the tower tree.
+ * @param origin  - The tower's origin in canvas px; every connector is measured relative to it.
+ * @param coords  - Map of brick id → the brick's top-left position in canvas px.
+ * @param towerId - Id of the tower, passed through onto every emitted connector.
+ */
+export function collectConnectors(
+    root: TowerNode,
+    origin: Point,
+    coords: Record<string, Point>,
+    towerId: string,
+): Connector[] {
+    const connectors: Connector[] = [];
+
+    for (const node of listNodes(root)) {
+        if (node.kind !== 'statement') continue;
+
+        const topLeft = coords[node.model.id];
+        if (!topLeft) continue;
+
+        const offsets = node.model.getConnectorCoords();
+
+        const worldPoint = (offset: Point): Point => ({
+            x: origin.x + topLeft.x + offset.x,
+            y: origin.y + topLeft.y + offset.y,
+        });
+
+        // prev groove — occupied when the node already has a predecessor.
+        if (offsets.prev) {
+            connectors.push({
+                towerId,
+                nodeId: node.model.id,
+                kind: 'prev',
+                point: worldPoint(offsets.prev),
+                occupied: node.prev !== null,
+            });
+        }
+
+        // next tab — occupied when the node already has a successor.
+        if (offsets.next) {
+            connectors.push({
+                towerId,
+                nodeId: node.model.id,
+                kind: 'next',
+                point: worldPoint(offsets.next),
+                occupied: node.next !== null,
+            });
+        }
+
+        // nestedNext cavity-roof tab — present only when the node has a cavity
+        // (nestedNext !== undefined); occupied when the cavity already holds a head.
+        if (node.nestedNext !== undefined && offsets.nestedNext) {
+            connectors.push({
+                towerId,
+                nodeId: node.model.id,
+                kind: 'nestedNext',
+                point: worldPoint(offsets.nestedNext),
+                occupied: node.nestedNext !== null,
+            });
+        }
+    }
+
+    return connectors;
+}
+
+/**
+ * Collects only the OPEN statement-domain connectors in a tower (the free chain ends) — derived
+ * from {@link collectConnectors} by dropping the occupied ones. See it for parameter meanings.
+ */
+export function collectOpenConnectors(
+    root: TowerNode,
+    origin: Point,
+    coords: Record<string, Point>,
+    towerId: string,
+): OpenConnector[] {
+    return collectConnectors(root, origin, coords, towerId)
+        .filter((connector) => !connector.occupied)
+        .map(
+            (connector): OpenConnector => ({
+                towerId: connector.towerId,
+                nodeId: connector.nodeId,
+                kind: connector.kind,
+                point: connector.point,
+            }),
+        );
+}
+
+/**
+ * Collects the DRAGGED tower's two probe connectors — its ROOT `prev` groove and its outer TAIL
+ * `next` tab — resolved to absolute canvas space, keeping only the open ones. These are the only
+ * connectors a moving tower snaps WITH (per the approved spec): a tower snaps by an END of its
+ * outer sequence, not by its middle or an inner cavity. A value/expression root yields nothing.
+ *
+ * See {@link collectConnectors} for parameter meanings. Returns up to two connectors (each omitted
+ * when absent or already occupied).
+ */
+export function collectProbeConnectors(
+    root: TowerNode,
+    origin: Point,
+    coords: Record<string, Point>,
+    towerId: string,
+): OpenConnector[] {
+    if (root.kind !== 'statement') return [];
+
+    const tail = findTail(root);
+    const probes: OpenConnector[] = [];
+
+    // Root `prev` groove — the tower's open TOP end; emitted only when open and placed.
+    const rootTopLeft = coords[root.model.id];
+    const rootPrev = root.model.getConnectorCoords().prev;
+    if (root.prev === null && rootTopLeft && rootPrev) {
+        probes.push({
+            towerId,
+            nodeId: root.model.id,
+            kind: 'prev',
+            point: {
+                x: origin.x + rootTopLeft.x + rootPrev.x,
+                y: origin.y + rootTopLeft.y + rootPrev.y,
+            },
+        });
+    }
+
+    // Outer tail `next` tab — the tower's open BOTTOM end; emitted only when open and placed.
+    const tailTopLeft = coords[tail.model.id];
+    const tailNext = tail.model.getConnectorCoords().next;
+    if (tail.next === null && tailTopLeft && tailNext) {
+        probes.push({
+            towerId,
+            nodeId: tail.model.id,
+            kind: 'next',
+            point: {
+                x: origin.x + tailTopLeft.x + tailNext.x,
+                y: origin.y + tailTopLeft.y + tailNext.y,
+            },
+        });
+    }
+
+    return probes;
+}

--- a/modules/masonry/src/utils/snap.test.ts
+++ b/modules/masonry/src/utils/snap.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Point } from '@/@types/common.types';
+
+import type { Connector, ConnectorKind } from './connectors';
+import { SNAP_DISTANCE, SnapEngine } from './snap';
+
+// Canvas large enough that every connector sits well inside the collision space's valid margin
+// (createObjects drops anything within SNAP_DIAMETER/2 of an edge).
+const CANVAS: Point = { x: 1000, y: 1000 };
+
+/**
+ * Builds a statement-domain connector at an absolute canvas point. Defaults to open (`occupied`
+ * false); pass `occupied` to model a connector that already links a neighbour (an insertion
+ * target). A `Connector` is also a valid dragged probe, since it extends `OpenConnector`.
+ */
+function connector(
+    towerId: string,
+    nodeId: string,
+    kind: ConnectorKind,
+    point: Point,
+    occupied = false,
+): Connector {
+    return { towerId, nodeId, kind, point, occupied };
+}
+
+function makeEngine(targets: Connector[]): SnapEngine {
+    const engine = new SnapEngine(CANVAS.x, CANVAS.y);
+    engine.setTargets(targets);
+    return engine;
+}
+
+describe('SnapEngine.findSnap', () => {
+    describe('accepts the approved matings', () => {
+        it('S1: dragged prev groove snaps to a target next tab (stack below)', () => {
+            const target = connector('target', 'T', 'next', { x: 300, y: 300 });
+            const engine = makeEngine([target]);
+
+            const dragged = connector('dragged', 'D', 'prev', { x: 305, y: 300 }); // distance 5
+
+            const result = engine.findSnap(dragged);
+            expect(result).not.toBeNull();
+            expect(result!.targetTowerId).toBe('target');
+            expect(result!.targetNodeId).toBe('T');
+            expect(result!.targetKind).toBe('next');
+            expect(result!.draggedKind).toBe('prev');
+            expect(result!.distance).toBeCloseTo(5);
+        });
+
+        it('S2: dragged prev groove snaps to a target nestedNext tab (nest in clamp)', () => {
+            const target = connector('target', 'T', 'nestedNext', { x: 400, y: 400 });
+            const engine = makeEngine([target]);
+
+            const dragged = connector('dragged', 'D', 'prev', { x: 400, y: 410 }); // distance 10
+
+            const result = engine.findSnap(dragged);
+            expect(result).not.toBeNull();
+            expect(result!.targetKind).toBe('nestedNext');
+            expect(result!.draggedKind).toBe('prev');
+        });
+
+        it('S3: dragged next tab snaps to a target prev groove (attach above)', () => {
+            const target = connector('target', 'T', 'prev', { x: 500, y: 500 });
+            const engine = makeEngine([target]);
+
+            const dragged = connector('dragged', 'D', 'next', { x: 500, y: 505 }); // distance 5
+
+            const result = engine.findSnap(dragged);
+            expect(result).not.toBeNull();
+            expect(result!.targetKind).toBe('prev');
+            expect(result!.draggedKind).toBe('next');
+        });
+    });
+
+    it('reports the full matched target connector (for mid-chain insertion detection)', () => {
+        const target = connector('target', 'clamp', 'nestedNext', { x: 300, y: 300 });
+        const engine = makeEngine([target]);
+
+        const dragged = connector('dragged', 'D', 'prev', { x: 303, y: 300 });
+
+        const result = engine.findSnap(dragged);
+        expect(result).not.toBeNull();
+        expect(result!.target).toEqual(target);
+        expect(result!.dragged).toEqual(dragged);
+    });
+
+    describe('accepts occupied targets (mid-chain insertion)', () => {
+        it('matches an occupied next tab and flags it for insertion below', () => {
+            // A node already followed by a successor: dragged prev groove snaps in between.
+            const target = connector('target', 'T', 'next', { x: 300, y: 300 }, true);
+            const engine = makeEngine([target]);
+
+            const dragged = connector('dragged', 'D', 'prev', { x: 302, y: 300 });
+
+            const result = engine.findSnap(dragged);
+            expect(result).not.toBeNull();
+            expect(result!.targetKind).toBe('next');
+            expect(result!.target.occupied).toBe(true);
+        });
+
+        it('matches an occupied prev groove and flags it for insertion above', () => {
+            const target = connector('target', 'T', 'prev', { x: 400, y: 400 }, true);
+            const engine = makeEngine([target]);
+
+            const dragged = connector('dragged', 'D', 'next', { x: 400, y: 403 });
+
+            const result = engine.findSnap(dragged);
+            expect(result).not.toBeNull();
+            expect(result!.targetKind).toBe('prev');
+            expect(result!.target.occupied).toBe(true);
+        });
+
+        it('matches an occupied nestedNext tab (insert at cavity head)', () => {
+            const target = connector('target', 'clamp', 'nestedNext', { x: 500, y: 500 }, true);
+            const engine = makeEngine([target]);
+
+            const dragged = connector('dragged', 'D', 'prev', { x: 500, y: 504 });
+
+            const result = engine.findSnap(dragged);
+            expect(result).not.toBeNull();
+            expect(result!.targetKind).toBe('nestedNext');
+            expect(result!.target.occupied).toBe(true);
+        });
+    });
+
+    describe('rejects incompatible tab/groove pairings', () => {
+        it('tab ↔ tab: dragged next tab does not mate a target next tab', () => {
+            const target = connector('target', 'T', 'next', { x: 300, y: 300 });
+            const engine = makeEngine([target]);
+
+            const dragged = connector('dragged', 'D', 'next', { x: 300, y: 300 }); // same point
+            expect(engine.findSnap(dragged)).toBeNull();
+        });
+
+        it('groove ↔ groove: dragged prev groove does not mate a target prev groove', () => {
+            const target = connector('target', 'T', 'prev', { x: 300, y: 300 });
+            const engine = makeEngine([target]);
+
+            const dragged = connector('dragged', 'D', 'prev', { x: 300, y: 300 });
+            expect(engine.findSnap(dragged)).toBeNull();
+        });
+
+        it('dragged nestedNext is never a valid probe, even onto a compatible groove', () => {
+            // nestedNext is a tab and prev a groove, so geometry would allow it — but a moving tower
+            // only ever probes by its outer prev/next ends, so a dragged nestedNext is rejected.
+            const target = connector('target', 'T', 'prev', { x: 300, y: 300 });
+            const engine = makeEngine([target]);
+
+            const dragged = connector('dragged', 'D', 'nestedNext', { x: 300, y: 300 });
+            expect(engine.findSnap(dragged)).toBeNull();
+        });
+    });
+
+    it('rejects a connector on the same tower (cycle guard)', () => {
+        // Compatible kinds and coincident points, but same towerId — must not mate.
+        const target = connector('same', 'T', 'next', { x: 300, y: 300 });
+        const engine = makeEngine([target]);
+
+        const dragged = connector('same', 'D', 'prev', { x: 300, y: 300 });
+        expect(engine.findSnap(dragged)).toBeNull();
+    });
+
+    describe('snap-distance boundary (fires strictly inside SNAP_DISTANCE)', () => {
+        // Collision fires when centre distance is STRICTLY less than SNAP_DISTANCE, so the boundary
+        // itself is a miss. These pin the exact edge so a change to SNAP_DISTANCE/threshold is caught.
+        it('snaps a valid mate just inside SNAP_DISTANCE', () => {
+            const target = connector('target', 'T', 'next', { x: 300, y: 300 });
+            const engine = makeEngine([target]);
+
+            const dragged = connector('dragged', 'D', 'prev', {
+                x: 300 + SNAP_DISTANCE - 1,
+                y: 300,
+            });
+            const result = engine.findSnap(dragged);
+            expect(result).not.toBeNull();
+            expect(result!.distance).toBeCloseTo(SNAP_DISTANCE - 1);
+        });
+
+        it('does not snap a valid mate sitting exactly at SNAP_DISTANCE', () => {
+            const target = connector('target', 'T', 'next', { x: 300, y: 300 });
+            const engine = makeEngine([target]);
+
+            const dragged = connector('dragged', 'D', 'prev', { x: 300 + SNAP_DISTANCE, y: 300 });
+            expect(engine.findSnap(dragged)).toBeNull();
+        });
+
+        it('does not snap a valid mate just beyond SNAP_DISTANCE', () => {
+            const target = connector('target', 'T', 'next', { x: 300, y: 300 });
+            const engine = makeEngine([target]);
+
+            const dragged = connector('dragged', 'D', 'prev', {
+                x: 300 + SNAP_DISTANCE + 1,
+                y: 300,
+            });
+            expect(engine.findSnap(dragged)).toBeNull();
+        });
+    });
+
+    it('returns the nearest valid candidate when several are in range', () => {
+        const near = connector('target', 'near', 'next', { x: 300, y: 300 });
+        const far = connector('target', 'far', 'next', { x: 300, y: 312 });
+        // Register the far one first, so the result depends on distance, not insertion order.
+        const engine = makeEngine([far, near]);
+
+        const dragged = connector('dragged', 'D', 'prev', { x: 300, y: 302 }); // 2px from near, 10px from far
+
+        const result = engine.findSnap(dragged);
+        expect(result).not.toBeNull();
+        expect(result!.targetNodeId).toBe('near');
+        expect(result!.distance).toBeCloseTo(2);
+    });
+
+    it('breaks an exact distance tie in favour of the earliest-registered target', () => {
+        // Two compatible targets equidistant from the probe: the one registered first must win, so
+        // the outcome is deterministic rather than dependent on the collision space's scan order.
+        const first = connector('target', 'first', 'next', { x: 300 - 10, y: 300 });
+        const second = connector('target', 'second', 'next', { x: 300 + 10, y: 300 });
+        const engine = makeEngine([first, second]);
+
+        const dragged = connector('dragged', 'D', 'prev', { x: 300, y: 300 }); // 10px from each
+
+        const result = engine.findSnap(dragged);
+        expect(result).not.toBeNull();
+        expect(result!.distance).toBeCloseTo(10);
+        expect(result!.targetNodeId).toBe('first');
+    });
+
+    it('skips an incompatible nearer candidate in favour of a compatible farther one', () => {
+        const nearIncompatible = connector('target', 'near', 'prev', { x: 300, y: 301 }); // groove ↔ groove
+        const farCompatible = connector('target', 'far', 'next', { x: 300, y: 308 });
+        const engine = makeEngine([nearIncompatible, farCompatible]);
+
+        const dragged = connector('dragged', 'D', 'prev', { x: 300, y: 300 });
+
+        const result = engine.findSnap(dragged);
+        expect(result).not.toBeNull();
+        expect(result!.targetNodeId).toBe('far');
+    });
+
+    it('returns null when there are no targets', () => {
+        const engine = makeEngine([]);
+        const dragged = connector('dragged', 'D', 'prev', { x: 300, y: 300 });
+        expect(engine.findSnap(dragged)).toBeNull();
+    });
+});

--- a/modules/masonry/src/utils/snap.ts
+++ b/modules/masonry/src/utils/snap.ts
@@ -1,0 +1,166 @@
+import { BruteForceCollisionSpace, type CollisionObject, type CollisionSpace } from './collision';
+import type { Connector, ConnectorKind, OpenConnector } from './connectors';
+
+/**
+ * Centre-to-centre distance, in canvas px, within which two connectors are considered close
+ * enough to snap. Tunable: raise it for a more forgiving snap, lower it for a stricter one.
+ */
+export const SNAP_DISTANCE = 20;
+
+/**
+ * Side length of a connector's square probe box. The collision space treats each box as a circle
+ * of radius `min(w, h) / 2` and fires when two centres are within `(rA + rB) * (1 - threshold)`.
+ * Sizing both boxes to `SNAP_DIAMETER` with the space at `SNAP_THRESHOLD` reduces that expression
+ * to exactly `SNAP_DISTANCE`.
+ */
+export const SNAP_DIAMETER = SNAP_DISTANCE * 2;
+
+/**
+ * Overlap threshold that, with `SNAP_DIAMETER`, makes a collision fire precisely when two connector
+ * centres are closer than `SNAP_DISTANCE`: `(SNAP_DIAMETER / 2 + SNAP_DIAMETER / 2) * (1 - 0.5)`.
+ */
+const SNAP_THRESHOLD = 0.5;
+
+// Sentinel id for the transient dragged probe. Target ids are non-negative, so the probe can
+// never be mistaken for (or self-collide with) a tracked target.
+const PROBE_ID = -1;
+
+/**
+ * A valid snap between a dragged connector and a target connector on another tower. The full
+ * `target` connector (not just its id) is reported so the join step can read `target.occupied` to
+ * detect mid-chain insertion.
+ */
+export interface SnapCandidate {
+    /** Tower that owns the matched target connector. */
+    targetTowerId: string;
+    /** Node (brick) that owns the matched target connector. */
+    targetNodeId: string;
+    /** Which connector on the target was matched. */
+    targetKind: ConnectorKind;
+    /** Node (brick) on the dragged tower whose connector was probed. */
+    draggedNodeId: string;
+    /** Which connector on the dragged tower was probed. */
+    draggedKind: ConnectorKind;
+    /** Centre-to-centre distance between the two connectors, in canvas px. */
+    distance: number;
+    /** The full matched target connector; its `occupied` flag drives plain join vs. mid-chain insertion. */
+    target: Connector;
+    /** The full dragged connector that was probed. */
+    dragged: OpenConnector;
+}
+
+/**
+ * Whether a dragged connector may mate with a target, per the approved spec — tabs plug into
+ * grooves, never tab↔tab or groove↔groove (`prev` is a groove; `next`/`nestedNext` are tabs):
+ *   - S1 stack below:   dragged `prev` ← target `next`
+ *   - S2 nest in clamp: dragged `prev` ← target `nestedNext`
+ *   - S3 attach above:  dragged `next` → target `prev`
+ *
+ * A dragged `nestedNext` is not an approved case and is rejected.
+ */
+function isValidMate(draggedKind: ConnectorKind, targetKind: ConnectorKind): boolean {
+    if (draggedKind === 'prev') return targetKind === 'next' || targetKind === 'nestedNext';
+    if (draggedKind === 'next') return targetKind === 'prev';
+    return false;
+}
+
+/**
+ * Owns a collision space of TARGET connectors and finds the nearest valid mate for a dragged
+ * connector. Targets may be open or occupied (occupied ones enable mid-chain insertion); the mate
+ * rules — compatible tab/groove pairing and a different tower — are enforced in `findSnap`.
+ */
+export class SnapEngine {
+    private _space: CollisionSpace;
+    private _connectorById = new Map<number, Connector>();
+    private _nextId = 0;
+
+    /**
+     * @param width       - Canvas width in px; targets outside `[0, width]` are dropped by the space.
+     * @param height      - Canvas height in px; targets outside `[0, height]` are dropped by the space.
+     * @param createSpace - Factory for the backing collision space (default {@link BruteForceCollisionSpace}),
+     *                      injectable so a quadtree-backed space or a test double can be substituted.
+     */
+    constructor(
+        width: number,
+        height: number,
+        createSpace: (w: number, h: number) => CollisionSpace = (w, h) =>
+            new BruteForceCollisionSpace(w, h),
+    ) {
+        this._space = createSpace(width, height);
+        this._space.setOptions({ shape: 'circle', threshold: SNAP_THRESHOLD });
+    }
+
+    /**
+     * (Re)builds the target space from a connector list, assigning each connector a numeric id and
+     * recording the id → connector reverse map.
+     */
+    public setTargets(connectors: Connector[]): void {
+        this._space.reset();
+        this._space.setOptions({ shape: 'circle', threshold: SNAP_THRESHOLD });
+        this._connectorById.clear();
+        this._nextId = 0;
+
+        const objects: CollisionObject[] = [];
+        for (const connector of connectors) {
+            const id = this._nextId++;
+            this._connectorById.set(id, connector);
+            objects.push({
+                id,
+                x: connector.point.x,
+                y: connector.point.y,
+                w: SNAP_DIAMETER,
+                h: SNAP_DIAMETER,
+            });
+        }
+
+        this._space.createObjects(objects);
+    }
+
+    /**
+     * Probes the target space with a dragged connector and returns the NEAREST valid mate by centre
+     * distance, or `null` if none is in range. Candidates are filtered to a different tower and a
+     * compatible tab/groove pairing; on a tie the earliest-registered target wins.
+     */
+    public findSnap(dragged: OpenConnector): SnapCandidate | null {
+        const probe: CollisionObject = {
+            id: PROBE_ID,
+            x: dragged.point.x,
+            y: dragged.point.y,
+            w: SNAP_DIAMETER,
+            h: SNAP_DIAMETER,
+        };
+
+        let best: SnapCandidate | null = null;
+
+        for (const id of this._space.checkCollision(probe)) {
+            const target = this._connectorById.get(id);
+            if (target === undefined) continue;
+
+            // Cycle guard: a connector can never mate with one on its own tower.
+            if (target.towerId === dragged.towerId) continue;
+
+            // Tab/groove compatibility per the approved spec.
+            if (!isValidMate(dragged.kind, target.kind)) continue;
+
+            const distance = Math.hypot(
+                target.point.x - dragged.point.x,
+                target.point.y - dragged.point.y,
+            );
+
+            if (best === null || distance < best.distance) {
+                best = {
+                    targetTowerId: target.towerId,
+                    targetNodeId: target.nodeId,
+                    targetKind: target.kind,
+                    draggedNodeId: dragged.nodeId,
+                    draggedKind: dragged.kind,
+                    distance,
+                    target,
+                    dragged,
+                };
+            }
+        }
+
+        return best;
+    }
+}

--- a/modules/masonry/src/utils/tower-join.test.ts
+++ b/modules/masonry/src/utils/tower-join.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TowerStatementNode } from '@/@types/tower.types';
+import { StatementBrickModel } from '@/models/brick';
+
+import { joinTowers } from './tower-join';
+
+const colorsDefault = { background: '#3498db', foreground: '#ffffff', border: '#2980b9' };
+
+function makeStatement(
+    id: string,
+    options: {
+        hasNesting?: boolean;
+        hasConnectionPrev?: boolean;
+        hasConnectionNext?: boolean;
+    } = {},
+): TowerStatementNode {
+    return {
+        kind: 'statement',
+        model: new StatementBrickModel({
+            id,
+            colorsDefault,
+            tooltipText: '',
+            widget: { type: 'label', text: id },
+            params: [],
+            hasConnectionPrev: options.hasConnectionPrev ?? true,
+            hasConnectionNext: options.hasConnectionNext ?? true,
+            hasNesting: options.hasNesting ?? false,
+        }),
+        prev: null,
+        next: null,
+        args: [],
+        nestedNext: options.hasNesting ? null : undefined,
+    };
+}
+
+/** Links a run of statement nodes head→tail via prev/next; returns the head. */
+function chain(...nodes: TowerStatementNode[]): TowerStatementNode {
+    nodes.forEach((node, i) => {
+        node.prev = nodes[i - 1] ?? null;
+        node.next = nodes[i + 1] ?? null;
+    });
+    return nodes[0];
+}
+
+describe('joinTowers', () => {
+    describe('S1 — dragged root prev ← target next (stack below)', () => {
+        it('links the dragged root beneath a free target', () => {
+            const target = makeStatement('T', { hasConnectionNext: false });
+            const draggedRoot = makeStatement('D', { hasConnectionPrev: false });
+
+            joinTowers({ draggedRoot, target, draggedKind: 'prev', targetKind: 'next' });
+
+            expect(target.next).toBe(draggedRoot);
+            expect(draggedRoot.prev).toBe(target);
+            expect(target.model.hasConnectionNext).toBe(true);
+            expect(draggedRoot.model.hasConnectionPrev).toBe(true);
+        });
+
+        it('inserts mid-chain, reconnecting the displaced successor to the dragged tail', () => {
+            const oldNext = makeStatement('oldNext');
+            const target = chain(makeStatement('T'), oldNext);
+
+            const draggedRoot = chain(makeStatement('D1'), makeStatement('D2'));
+            const draggedTail = draggedRoot.next as TowerStatementNode;
+
+            joinTowers({ draggedRoot, target, draggedKind: 'prev', targetKind: 'next' });
+
+            // T → D1 → D2 → oldNext
+            expect(target.next).toBe(draggedRoot);
+            expect(draggedRoot.prev).toBe(target);
+            expect(draggedTail.next).toBe(oldNext);
+            expect(oldNext.prev).toBe(draggedTail);
+            expect(draggedTail.model.hasConnectionNext).toBe(true);
+            expect(oldNext.model.hasConnectionPrev).toBe(true);
+        });
+    });
+
+    describe('S2 — dragged root prev ← target nestedNext (nest in clamp)', () => {
+        it('links the dragged root as the clamp cavity head, prev pointing at the clamp', () => {
+            const clamp = makeStatement('clamp', { hasNesting: true }); // empty cavity
+            const draggedRoot = makeStatement('D', { hasConnectionPrev: false });
+
+            joinTowers({
+                draggedRoot,
+                target: clamp,
+                draggedKind: 'prev',
+                targetKind: 'nestedNext',
+            });
+
+            expect(clamp.nestedNext).toBe(draggedRoot);
+            expect(draggedRoot.prev).toBe(clamp);
+            expect(draggedRoot.model.hasConnectionPrev).toBe(true);
+        });
+
+        it('inserts at the cavity head, splicing the displaced head onto the dragged tail', () => {
+            const clamp = makeStatement('clamp', { hasNesting: true });
+            const oldHead = makeStatement('oldHead');
+            clamp.nestedNext = oldHead;
+            oldHead.prev = clamp;
+
+            const draggedRoot = chain(makeStatement('D1'), makeStatement('D2'));
+            const draggedTail = draggedRoot.next as TowerStatementNode;
+
+            joinTowers({
+                draggedRoot,
+                target: clamp,
+                draggedKind: 'prev',
+                targetKind: 'nestedNext',
+            });
+
+            // clamp ╠═▶ D1 → D2 → oldHead
+            expect(clamp.nestedNext).toBe(draggedRoot);
+            expect(draggedRoot.prev).toBe(clamp);
+            expect(draggedTail.next).toBe(oldHead);
+            expect(oldHead.prev).toBe(draggedTail);
+            expect(draggedTail.model.hasConnectionNext).toBe(true);
+            expect(oldHead.model.hasConnectionPrev).toBe(true);
+        });
+    });
+
+    describe('S3 — dragged tail next → target prev (attach above)', () => {
+        it('links the dragged tail above a free target', () => {
+            const target = makeStatement('T', { hasConnectionPrev: false });
+            const draggedRoot = chain(makeStatement('D1'), makeStatement('D2'));
+            const draggedTail = draggedRoot.next as TowerStatementNode;
+
+            joinTowers({ draggedRoot, target, draggedKind: 'next', targetKind: 'prev' });
+
+            // D1 → D2 → T
+            expect(draggedTail.next).toBe(target);
+            expect(target.prev).toBe(draggedTail);
+            expect(draggedTail.model.hasConnectionNext).toBe(true);
+            expect(target.model.hasConnectionPrev).toBe(true);
+            // The dragged root stays the head of the merged chain.
+            expect(draggedRoot.prev).toBeNull();
+        });
+
+        it('inserts above, threading the displaced predecessor before the dragged root', () => {
+            const oldPrev = makeStatement('oldPrev');
+            const target = chain(oldPrev, makeStatement('T')).next as TowerStatementNode;
+
+            const draggedRoot = chain(makeStatement('D1'), makeStatement('D2'));
+            const draggedTail = draggedRoot.next as TowerStatementNode;
+
+            joinTowers({ draggedRoot, target, draggedKind: 'next', targetKind: 'prev' });
+
+            // oldPrev → D1 → D2 → T
+            expect(oldPrev.next).toBe(draggedRoot);
+            expect(draggedRoot.prev).toBe(oldPrev);
+            expect(draggedTail.next).toBe(target);
+            expect(target.prev).toBe(draggedTail);
+            expect(oldPrev.model.hasConnectionNext).toBe(true);
+            expect(draggedRoot.model.hasConnectionPrev).toBe(true);
+        });
+    });
+
+    it('throws on an unsupported mating (should be rejected upstream)', () => {
+        const target = makeStatement('T');
+        const draggedRoot = makeStatement('D');
+        expect(() =>
+            joinTowers({ draggedRoot, target, draggedKind: 'next', targetKind: 'next' }),
+        ).toThrow(/unsupported mating/);
+    });
+});

--- a/modules/masonry/src/utils/tower-join.ts
+++ b/modules/masonry/src/utils/tower-join.ts
@@ -1,0 +1,103 @@
+import type { TowerStatementNode } from '@/@types/tower.types';
+
+import type { ConnectorKind } from './connectors';
+import { findTail } from './tower-traversal';
+
+/**
+ * Which connector on the DRAGGED tower was probed. A moving tower snaps only by one of its two
+ * outer ends — its root `prev` groove or its outer tail `next` tab — never by a `nestedNext`.
+ */
+export type DraggedKind = Extract<ConnectorKind, 'prev' | 'next'>;
+
+/** Parameters describing a single validated snap-join between two towers. */
+export interface JoinParams {
+    /** Root node of the dragged (moving) tower. */
+    draggedRoot: TowerStatementNode;
+    /** The target node on the stationary tower whose connector was matched. */
+    target: TowerStatementNode;
+    /** Which connector on the dragged tower was probed (its root `prev` or its outer tail `next`). */
+    draggedKind: DraggedKind;
+    /** Which connector on the target was matched. */
+    targetKind: ConnectorKind;
+}
+
+/**
+ * Reconnects a displaced successor (the node that used to follow the target) onto the dragged
+ * tower's tail, completing a mid-chain insertion. No-op when there was no successor.
+ *
+ * Only statement successors are spliced — sequence `next`/`nestedNext` pointers always reference a
+ * statement in practice, and a non-statement cannot carry a `prev` back-pointer.
+ */
+function spliceSuccessor(
+    draggedTail: TowerStatementNode,
+    displaced: TowerStatementNode | null,
+): void {
+    if (displaced === null) return;
+
+    draggedTail.next = displaced;
+    displaced.prev = draggedTail;
+    draggedTail.model.hasConnectionNext = true;
+    displaced.model.hasConnectionPrev = true;
+}
+
+/**
+ * Splices the dragged tower into the target by mutating tower-node pointers in place, per the
+ * approved spec (see the S1/S2/S3 cases inline below). Pure with respect to stores and layout — it
+ * only edits the node graph and the affected models' notch flags (`hasConnectionPrev`/`Next`, so
+ * notches render); the caller merges the towers in the store and triggers a re-layout.
+ */
+export function joinTowers(params: JoinParams): void {
+    const { draggedRoot, target, draggedKind, targetKind } = params;
+    const draggedTail = findTail(draggedRoot);
+
+    // S1 — dragged root `prev` groove ← target `next` tab (stack below / insert below).
+    if (draggedKind === 'prev' && targetKind === 'next') {
+        const displaced = target.next;
+
+        target.next = draggedRoot;
+        draggedRoot.prev = target;
+        target.model.hasConnectionNext = true;
+        draggedRoot.model.hasConnectionPrev = true;
+
+        spliceSuccessor(draggedTail, displaced?.kind === 'statement' ? displaced : null);
+        return;
+    }
+
+    // S2 — dragged root `prev` groove ← target `nestedNext` tab (nest in clamp / insert at head).
+    if (draggedKind === 'prev' && targetKind === 'nestedNext') {
+        const displaced = target.nestedNext ?? null;
+
+        target.nestedNext = draggedRoot;
+        // The nested cavity head's `prev` back-pointer points at the clamp brick.
+        draggedRoot.prev = target;
+        draggedRoot.model.hasConnectionPrev = true;
+
+        spliceSuccessor(draggedTail, displaced?.kind === 'statement' ? displaced : null);
+        return;
+    }
+
+    // S3 — dragged tail `next` tab → target `prev` groove (attach above / insert above).
+    if (draggedKind === 'next' && targetKind === 'prev') {
+        const displaced = target.prev;
+
+        draggedTail.next = target;
+        target.prev = draggedTail;
+        draggedTail.model.hasConnectionNext = true;
+        target.model.hasConnectionPrev = true;
+
+        if (displaced !== null && displaced.kind === 'statement') {
+            // Insert above: the displaced predecessor now precedes the dragged root.
+            displaced.next = draggedRoot;
+            draggedRoot.prev = displaced;
+            displaced.model.hasConnectionNext = true;
+            draggedRoot.model.hasConnectionPrev = true;
+        }
+        return;
+    }
+
+    // Any other pairing is not an approved mating and should have been rejected upstream by
+    // `SnapEngine.findSnap`; reaching here means a bug in the caller.
+    throw new Error(
+        `joinTowers: unsupported mating dragged '${draggedKind}' → target '${targetKind}'`,
+    );
+}

--- a/modules/masonry/src/utils/tower-traversal.ts
+++ b/modules/masonry/src/utils/tower-traversal.ts
@@ -59,6 +59,20 @@ export function listNodes(root: TowerNode): TowerNode[] {
     return nodes;
 }
 
+/**
+ * Walks a tower's outer statement sequence to its TAIL — the last node still linked by a main-chain
+ * `next`. Shared by the snap probe collection and the join step: it is the node carrying the dragged
+ * tower's open bottom `next` end, and the node that receives a displaced successor on a mid-chain
+ * insertion.
+ */
+export function findTail(root: TowerStatementNode): TowerStatementNode {
+    let tail: TowerStatementNode = root;
+    while (tail.next !== null && tail.next.kind === 'statement') {
+        tail = tail.next;
+    }
+    return tail;
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
- **#700 | feat(masonry): add scaled getConnectorCoords accessor on brick model**
- **#700 | feat(masonry): add tower connector collection utilities**
- **#700 | feat(masonry): add SnapEngine for nearest valid connector mate**
- **#700 | feat(masonry): add joinTowers node-graph splice**
- **#700 | feat(masonry): add shared snap-target store**
- **#700 | feat(masonry): add layoutVersion re-layout trigger**
- **#700 | feat(masonry): add absorbTower to merge joined towers**
- **#700 | feat(masonry): drag whole tower and snap-join on drop**
- **#700 | refactor(masonry): dedupe connector world-point math into toWorld helper**
- **#700 | fix(masonry): reset shared snap engine on Workspace unmount**
- **#700 | perf(masonry): drag whole tower via direct DOM writes, commit to store once on drop**
- **#700 | test(masonry): cover whole-tower drag, snap-join, and reconcile in useBrickMove**
