### PR TITLE
#698 | Add all Argument connector points in the Collision space

### DIFF
--- a/modules/masonry/src/@types/brick.types.ts
+++ b/modules/masonry/src/@types/brick.types.ts
@@ -81,8 +81,8 @@ export interface BrickOutlineOutput {
  *   next       — hasNextNotch
  *   nestedNext — hasNesting (cavity-roof tab)
  *   output     — hasOutputNotch
- * `inputs` is always present: one Point per argument slot whose arg !== null,
- * ordered top-to-bottom; an empty array when the brick has no filled arg slots.
+ * `inputs` is always present: one entry per argument slot (filled and empty),
+ * ordered top-to-bottom; an empty array when the brick has no arg slots.
  */
 export interface BrickConnectorCoords {
     /** Sequence-in connector centroid (top-edge groove). */
@@ -93,8 +93,22 @@ export interface BrickConnectorCoords {
     nestedNext?: Point;
     /** Output connector centroid (left-edge tab). */
     output?: Point;
-    /** Argument-slot connector centroids (right-edge grooves), one per filled slot. */
-    inputs: Point[];
+    /** Argument-slot connector centroids (right-edge grooves), one per slot. */
+    inputs: BrickInputConnector[];
+}
+
+/**
+ * One argument-slot input connector: its centroid plus which slot it belongs to and
+ * whether that slot currently holds a child. Emitted for every slot — filled and empty —
+ * so empty slots can be queried as snap targets.
+ */
+export interface BrickInputConnector {
+    /** Connector centroid (right-edge groove). */
+    point: Point;
+    /** Slot's declaration-order index. */
+    index: number;
+    /** Whether the slot currently holds a child. */
+    filled: boolean;
 }
 
 export interface BrickMinimums {

--- a/modules/masonry/src/components/Path/Path.tsx
+++ b/modules/masonry/src/components/Path/Path.tsx
@@ -177,8 +177,8 @@ export function PathBrickView({ input }: { input: BrickOutlineInput }) {
         {connectors.inputs.map((p, i) => (
           <circle
             key={i}
-            cx={svgToPx(p.x)}
-            cy={svgToPx(p.y)}
+            cx={svgToPx(p.point.x)}
+            cy={svgToPx(p.point.y)}
             r={MARKER_RADIUS}
             fill={CONNECTOR_COLORS.inputs}
             stroke="#fff"

--- a/modules/masonry/src/hooks/useBrickMove.ts
+++ b/modules/masonry/src/hooks/useBrickMove.ts
@@ -92,9 +92,10 @@ function resolveSnap(
     if (best === null) return null;
     const snap = best;
 
-    // A dragged `nestedNext` is never an approved mate; narrow to a 'prev' | 'next' with no cast so
-    // `joinTowers` only ever receives a `DraggedKind`.
-    if (snap.draggedKind === 'nestedNext') return null;
+    // Only a dragged `prev`/`next` is an approved mate (a `nestedNext` or an argument-domain
+    // `input`/`output` is not); narrow to a 'prev' | 'next' with no cast so `joinTowers` only ever
+    // receives a `DraggedKind`.
+    if (snap.draggedKind !== 'prev' && snap.draggedKind !== 'next') return null;
     const draggedKind: DraggedKind = snap.draggedKind;
 
     const draggedRoot = tower.root;

--- a/modules/masonry/src/models/brick.test.ts
+++ b/modules/masonry/src/models/brick.test.ts
@@ -106,7 +106,30 @@ describe('BrickModelBase.getConnectorCoords', () => {
 
         // Single filled slot: first-row groove y = H_NOTCH_OFFSET_Y (svg) * brickScale (=1 here).
         expect(coords.inputs).toHaveLength(1);
-        expect(coords.inputs[0]!.y).toBeCloseTo(
+        expect(coords.inputs[0]!.index).toBe(0);
+        expect(coords.inputs[0]!.filled).toBe(true);
+        expect(coords.inputs[0]!.point.y).toBeCloseTo(
+            H_NOTCH_OFFSET_Y * SCALE_LEVEL_CONFIG[2].brickScale,
+        );
+    });
+
+    it('emits an empty input slot for a param with no argument', () => {
+        const brick = new StatementBrickModel({
+            colorsDefault,
+            tooltipText: '',
+            widget: { type: 'label', text: 'St' },
+            scaleLevel: 2,
+            params: ['A'],
+            argDims: [null],
+        });
+
+        const coords = brick.getConnectorCoords();
+
+        // The slot is declared but holds no child: still emitted, tagged empty at index 0.
+        expect(coords.inputs).toHaveLength(1);
+        expect(coords.inputs[0]!.index).toBe(0);
+        expect(coords.inputs[0]!.filled).toBe(false);
+        expect(coords.inputs[0]!.point.y).toBeCloseTo(
             H_NOTCH_OFFSET_Y * SCALE_LEVEL_CONFIG[2].brickScale,
         );
     });

--- a/modules/masonry/src/models/brick.ts
+++ b/modules/masonry/src/models/brick.ts
@@ -111,7 +111,8 @@ abstract class BrickModelBase {
      * returns unscaled SVG-space coords; each Point is multiplied by `brickScale` here.
      *
      * Optional connectors (prev/next/nestedNext/output) are present only when their feature is
-     * enabled; `inputs` is always an array with one entry per filled argument slot, top-to-bottom.
+     * enabled; `inputs` is always an array with one entry per argument slot (filled and empty),
+     * top-to-bottom, tagged with the slot index and its filled state.
      */
     public getConnectorCoords(): BrickConnectorCoords {
         const raw = this.outlineGenerator.getConnectorCoords(this._buildOutlineInput());
@@ -119,7 +120,13 @@ abstract class BrickModelBase {
             x: this.svgToPx(point.x),
             y: this.svgToPx(point.y),
         });
-        const scaled: BrickConnectorCoords = { inputs: raw.inputs.map(scalePoint) };
+        const scaled: BrickConnectorCoords = {
+            inputs: raw.inputs.map((s) => ({
+                point: scalePoint(s.point),
+                index: s.index,
+                filled: s.filled,
+            })),
+        };
         if (raw.prev) scaled.prev = scalePoint(raw.prev);
         if (raw.next) scaled.next = scalePoint(raw.next);
         if (raw.nestedNext) scaled.nestedNext = scalePoint(raw.nestedNext);

--- a/modules/masonry/src/stores/snap.test.ts
+++ b/modules/masonry/src/stores/snap.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import type { Point } from '@/@types/common.types';
-import type { TowerStatementNode } from '@/@types/tower.types';
-import { StatementBrickModel } from '@/models/brick';
-import { collectConnectors, type OpenConnector } from '@/utils/connectors';
+import type { TowerStatementNode, TowerValueNode } from '@/@types/tower.types';
+import { StatementBrickModel, ValueBrickModel } from '@/models/brick';
+import { collectArgConnectors, collectConnectors, type OpenConnector } from '@/utils/connectors';
 
 import { useBrickLayoutStore } from './brick';
 import { getSnapEngine, refreshSnapTargets } from './snap';
@@ -125,6 +125,70 @@ describe('stores/snap', () => {
             expect(hit).not.toBeNull();
             expect(hit!.targetNodeId).toBe('head');
             expect(hit!.target.occupied).toBe(true);
+        });
+
+        it('adds argument connectors to the target set without disturbing statement snapping', () => {
+            // A statement carrying one value arg, so the tower exposes argument-domain connectors
+            // (the slot input + the value's output) alongside its statement-sequence connectors.
+            const child: TowerValueNode = {
+                kind: 'value',
+                model: new ValueBrickModel({
+                    id: 'C',
+                    colorsDefault,
+                    tooltipText: '',
+                    widget: { type: 'numberbox', value: 0 },
+                }),
+                parent: null,
+            };
+            const host: TowerStatementNode = {
+                kind: 'statement',
+                model: new StatementBrickModel({
+                    id: 'H',
+                    colorsDefault,
+                    tooltipText: '',
+                    widget: { type: 'label', text: 'H' },
+                    params: ['A'],
+                    hasConnectionPrev: true,
+                    hasConnectionNext: true,
+                    hasNesting: false,
+                }),
+                prev: null,
+                next: null,
+                args: [child],
+                nestedNext: undefined,
+            };
+            child.parent = host;
+
+            const pos: Point = { x: 300, y: 300 };
+            useWorkspaceStore.setState({
+                towers: { host: { id: 'host', root: host, position: pos } },
+            });
+            useBrickLayoutStore.getState().setCoords({ H: pos, C: { x: 420, y: 300 } });
+
+            const coords = useBrickLayoutStore.getState().coords;
+            const origin: Point = { x: 0, y: 0 };
+            const args = collectArgConnectors(host, origin, coords, 'host');
+            // Sanity: the tower really does expose argument connectors that must reach the space.
+            expect(args.some((c) => c.kind === 'output')).toBe(true);
+            expect(args.some((c) => c.kind === 'input')).toBe(true);
+
+            const hostNext = collectConnectors(host, origin, coords, 'host').find(
+                (c) => c.kind === 'next',
+            )!;
+            const valueOutput = args.find((c) => c.kind === 'output')!;
+
+            const engine = getSnapEngine(1000, 1000);
+            refreshSnapTargets('dragged');
+
+            // Statement snapping still resolves against the arg-bearing tower.
+            const hit = engine.findSnap(probe('prev', hostNext.point));
+            expect(hit).not.toBeNull();
+            expect(hit!.targetNodeId).toBe('H');
+            expect(hit!.targetKind).toBe('next');
+
+            // Argument connectors are in the space but never cross-match a statement probe
+            // (isValidMate rejects the argument domain until join lands), so no false snap.
+            expect(engine.findSnap(probe('prev', valueOutput.point))).toBeNull();
         });
     });
 });

--- a/modules/masonry/src/stores/snap.ts
+++ b/modules/masonry/src/stores/snap.ts
@@ -1,4 +1,9 @@
-import { collectConnectors, ORIGIN, type Connector } from '@/utils/connectors';
+import {
+    collectArgConnectors,
+    collectConnectors,
+    ORIGIN,
+    type Connector,
+} from '@/utils/connectors';
 import { SnapEngine } from '@/utils/snap';
 
 import { useBrickLayoutStore } from './brick';
@@ -36,8 +41,9 @@ export function getSnapEngine(width: number, height: number): SnapEngine {
 
 /**
  * Rebuilds the shared engine's target set from every tower EXCEPT the dragged one (so a tower can
- * never snap to itself), using live coords from the brick layout store. Targets include open and
- * occupied connectors so mid-chain insertion is reachable. No-ops if the engine does not exist yet.
+ * never snap to itself), using live coords from the brick layout store. Targets include both
+ * statement-sequence and argument-slot connectors, open and occupied, so mid-chain insertion and
+ * arg snapping are both reachable. No-ops if the engine does not exist yet.
  */
 export function refreshSnapTargets(draggedTowerId: string): void {
     if (engine === null) return;
@@ -48,7 +54,10 @@ export function refreshSnapTargets(draggedTowerId: string): void {
     const targets: Connector[] = [];
     for (const tower of Object.values(towers)) {
         if (tower.id === draggedTowerId) continue;
+        // Both snapping domains share one engine: statement-sequence connectors and argument-slot
+        // connectors go into the same target set. isValidMate keeps the domains from cross-matching.
         targets.push(...collectConnectors(tower.root, ORIGIN, coords, tower.id));
+        targets.push(...collectArgConnectors(tower.root, ORIGIN, coords, tower.id));
     }
 
     engine.setTargets(targets);

--- a/modules/masonry/src/utils/brick-shape.test.ts
+++ b/modules/masonry/src/utils/brick-shape.test.ts
@@ -744,9 +744,11 @@ describe('getConnectorCoords', () => {
         expect(full.nestedNext).toBeDefined();
         expect(full.output).toBeDefined();
         expect(full.inputs).toHaveLength(1);
+        expect(full.inputs[0]!.index).toBe(0);
+        expect(full.inputs[0]!.filled).toBe(true);
     });
 
-    it('inputs has one entry per filled arg slot, ordered top-to-bottom', () => {
+    it('inputs has one entry per slot (filled and empty), ordered top-to-bottom', () => {
         const paramArgDims = [
             { param: null, arg: { w: 50, h: 40 } },
             { param: { w: 50, h: 20 }, arg: null },
@@ -758,13 +760,33 @@ describe('getConnectorCoords', () => {
             paramArgDims,
         });
 
-        // Derive the expected count from the input itself — param-only rows contribute nothing.
-        const expected = paramArgDims.filter((r) => r.arg !== null).length;
-        expect(inputs).toHaveLength(expected);
-        expect(expected).toBe(2);
+        // One entry per slot now — the middle param-only row is emitted as an empty slot.
+        expect(inputs).toHaveLength(paramArgDims.length);
+        expect(inputs.map((s) => s.index)).toEqual([0, 1, 2]);
+        expect(inputs.map((s) => s.filled)).toEqual([true, false, true]);
 
         // Ordered top-to-bottom: y values strictly increasing.
-        expect(inputs[1]!.y).toBeGreaterThan(inputs[0]!.y);
+        expect(inputs[1]!.point.y).toBeGreaterThan(inputs[0]!.point.y);
+        expect(inputs[2]!.point.y).toBeGreaterThan(inputs[1]!.point.y);
+    });
+
+    it('an empty arg slot is emitted with filled:false at the right y', () => {
+        const paramArgDims = [
+            { param: null, arg: { w: 50, h: 40 } },
+            { param: { w: 50, h: 20 }, arg: null },
+        ];
+        const { inputs } = brickOutlineGenerator.getConnectorCoords({
+            strokeWidth,
+            widgetDims: { w: 100, h: 20 },
+            paramArgDims,
+        });
+
+        // The second slot holds no child: still emitted, tagged empty, seated one row down.
+        const empty = inputs[1]!;
+        expect(empty.filled).toBe(false);
+        expect(empty.index).toBe(1);
+        const firstRowH = Math.max(40, MINIMUMS.minArgHeight);
+        expect(empty.point.y).toBe(firstRowH + BrickOutlineGeneratorTest.H_NOTCH_OFFSET_Y);
     });
 
     it('inputs align with the rendered arg grooves from generate()', () => {
@@ -780,13 +802,15 @@ describe('getConnectorCoords', () => {
         const { bounds, width } = brickOutlineGenerator.generate(input);
         const argGrooves = bounds.args!.filter((a): a is NonNullable<typeof a> => a !== null);
 
-        inputs.forEach((p, k) => {
+        // Both slots are filled here, so every input entry lines up with a rendered groove.
+        const filled = inputs.filter((s) => s.filled);
+        filled.forEach((s, k) => {
             const a = argGrooves[k]!;
-            expect(p.y).toBe(a.y + BrickOutlineGeneratorTest.H_NOTCH_OFFSET_Y);
-            expect(p.x).toBe(a.x - strokeWidth / 2);
+            expect(s.point.y).toBe(a.y + BrickOutlineGeneratorTest.H_NOTCH_OFFSET_Y);
+            expect(s.point.x).toBe(a.x - strokeWidth / 2);
         });
         // Grooves sit at the right edge (x = width); the connector is inset by half the stroke.
-        expect(inputs[0]!.x).toBe(width - strokeWidth / 2);
+        expect(inputs[0]!.point.x).toBe(width - strokeWidth / 2);
     });
 
     it("next connector sits on the brick's bottom edge (height branch)", () => {
@@ -854,7 +878,7 @@ describe('getConnectorCoords', () => {
             widgetDims: { w: 100, h: 20 },
             paramArgDims: [{ param: null, arg: { w: 50, h: 40 } }],
         };
-        const parentInput = brickOutlineGenerator.getConnectorCoords(parent).inputs[0]!;
+        const parentInput = brickOutlineGenerator.getConnectorCoords(parent).inputs[0]!.point;
         const parentArg = brickOutlineGenerator.generate(parent).bounds.args![0]!;
 
         const output = brickOutlineGenerator.getConnectorCoords({
@@ -882,7 +906,7 @@ describe('getConnectorCoords', () => {
         };
         const { width, height } = brickOutlineGenerator.generate(input);
         const c = brickOutlineGenerator.getConnectorCoords(input);
-        const pts = [c.prev!, c.next!, c.nestedNext!, c.output!, ...c.inputs];
+        const pts = [c.prev!, c.next!, c.nestedNext!, c.output!, ...c.inputs.map((s) => s.point)];
 
         pts.forEach((p) => {
             expect(p.x).toBeGreaterThanOrEqual(0);

--- a/modules/masonry/src/utils/brick-shape.ts
+++ b/modules/masonry/src/utils/brick-shape.ts
@@ -33,6 +33,7 @@
 import type {
     BrickComputedDimensions,
     BrickConnectorCoords,
+    BrickInputConnector,
     BrickMinimums,
     BrickOutlineInput,
     BrickOutlineOutput,
@@ -883,7 +884,8 @@ export class BrickOutlineGenerator {
      * unscaled SVG space as `generate`'s path/bounds and relative to the brick's top-left origin.
      *
      * Optional connectors (prev/next/nestedNext/output) are present only when their feature is
-     * enabled; `inputs` is always an array with one entry per filled argument slot, top-to-bottom.
+     * enabled; `inputs` is always an array with one entry per argument slot (filled and empty),
+     * top-to-bottom, tagged with the slot index and its filled state.
      *
      * @param input - Same input shape as `generate` / `computeDimensions`.
      * @returns Connector centroids, keyed by connector kind.
@@ -900,19 +902,23 @@ export class BrickOutlineGenerator {
         const { width, headHeight, height } = this.dimensions;
         const { hasPrevNotch, hasNextNotch, hasNesting, hasOutputNotch } = this.input;
 
-        // Right-edge grooves: one centroid per filled arg slot, using the same slotTop
-        // accumulation as segHeadRight so the coords line up with the rendered grooves.
-        const inputs: Point[] = [];
+        // Right-edge grooves: one centroid per arg slot (filled and empty), using the same
+        // slotTop accumulation as segHeadRight so the coords line up with the rendered grooves.
+        const inputs: BrickInputConnector[] = [];
         let slotTop = 0;
+        let index = 0;
         for (const { arg } of this.input.paramArgDims) {
             const rowH = Math.max(arg?.h ?? 0, this.minimums.minArgHeight);
-            if (arg !== null) {
-                inputs.push({
+            inputs.push({
+                point: {
                     x: width - strokeWidth / 2,
                     y: slotTop + BrickOutlineGenerator.H_NOTCH_OFFSET_Y,
-                });
-            }
+                },
+                index,
+                filled: arg !== null,
+            });
             slotTop += rowH;
+            index += 1;
         }
 
         const coords: BrickConnectorCoords = { inputs };

--- a/modules/masonry/src/utils/connectors.test.ts
+++ b/modules/masonry/src/utils/connectors.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Point } from '@/@types/common.types';
-import type { TowerNode, TowerStatementNode } from '@/@types/tower.types';
-import { StatementBrickModel } from '@/models/brick';
+import type {
+    TowerExpressionNode,
+    TowerNode,
+    TowerStatementNode,
+    TowerValueNode,
+} from '@/@types/tower.types';
+import { ExpressionBrickModel, StatementBrickModel, ValueBrickModel } from '@/models/brick';
 import { statementTreeNoNesting, statementTreeWithNesting, valueTree } from '@/mocks/tower';
 
 import {
+    collectArgConnectors,
     collectConnectors,
     collectOpenConnectors,
     collectProbeConnectors,
@@ -337,5 +343,135 @@ describe('collectProbeConnectors', () => {
     it('returns nothing for a non-statement root', () => {
         const coords: Record<string, Point> = { [valueTree.model.id]: { x: 0, y: 0 } };
         expect(collectProbeConnectors(valueTree, { x: 0, y: 0 }, coords, 't')).toEqual([]);
+    });
+});
+
+/** A free-floating value node; pass a parent to mark it plugged in. */
+function makeValue(id: string, parent: TowerNode | null = null): TowerValueNode {
+    return {
+        kind: 'value',
+        model: new ValueBrickModel({
+            id,
+            colorsDefault,
+            tooltipText: '',
+            widget: { type: 'numberbox', value: 0 },
+        }),
+        parent,
+    };
+}
+
+/** An expression node with `params.length` argument slots, all empty unless `args` is supplied. */
+function makeExpression(
+    id: string,
+    params: [string | null, ...(string | null)[]],
+    args?: (TowerNode | null)[],
+): TowerExpressionNode {
+    return {
+        kind: 'expression',
+        model: new ExpressionBrickModel({
+            id,
+            colorsDefault,
+            tooltipText: '',
+            widget: { type: 'label', text: id },
+            params,
+        }),
+        parent: null,
+        args: args ?? params.map(() => null),
+    };
+}
+
+describe('collectArgConnectors', () => {
+    it('emits one input per slot with correct slotIndex, occupancy, and world point', () => {
+        // Two slots: slot 0 holds a child (occupied), slot 1 is empty (open).
+        const expr = makeExpression('E', ['A', 'B']);
+        const child = makeValue('E.child', expr);
+        expr.args = [child, null];
+
+        const origin: Point = { x: 5, y: 7 };
+        const topLeft: Point = { x: 40, y: 400 };
+        const coords: Record<string, Point> = { 'E': topLeft, 'E.child': { x: 60, y: 400 } };
+
+        const result = collectArgConnectors(expr, origin, coords, 'tower-1');
+        const inputs = result.filter((c) => c.kind === 'input');
+        const offsets = expr.model.getConnectorCoords();
+
+        expect(inputs).toHaveLength(2);
+        expect(offsets.inputs).toHaveLength(2);
+
+        const slot0 = inputs.find((c) => c.slotIndex === 0)!;
+        expect(slot0).toBeDefined();
+        expect(slot0.towerId).toBe('tower-1');
+        expect(slot0.nodeId).toBe('E');
+        expect(slot0.occupied).toBe(true); // node.args[0] is the child
+        expect(slot0.point).toEqual({
+            x: origin.x + topLeft.x + offsets.inputs[0].point.x,
+            y: origin.y + topLeft.y + offsets.inputs[0].point.y,
+        });
+
+        const slot1 = inputs.find((c) => c.slotIndex === 1)!;
+        expect(slot1.occupied).toBe(false); // node.args[1] is null
+        expect(slot1.point).toEqual({
+            x: origin.x + topLeft.x + offsets.inputs[1].point.x,
+            y: origin.y + topLeft.y + offsets.inputs[1].point.y,
+        });
+    });
+
+    it('derives input occupancy from the node graph, not the model filled flag', () => {
+        // args say occupied, but argDims (model filled flag) are left empty — the graph wins.
+        const expr = makeExpression('E', ['A']);
+        expr.args = [makeValue('E.child', expr)];
+        const result = collectArgConnectors(expr, { x: 0, y: 0 }, { E: { x: 0, y: 0 } }, 't');
+
+        const input = result.filter((c) => c.kind === 'input');
+        expect(input).toHaveLength(1);
+        expect(input[0].occupied).toBe(true);
+        expect(expr.model.getConnectorCoords().inputs[0].filled).toBe(false);
+    });
+
+    it('emits an output for a value brick, occupancy reflecting its parent', () => {
+        const free = makeValue('V');
+        const freeResult = collectArgConnectors(free, { x: 3, y: 9 }, { V: { x: 10, y: 20 } }, 't');
+        expect(freeResult).toHaveLength(1);
+
+        const output = freeResult[0];
+        const offsets = free.model.getConnectorCoords();
+        expect(output.kind).toBe('output');
+        expect(output.occupied).toBe(false); // parent === null
+        expect(output.slotIndex).toBeUndefined();
+        expect(output.point).toEqual({
+            x: 3 + 10 + offsets.output!.x,
+            y: 9 + 20 + offsets.output!.y,
+        });
+
+        // A value plugged into a parent reports its output as occupied.
+        const parent = makeExpression('P', ['A']);
+        const plugged = makeValue('P.child', parent);
+        parent.args = [plugged];
+        const pluggedResult = collectArgConnectors(
+            plugged,
+            { x: 0, y: 0 },
+            { 'P.child': { x: 0, y: 0 } },
+            't',
+        );
+        expect(pluggedResult).toHaveLength(1);
+        expect(pluggedResult[0].occupied).toBe(true);
+    });
+
+    it('emits BOTH the output and the input slots of an expression brick', () => {
+        const expr = makeExpression('E', ['A', 'B']);
+        const result = collectArgConnectors(expr, { x: 0, y: 0 }, { E: { x: 0, y: 0 } }, 't');
+
+        const inputs = result.filter((c) => c.kind === 'input');
+        const outputs = result.filter((c) => c.kind === 'output');
+        expect(inputs).toHaveLength(2);
+        expect(outputs).toHaveLength(1);
+        // Its own output is open (no parent), both slots open (no args).
+        expect(outputs[0].occupied).toBe(false);
+        expect(inputs.every((c) => !c.occupied)).toBe(true);
+    });
+
+    it('skips nodes whose top-left coordinate is missing from the coords map', () => {
+        const expr = makeExpression('E', ['A']);
+        expect(collectArgConnectors(expr, { x: 0, y: 0 }, {}, 't')).toEqual([]);
     });
 });

--- a/modules/masonry/src/utils/connectors.ts
+++ b/modules/masonry/src/utils/connectors.ts
@@ -13,10 +13,13 @@ import { findTail, listNodes } from './tower-traversal';
 export const ORIGIN: Point = { x: 0, y: 0 };
 
 /**
- * Statement-domain connector kinds that participate in sequence snapping. Argument-domain
- * `inputs`/`output` connectors are handled separately and are out of scope here.
+ * Every connector kind a tower can expose, across both snapping domains:
+ *   - Statement domain (sequence snapping): `prev` | `next` | `nestedNext`.
+ *   - Argument domain (arg snapping): `output` — the left-edge tab on a value/expression brick that
+ *     plugs into a parent's argument slot; `input` — an argument slot on an expression/statement
+ *     brick that accepts such a tab.
  */
-export type ConnectorKind = 'prev' | 'next' | 'nestedNext';
+export type ConnectorKind = 'prev' | 'next' | 'nestedNext' | 'output' | 'input';
 
 /**
  * An OPEN connector on a tower, resolved into absolute canvas (world) space. "Open" means the
@@ -34,6 +37,11 @@ export interface OpenConnector {
     kind: ConnectorKind;
     /** Connector centroid in absolute canvas (world) pixels. */
     point: Point;
+    /**
+     * Present only on `input` connectors: the declaration-order index of the argument slot, used to
+     * resolve the connector back to `node.args[slotIndex]`.
+     */
+    slotIndex?: number;
 }
 
 /**
@@ -126,6 +134,77 @@ export function collectConnectors(
                 point: toWorld(origin, topLeft, offsets.nestedNext),
                 occupied: node.nestedNext !== null,
             });
+        }
+    }
+
+    return connectors;
+}
+
+/**
+ * Collects every argument-domain connector in a tower (open AND occupied), resolved to absolute
+ * canvas space, so the result is suitable as the SNAP TARGET set for arg snapping. Mirrors
+ * {@link collectConnectors} but over the argument domain:
+ *   - `input`  — one per argument slot on an expression/statement node (filled and empty), tagged
+ *                with its `slotIndex`; occupied when `node.args[slotIndex]` already holds a child.
+ *   - `output` — the left-edge tab on a value/expression node; occupied when the node already has a
+ *                `parent`.
+ *
+ * Both open and occupied connectors are emitted — #698 populates the space with ALL argument
+ * connectors; filtering to empty slots is the join step's concern.
+ *
+ * Pure: the caller supplies per-brick top-lefts via `coords`; this never reads a store. A
+ * connector's world point is the sum of three offsets:
+ *   `origin` + brick top-left px (`coords[nodeId]`) + connector px offset (`getConnectorCoords()`)
+ *
+ * Occupancy is derived from the NODE GRAPH (`node.args` / `node.parent`), the authoritative source,
+ * not from the model's `filled` flag. A node missing from `coords` is skipped (it cannot be placed
+ * in world space yet).
+ *
+ * @param root    - Root node of the tower tree.
+ * @param origin  - The tower's origin in canvas px; every connector is measured relative to it.
+ * @param coords  - Map of brick id → the brick's top-left position in canvas px.
+ * @param towerId - Id of the tower, passed through onto every emitted connector.
+ */
+export function collectArgConnectors(
+    root: TowerNode,
+    origin: Point,
+    coords: Record<string, Point>,
+    towerId: string,
+): Connector[] {
+    const connectors: Connector[] = [];
+
+    for (const node of listNodes(root)) {
+        const topLeft = coords[node.model.id];
+        if (!topLeft) continue;
+
+        const offsets = node.model.getConnectorCoords();
+
+        // input grooves — one per argument slot; occupied when the slot already holds a child.
+        if (node.kind === 'expression' || node.kind === 'statement') {
+            for (const input of offsets.inputs) {
+                connectors.push({
+                    towerId,
+                    nodeId: node.model.id,
+                    kind: 'input',
+                    point: toWorld(origin, topLeft, input.point),
+                    slotIndex: input.index,
+                    occupied: node.args[input.index] !== null,
+                });
+            }
+        }
+
+        // output tab — present only when the node can produce a value; occupied when already plugged
+        // into a parent.
+        if (node.kind === 'value' || node.kind === 'expression') {
+            if (offsets.output) {
+                connectors.push({
+                    towerId,
+                    nodeId: node.model.id,
+                    kind: 'output',
+                    point: toWorld(origin, topLeft, offsets.output),
+                    occupied: node.parent !== null,
+                });
+            }
         }
     }
 


### PR DESCRIPTION
- **#698 | feat(masonry): emit empty argument-slot input connector coords**
- **#698 | feat(masonry): add all Argument connector points in the Collision space**
