### PR TITLE
fix:Set prettier end0fline to auto to prevent windows CRLF warnings

### DIFF
--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -9,7 +9,7 @@ export default {
     trailingComma: 'all',
     bracketSpacing: true,
     arrowParens: 'always',
-    endOfLine: 'lf',
+    endOfLine: 'auto',
     overrides: [
         {
             files: ['*.json', '*.jsonc', '*.yml', '*.html', '*.css', '*.scss', '*.tsx'],


### PR DESCRIPTION
Hi maintainers! 

This pull request resolves #518. On Windows systems, developers frequently encounter thousands of noisy `Delete ␍` formatting warnings because Prettier was strictly enforcing `lf` line endings while Git automatically checks files out as `crlf`.

I have updated `prettier.config.mjs` to use `endOfLine: 'auto'`. This safely instructs the formatting rules to accept the line endings of whatever native operating system the developer is currently contributing on, completely clearing out the warning clutter for Windows environment logs.
