### PR TITLE
#352 | test(code-builder): add unit tests for collision detection

### DIFF
--- a/modules/code-builder/src/collision/spec/Brute.spec.ts
+++ b/modules/code-builder/src/collision/spec/Brute.spec.ts
@@ -1,0 +1,65 @@
+import CollisionSpaceBrute from '../Brute';
+
+describe('Code Builder: Collision > Space (Brute)', () => {
+    let space: CollisionSpaceBrute;
+
+    beforeEach(() => {
+        space = new CollisionSpaceBrute(100, 100);
+    });
+
+    it('adds objects inside bounds and filters out out-of-bounds ones', () => {
+        const inside = { id: 'inside', x: 50, y: 50, width: 10, height: 10 };
+        const left = { id: 'left', x: 5, y: 50, width: 10, height: 10 };
+        const right = { id: 'right', x: 95, y: 50, width: 10, height: 10 };
+
+        space.addObjects([inside, left, right]);
+
+        const colliding = space.checkCollision({
+            id: 'test',
+            x: 50,
+            y: 50,
+            width: 100,
+            height: 100,
+        });
+        expect(colliding).toContain('inside');
+        expect(colliding).not.toContain('left');
+        expect(colliding).not.toContain('right');
+    });
+
+    it('removes objects by ID', () => {
+        const obj1 = { id: '1', x: 50, y: 50, width: 10, height: 10 };
+        const obj2 = { id: '2', x: 60, y: 60, width: 10, height: 10 };
+
+        space.addObjects([obj1, obj2]);
+        space.delObjects([obj1]);
+
+        const colliding = space.checkCollision({
+            id: 'test',
+            x: 50,
+            y: 50,
+            width: 100,
+            height: 100,
+        });
+        expect(colliding).toEqual(['2']);
+    });
+
+    it('respects collision options and thresholds', () => {
+        const obj = { id: '1', x: 50, y: 50, width: 10, height: 10 };
+        space.addObjects([obj]);
+        space.setOptions({ objType: 'rect', colThres: 0.5 });
+
+        const checkA = { id: 'checkA', x: 54, y: 50, width: 10, height: 10 };
+        const checkB = { id: 'checkB', x: 56, y: 50, width: 10, height: 10 };
+
+        expect(space.checkCollision(checkA)).toContain('1');
+        expect(space.checkCollision(checkB)).not.toContain('1');
+    });
+
+    it('clears all objects on reset', () => {
+        const obj = { id: '1', x: 50, y: 50, width: 10, height: 10 };
+        space.addObjects([obj]);
+        space.reset();
+
+        expect(space.checkCollision(obj)).toEqual([]);
+    });
+});

--- a/modules/code-builder/src/collision/spec/QuadTree.spec.ts
+++ b/modules/code-builder/src/collision/spec/QuadTree.spec.ts
@@ -1,0 +1,65 @@
+import CollisionSpaceQuadTree from '../QuadTree';
+
+describe('Code Builder: Collision > Space (QuadTree)', () => {
+    let space: CollisionSpaceQuadTree;
+
+    beforeEach(() => {
+        space = new CollisionSpaceQuadTree(100, 100);
+    });
+
+    it('adds objects inside bounds and filters out out-of-bounds ones', () => {
+        const inside = { id: 'inside', x: 50, y: 50, width: 10, height: 10 };
+        const left = { id: 'left', x: 5, y: 50, width: 10, height: 10 };
+        const right = { id: 'right', x: 95, y: 50, width: 10, height: 10 };
+
+        space.addObjects([inside, left, right]);
+
+        const colliding = space.checkCollision({
+            id: 'test',
+            x: 50,
+            y: 50,
+            width: 100,
+            height: 100,
+        });
+        expect(colliding).toContain('inside');
+        expect(colliding).not.toContain('left');
+        expect(colliding).not.toContain('right');
+    });
+
+    it('removes objects by ID', () => {
+        const obj1 = { id: '1', x: 50, y: 50, width: 10, height: 10 };
+        const obj2 = { id: '2', x: 60, y: 60, width: 10, height: 10 };
+
+        space.addObjects([obj1, obj2]);
+        space.delObjects([obj1]);
+
+        const colliding = space.checkCollision({
+            id: 'test',
+            x: 50,
+            y: 50,
+            width: 100,
+            height: 100,
+        });
+        expect(colliding).toEqual(['2']);
+    });
+
+    it('respects collision options and thresholds', () => {
+        const obj = { id: '1', x: 50, y: 50, width: 10, height: 10 };
+        space.addObjects([obj]);
+        space.setOptions({ objType: 'rect', colThres: 0.5 });
+
+        const checkA = { id: 'checkA', x: 54, y: 50, width: 10, height: 10 };
+        const checkB = { id: 'checkB', x: 56, y: 50, width: 10, height: 10 };
+
+        expect(space.checkCollision(checkA)).toContain('1');
+        expect(space.checkCollision(checkB)).not.toContain('1');
+    });
+
+    it('clears all objects on reset', () => {
+        const obj = { id: '1', x: 50, y: 50, width: 10, height: 10 };
+        space.addObjects([obj]);
+        space.reset();
+
+        expect(space.checkCollision(obj)).toEqual([]);
+    });
+});

--- a/modules/code-builder/src/collision/spec/index.spec.ts
+++ b/modules/code-builder/src/collision/spec/index.spec.ts
@@ -1,0 +1,66 @@
+import { checkCollision } from '../utils';
+import type { TCollisionObject } from '../../@types/collision';
+
+describe('Code Builder: Collision > Utility', () => {
+    const objA: TCollisionObject = { id: 'A', x: 10, y: 10, width: 10, height: 10 };
+
+    describe('circle collision', () => {
+        const testCases = [
+            { label: 'detects overlap', x: 14, y: 10, threshold: 0, expected: true },
+            { label: 'ignores separation', x: 25, y: 10, threshold: 0, expected: false },
+            {
+                label: 'applies threshold (not overlapping enough)',
+                x: 16,
+                y: 10,
+                threshold: 0.5,
+                expected: false,
+            },
+            {
+                label: 'applies threshold (overlapping enough)',
+                x: 16,
+                y: 10,
+                threshold: 0.2,
+                expected: true,
+            },
+        ];
+
+        testCases.forEach(({ label, x, y, threshold, expected }) => {
+            it(label, () => {
+                const objB = { id: 'B', x, y, width: 10, height: 10 };
+                expect(checkCollision(objA, objB, { objType: 'circle', colThres: threshold })).toBe(
+                    expected,
+                );
+            });
+        });
+    });
+
+    describe('rectangle collision', () => {
+        const testCases = [
+            { label: 'detects overlap', x: 14, y: 10, threshold: 0, expected: true },
+            { label: 'ignores separation', x: 25, y: 10, threshold: 0, expected: false },
+            {
+                label: 'applies threshold (overlapping enough)',
+                x: 14,
+                y: 10,
+                threshold: 0.5,
+                expected: true,
+            },
+            {
+                label: 'applies threshold (not overlapping enough)',
+                x: 14,
+                y: 10,
+                threshold: 0.7,
+                expected: false,
+            },
+        ];
+
+        testCases.forEach(({ label, x, y, threshold, expected }) => {
+            it(label, () => {
+                const objB = { id: 'B', x, y, width: 10, height: 10 };
+                expect(checkCollision(objA, objB, { objType: 'rect', colThres: threshold })).toBe(
+                    expected,
+                );
+            });
+        });
+    });
+});


### PR DESCRIPTION
### Description
Adds unit tests for the collision detection logic in the `code-builder` module to cover:
- Core circle and rectangle overlap utilities (`utils/index.ts`)
- Brute force collision space implementation (`Brute.ts`)
- Quadtree-based collision space implementation (`QuadTree.ts`)

### Related Issue
Closes #352

### Verification
- Ran `npx vitest run modules/code-builder` and verified all 42 tests pass.
- Verified linter (`npm run lint`) passes.
