### PR TITLE
#509 | feat(editor): add hover text label to editor toggle button

### DIFF
--- a/@types/components/editor.d.ts
+++ b/@types/components/editor.d.ts
@@ -2,7 +2,7 @@ import type { TAsset } from '../assets';
 
 export type TInjectedEditor = {
     flags: undefined;
-    i18n: Record<'editor.build' | 'editor.help', string>;
+    i18n: Record<'editor.build' | 'editor.help' | 'editor.toggle' | 'editor.close', string>;
     assets: Record<
         | 'image.icon.build'
         | 'image.icon.help'

--- a/app/src/components.ts
+++ b/app/src/components.ts
@@ -13,6 +13,8 @@ const manifest: TComponentManifest = {
             strings: {
                 'editor.build': 'build button - build the program',
                 'editor.help': 'help button - show syntax information',
+                'editor.toggle': 'editor button - toggle editor panel',
+                'editor.close': 'close button - close the editor panel',
             },
             assets: [
                 'image.icon.build',

--- a/lib/i18n/lang/en.ts
+++ b/lib/i18n/lang/en.ts
@@ -3,6 +3,8 @@ import type { TI18nFile } from '#/@types/i18n';
 const strings: TI18nFile = {
     'editor.build': 'build',
     'editor.help': 'help',
+    'editor.toggle': 'Editor',
+    'editor.close': 'Close',
 
     'menu.reset': 'reset',
     'menu.run': 'run',

--- a/lib/i18n/lang/es.ts
+++ b/lib/i18n/lang/es.ts
@@ -3,6 +3,8 @@ import type { TI18nFile } from '#/@types/i18n';
 const strings: TI18nFile = {
     'editor.build': 'construir',
     'editor.help': 'ayuda',
+    'editor.toggle': 'Editor',
+    'editor.close': 'Cerrar',
 
     'menu.reset': 'reiniciar',
     'menu.run': 'tocar',

--- a/modules/editor/src/view/components/button/index.scss
+++ b/modules/editor/src/view/components/button/index.scss
@@ -1,26 +1,71 @@
 @import '@res/themes/light';
 
 #editor-toolbar-btn {
+  position: relative;
+  display: grid;
+  justify-content: center;
+  align-items: center;
   padding: 0.25rem;
 
-  svg {
+  .editor-btn-label {
+    position: absolute;
+    z-index: 100;
+    left: calc(100% + 0.25rem);
+    display: none;
+    margin: 0;
+    padding: 0 0.375rem 0.125rem 0.25rem;
+    border-radius: 0 0.25rem 0.25rem 0;
+    background-color: $mb-accent-light;
+
+    &::before {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      display: block;
+      content: '';
+      width: 0.25rem;
+      transform: translateX(-100%);
+      clip-path: polygon(0 50%, 100% 0%, 100% 100%);
+      background-color: $mb-accent-light;
+    }
+
+    span {
+      font-size: 0.75rem;
+      font-weight: bold;
+      color: $text-light;
+    }
+  }
+
+  .editor-btn-img {
     width: 100%;
     height: 100%;
 
-    &.editor-toolbar-btn-img-hidden {
-      display: none;
-    }
+    svg {
+      width: 100%;
+      height: 100%;
 
-    .path-fill {
-      fill: $mb-accent;
-      transition: all 0.25s ease;
+      &.editor-toolbar-btn-img-hidden {
+        display: none;
+      }
+
+      .path-fill {
+        fill: $mb-accent;
+        transition: all 0.25s ease;
+      }
     }
   }
 
   &:hover {
-    svg {
-      .path-fill {
-        fill: $mb-accent-light;
+    .editor-btn-label {
+      display: block;
+    }
+
+    .editor-btn-img {
+      svg {
+        .path-fill {
+          fill: $mb-accent-light;
+        }
       }
     }
   }

--- a/modules/editor/src/view/components/button/index.tsx
+++ b/modules/editor/src/view/components/button/index.tsx
@@ -7,6 +7,8 @@ import './index.scss';
 // -- private variables ----------------------------------------------------------------------------
 
 let _container: HTMLElement;
+let _imgContainer: HTMLElement;
+let _labelSpan: HTMLElement;
 let _svgCode: string;
 let _svgClose: string;
 
@@ -20,6 +22,17 @@ export function setup(container: HTMLElement): void {
   container.id = 'editor-toolbar-btn';
   _container = container;
 
+  const labelEl = document.createElement('p');
+  labelEl.className = 'editor-btn-label';
+  _labelSpan = document.createElement('span');
+  _labelSpan.innerText = injected.i18n['editor.toggle'];
+  labelEl.appendChild(_labelSpan);
+  _container.appendChild(labelEl);
+
+  _imgContainer = document.createElement('div');
+  _imgContainer.className = 'editor-btn-img';
+  _container.appendChild(_imgContainer);
+
   _svgCode = injected.assets['image.icon.code'].data;
   _svgClose = injected.assets['image.icon.close'].data;
 
@@ -31,5 +44,9 @@ export function setup(container: HTMLElement): void {
  * @param icon icon name
  */
 export function setButtonImg(icon: 'code' | 'cross'): void {
-  _container.innerHTML = icon === 'code' ? _svgCode : _svgClose;
+  _imgContainer.innerHTML = icon === 'code' ? _svgCode : _svgClose;
+  if (_labelSpan) {
+    _labelSpan.innerText =
+      icon === 'code' ? injected.i18n['editor.toggle'] : injected.i18n['editor.close'];
+  }
 }


### PR DESCRIPTION
### Summary
Adds a hover text label to the Editor toggle button in the sidebar.

Fixes #509 

### Changes Made
- Updated i18n locale strings (`editor.toggle` and `editor.close`) for English and Spanish.
- Updated component manifest and `@types/components/editor.d.ts` types.
- Updated `button/index.tsx` to dynamically switch label text between "Editor" and "Close" based on the panel state.
- Added SCSS tooltip styling matching existing sidebar UI components.


### screenshots
<img width="414" height="183" alt="image" src="https://github.com/user-attachments/assets/40e259b8-654a-4c71-9899-fb1c991d166b" />
<img width="621" height="415" alt="image" src="https://github.com/user-attachments/assets/4329fc40-4e21-4938-b0de-efe8c3c12fcc" />
