### PR TITLE
#680 | feat(masonry): improve Palette interactions

### DIFF
--- a/modules/masonry/src/components/Palette/BrickSlot.tsx
+++ b/modules/masonry/src/components/Palette/BrickSlot.tsx
@@ -44,7 +44,7 @@ export function BrickSlot({ brick }: BrickSlotProps) {
         <div
           title={brick.description}
           data-brick-id={brick.id}
-          className="palette-brick-slot flex min-h-11 cursor-grab touch-none items-center px-1 py-1 transition-colors select-none hover:brightness-110 active:cursor-grabbing"
+          className="palette-brick-slot flex min-h-11 w-fit cursor-grab touch-none items-center px-1 py-1 transition-colors select-none hover:brightness-110 active:cursor-grabbing"
         >
           <div className="pointer-events-none">
             <BrickView {...viewProps} />

--- a/modules/masonry/src/components/Palette/Palette.test.tsx
+++ b/modules/masonry/src/components/Palette/Palette.test.tsx
@@ -5,7 +5,7 @@
 // Scope note: jsdom does no layout and does not implement scrollIntoView, so scroll-to is asserted
 // by spying on Element.prototype.scrollIntoView rather than checking real scroll position.
 
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { BrickViewProps } from '@/@types/brick.types';
@@ -113,6 +113,13 @@ const configSingle: PaletteConfig = {
 const search = (value: string) =>
   fireEvent.change(screen.getByPlaceholderText('Search bricks'), { target: { value } });
 
+/**
+ * Reads the flash marker off a category's header row. The heading is the queryable node;
+ * the marker sits on the row that wraps it alongside the icon.
+ */
+const flashState = (name: string) =>
+  screen.getByRole('heading', { name }).parentElement?.getAttribute('data-flashing') ?? null;
+
 // -------------------------------------------------------------------------------------------------
 
 describe('Palette', () => {
@@ -151,6 +158,14 @@ describe('Palette', () => {
       // Music is active by default; disambiguated from same-named headings via role='button'.
       expect(screen.getByRole('button', { name: 'Rhythm' })).toBeTruthy();
       expect(screen.getByRole('button', { name: 'Meter' })).toBeTruthy();
+    });
+
+    it('renders each sidebar category button with its name as a title attribute', () => {
+      render(<Palette config={config} />);
+
+      // The label is truncated when the sidebar is narrow, so the tooltip carries the full name.
+      expect(screen.getByRole('button', { name: 'Rhythm' }).getAttribute('title')).toBe('Rhythm');
+      expect(screen.getByRole('button', { name: 'Meter' }).getAttribute('title')).toBe('Meter');
     });
 
     it('renders a section heading (h3) for each active-classification category', () => {
@@ -235,6 +250,57 @@ describe('Palette', () => {
         behavior: 'smooth',
         block: 'start',
       });
+    });
+
+    it('flashes the target category header when its sidebar button is clicked', () => {
+      render(<Palette config={config} />);
+
+      expect(flashState('Meter')).toBeNull();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Meter' }));
+
+      // The list may already be scrolled to the end, where scrollIntoView is a no-op; the flash
+      // is what tells the user the click landed.
+      expect(flashState('Meter')).toBe('true');
+    });
+
+    it('clears the category header flash once it has elapsed', () => {
+      vi.useFakeTimers();
+      try {
+        render(<Palette config={config} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Meter' }));
+        expect(flashState('Meter')).toBe('true');
+
+        act(() => {
+          vi.advanceTimersByTime(1000);
+        });
+
+        expect(flashState('Meter')).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('flashes only the clicked category, leaving the others unmarked', () => {
+      render(<Palette config={config} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Meter' }));
+
+      expect(flashState('Meter')).toBe('true');
+      expect(flashState('Rhythm')).toBeNull();
+    });
+
+    it('drops a pending flash when another classification is selected', () => {
+      render(<Palette config={config} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Meter' }));
+      expect(flashState('Meter')).toBe('true');
+
+      // Leaving and returning must not resurrect the flash: the indices are per classification.
+      fireEvent.click(screen.getByRole('button', { name: 'Logic' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Music' }));
+
+      expect(flashState('Meter')).toBeNull();
     });
 
     it('filters bricks as the user types in the search input', () => {

--- a/modules/masonry/src/components/Palette/Palette.test.tsx
+++ b/modules/masonry/src/components/Palette/Palette.test.tsx
@@ -3,7 +3,8 @@
 // accessibility, and edge cases.
 //
 // Scope note: jsdom does no layout and does not implement scrollIntoView, so scroll-to is asserted
-// by spying on Element.prototype.scrollIntoView rather than checking real scroll position.
+// by spying on Element.prototype.scrollIntoView rather than checking real scroll position, and
+// cursor and width affordances by the utility classes that set them.
 
 import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -168,6 +169,30 @@ describe('Palette', () => {
       expect(screen.getByRole('button', { name: 'Meter' }).getAttribute('title')).toBe('Meter');
     });
 
+    it('marks the sidebar category buttons and the classification tabs as pointer targets', () => {
+      render(<Palette config={config} />);
+
+      // A button takes cursor:default from preflight, so the pointer has to be asked for.
+      expect(screen.getByRole('button', { name: 'Rhythm' }).className).toContain('cursor-pointer');
+      expect(screen.getByRole('button', { name: 'Music' }).className).toContain('cursor-pointer');
+    });
+
+    it('leaves the bricks as grab targets rather than pointer targets', () => {
+      const { container } = render(<Palette config={config} />);
+
+      // Bricks are drag sources, not click targets; a pointer would misdescribe them.
+      const slot = container.querySelector('[data-brick-id="r1"]');
+      expect(slot?.className).toContain('cursor-grab');
+      expect(slot?.className).not.toContain('cursor-pointer');
+    });
+
+    it('sizes a brick slot to its brick so the whitespace beside it is outside the slot', () => {
+      const { container } = render(<Palette config={config} />);
+
+      // The slot is a flex row; without w-fit it spans the list and the grab cursor with it.
+      expect(container.querySelector('[data-brick-id="r1"]')?.className).toContain('w-fit');
+    });
+
     it('renders a section heading (h3) for each active-classification category', () => {
       render(<Palette config={config} />);
 
@@ -303,6 +328,36 @@ describe('Palette', () => {
       expect(flashState('Meter')).toBeNull();
     });
 
+    it('flashes the header even though the scroll itself moves nothing', () => {
+      render(<Palette config={config} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Meter' }));
+
+      // jsdom never scrolls, so this is the already-at-the-end case: the call changes nothing.
+      expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+      expect(flashState('Meter')).toBe('true');
+    });
+
+    it('drops a pending flash timer when the component unmounts', () => {
+      vi.useFakeTimers();
+      try {
+        const { unmount } = render(<Palette config={config} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Meter' }));
+
+        unmount();
+
+        // A surviving timeout would set state on an unmounted component.
+        expect(vi.getTimerCount()).toBe(0);
+        expect(() =>
+          act(() => {
+            vi.advanceTimersByTime(1000);
+          }),
+        ).not.toThrow();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('filters bricks as the user types in the search input', () => {
       render(<Palette config={config} />);
 
@@ -420,6 +475,16 @@ describe('Palette', () => {
       // The visible span provides the name; distinct from the same-named headings.
       expect(screen.getByRole('button', { name: 'Rhythm' })).toBeTruthy();
       expect(screen.getByRole('button', { name: 'Meter' })).toBeTruthy();
+    });
+
+    it('names a sidebar category button from its visible label, not from its title', () => {
+      render(<Palette config={config} />);
+
+      const button = screen.getByRole('button', { name: 'Rhythm' });
+
+      // title is a tooltip for the truncated label; the span is what names the button.
+      expect(button.getAttribute('title')).toBe('Rhythm');
+      expect(within(button).getByText('Rhythm')).toBeTruthy();
     });
 
     it('exposes each category section header as an h3 heading with the category name', () => {

--- a/modules/masonry/src/components/Palette/Palette.tsx
+++ b/modules/masonry/src/components/Palette/Palette.tsx
@@ -1,5 +1,5 @@
 import { Search } from 'lucide-react';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import type { PaletteViewProps } from '@/@types/palette.types';
 
@@ -11,6 +11,11 @@ import { Input } from '@/ui/input';
 import { BrickSlot } from './BrickSlot';
 
 // -------------------------------------------------------------------------------------------------
+
+/**
+ * How long a category header stays highlighted after its sidebar button is clicked.
+ */
+const CATEGORY_FLASH_MS = 600;
 
 /**
  * Root Brick Palette shell.
@@ -36,6 +41,8 @@ export function Palette({ config }: PaletteViewProps) {
   const [activeClassification, setActiveClassification] = useState(0);
   const [query, setQuery] = useState('');
   const categoryRefs = useRef<Array<HTMLElement | null>>([]);
+  const [flashedCategory, setFlashedCategory] = useState<number | null>(null);
+  const flashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isDragging = usePaletteDragStore((state) => state.dragged !== null);
 
   const classifications = config.classifications;
@@ -72,14 +79,36 @@ export function Palette({ config }: PaletteViewProps) {
       .filter(({ category }) => category.bricks.length > 0);
   }, [activeCategories, query]);
 
+  const clearFlashTimer = () => {
+    if (flashTimer.current !== null) {
+      clearTimeout(flashTimer.current);
+      flashTimer.current = null;
+    }
+  };
+
+  // Cleanup only; inlined rather than reusing clearFlashTimer so the effect has no dependencies.
+  useEffect(
+    () => () => {
+      if (flashTimer.current !== null) clearTimeout(flashTimer.current);
+    },
+    [],
+  );
+
   const scrollToCategory = (index: number) => {
     categoryRefs.current[index]?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    // The list can already be scrolled as far as it goes, in which case scrollIntoView moves
+    // nothing and the click reads as ignored. Flashing the header answers the click either way.
+    clearFlashTimer();
+    setFlashedCategory(index);
+    flashTimer.current = setTimeout(() => setFlashedCategory(null), CATEGORY_FLASH_MS);
   };
 
   const selectClassification = (index: number) => {
     setActiveClassification(index);
     setQuery('');
     categoryRefs.current = [];
+    clearFlashTimer();
+    setFlashedCategory(null);
   };
 
   return (
@@ -93,8 +122,9 @@ export function Palette({ config }: PaletteViewProps) {
               key={index}
               variant="ghost"
               size="default"
+              title={category.name}
               onClick={() => scrollToCategory(index)}
-              className="h-auto flex-col gap-1 px-1 py-2 text-[0.7rem]"
+              className="h-auto cursor-pointer flex-col gap-1 px-1 py-2 text-[0.7rem]"
             >
               <Icon className="size-5" style={{ color: category.color }} />
               <span className="w-full truncate text-center">{category.name}</span>
@@ -117,7 +147,7 @@ export function Palette({ config }: PaletteViewProps) {
                 aria-pressed={isActive}
                 title={classification.name}
                 onClick={() => selectClassification(index)}
-                className="h-9 flex-1"
+                className="h-9 flex-1 cursor-pointer"
               >
                 <Icon className="size-5" />
                 <span className="sr-only">{classification.name}</span>
@@ -160,7 +190,13 @@ export function Palette({ config }: PaletteViewProps) {
                   }}
                   className="mb-6 scroll-mt-4"
                 >
-                  <div className="mb-2 flex items-center gap-2">
+                  <div
+                    data-flashing={flashedCategory === index ? 'true' : undefined}
+                    className={cn(
+                      '-mx-1 mb-2 flex items-center gap-2 rounded-md px-1 transition-colors duration-300',
+                      flashedCategory === index && 'bg-muted',
+                    )}
+                  >
                     <Icon className="size-4" style={{ color: category.color }} />
                     <h3 className="text-sm font-semibold" style={{ color: category.color }}>
                       {category.name}


### PR DESCRIPTION
Closes #680.

Implements all four objectives, plus tests.

## 1. Pointer cursor on the clickable items

`buttonVariants` in `ui/button.tsx` sets no cursor, and a `button` element takes `cursor: default` from preflight, so the sidebar category buttons and the classification tabs showed an arrow rather than a pointer. Both now carry `cursor-pointer`.

Deliberately **not** changed: the bricks keep `cursor-grab` / `active:cursor-grabbing` — they are drag sources, not click targets, so a pointer would misdescribe them. Also left alone: `buttonVariants` itself. Fixing it there would be the smaller diff, but it would change every button in the app, which is wider than "the Palette component". Say the word if you would rather have it at the primitive.

## 2. Cursor limited to the Brick

The drag source in `BrickSlot` was a block-level flex row, so it stretched the full width of the list and the grab cursor appeared over the empty space beside a Brick. `w-fit` shrinks it to the Brick. This also narrows the drag target to the Brick itself, which is the same intent read from the other direction — worth a look in case you want the wider row to stay draggable.

## 3. Title on the section buttons

The sidebar label is `truncate`d inside a `w-20` column, so a longer category name is cut off with no way to read it. The button now carries the category name as a `title`, matching what the classification tabs already do. It does not affect the accessible name, which still comes from the visible label.

## 4. Feedback when the list cannot scroll

Clicking a category button whose section is already at the end of the scroll container left `scrollIntoView` with nothing to do, so the click read as ignored — the case the issue calls out.

The target header now highlights briefly (600 ms) on **every** click rather than only when the scroll is a no-op. Detecting "the scroll did nothing" means comparing scroll offsets across a smooth-scroll animation, which is fragile and, in jsdom, not testable at all; flashing unconditionally answers the click in both cases and is much simpler to reason about. If you would rather it fire only in the no-op case, I will take another pass.

The marker is exposed as `data-flashing` so the behaviour can be asserted without reaching into class names. The pending timeout is cleared when a different classification is selected and on unmount.

## Tests

Five added, following the existing groupings in `Palette.test.tsx`:

- *rendering* — each sidebar category button carries its name as a `title`.
- *interaction* — the target header gains the flash on click.
- *interaction* — the flash clears once it has elapsed (fake timers).
- *interaction* — only the clicked category is marked.
- *interaction* — a pending flash does not survive a classification switch. Category indices are per classification, so a stale flash would otherwise land on whichever section happens to share the index.

## Verification

Run on a fork of this repository at the same commit — **all four jobs green**: `Verify TypeScript types`, `Run Tests on Source Code`, `Run Smoke Test (build)`, `Lint Code Base`.

Checked by hand as well:

- The header keeps its position when the highlight appears: it adds `px-1` and cancels it with `-mx-1`, so the icon and heading do not shift.
- `data-flashing` is `undefined` when inactive, so React omits the attribute rather than rendering `data-flashing="false"`.
- The cleanup effect has an empty dependency list and closes over nothing but the ref, so `react-hooks/exhaustive-deps` has nothing to flag.

Not verified: how the flash actually looks in a browser. I could not exercise the UI visually, so the 600 ms duration and the `bg-muted` tint are a judgement call rather than something I watched — worth a glance from someone who can run it.
