### PR TITLE
#482 | fix(menu): connect save work as PNG button to export action

### DIFF
--- a/@types/components/menu.d.ts
+++ b/@types/components/menu.d.ts
@@ -47,5 +47,5 @@ export type TEventMenu =
 export type TPropsMenu = {
     injected: TInjectedMenu;
     states: Record<'running', boolean>;
-    handlers: Partial<Record<'run' | 'stop' | 'reset', CallableFunction>>;
+    handlers: Partial<Record<'run' | 'stop' | 'reset' | 'exportDrawing', CallableFunction>>;
 };

--- a/lib/events/src/index.ts
+++ b/lib/events/src/index.ts
@@ -32,6 +32,7 @@ export function hearEvent(event: TEvent, callback: CallableFunction): void {
 export function emitEvent(event: 'menu.run'): void;
 export function emitEvent(event: 'menu.stop'): void;
 export function emitEvent(event: 'menu.reset'): void;
+export function emitEvent(event: 'menu.exportDrawing'): void;
 /**
  * Emits an event.
  * @param event event name

--- a/modules/menu/package.json
+++ b/modules/menu/package.json
@@ -6,6 +6,7 @@
   "main": "src/index.ts",
   "scripts": {
     "storybook": "storybook dev -p 6006",
+    "test": "vitest --passWithNoTests",
     "check": "tsc --types 'vite/client'",
     "lint": "eslint src"
   },

--- a/modules/menu/src/index.ts
+++ b/modules/menu/src/index.ts
@@ -42,6 +42,10 @@ export async function setup(): Promise<void> {
         updateState('running', false);
         emitEvent('menu.reset');
     });
+
+    await updateHandler('exportDrawing', () => {
+        emitEvent('menu.exportDrawing');
+    });
 }
 
 // -- public variables -----------------------------------------------------------------------------

--- a/modules/menu/src/view/components/index.test.tsx
+++ b/modules/menu/src/view/components/index.test.tsx
@@ -1,0 +1,57 @@
+import type { TAsset } from '#/@types/assets';
+import type { TPropsMenu } from '#/@types/components/menu';
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Menu } from '.';
+
+afterEach(cleanup);
+
+const pngAsset: TAsset = {
+  type: 'image/png',
+  data: 'data:image/png;base64,iVBORw0KGgo=',
+  meta: { width: 1, height: 1 },
+};
+
+const props = (overrides: Partial<TPropsMenu> = {}): TPropsMenu => ({
+  injected: {
+    flags: {
+      uploadFile: false,
+      recording: false,
+      exportDrawing: true,
+      loadProject: false,
+      saveProject: false,
+    },
+    i18n: {
+      'menu.run': 'run',
+      'menu.stop': 'stop',
+      'menu.reset': 'reset',
+    },
+    assets: {
+      'image.icon.run': pngAsset,
+      'image.icon.stop': pngAsset,
+      'image.icon.reset': pngAsset,
+      'image.icon.saveProjectHTML': pngAsset,
+      'image.icon.exportDrawing': pngAsset,
+      'image.icon.startRecording': pngAsset,
+      'image.icon.stopRecording': pngAsset,
+      'image.icon.uploadFile': pngAsset,
+      'image.icon.loadProject': pngAsset,
+    },
+  },
+  states: { running: false },
+  handlers: {},
+  ...overrides,
+});
+
+describe('Menu export drawing button', () => {
+  it('invokes the exportDrawing handler when the Save mouse artwork as PNG button is clicked', () => {
+    const exportDrawing = vi.fn();
+    render(<Menu {...props({ handlers: { exportDrawing } })} />);
+
+    fireEvent.click(screen.getByText('Save mouse artwork as PNG'));
+
+    expect(exportDrawing).toHaveBeenCalledTimes(1);
+  });
+});

--- a/modules/menu/src/view/components/index.tsx
+++ b/modules/menu/src/view/components/index.tsx
@@ -43,6 +43,9 @@ export function Menu(props: TPropsMenu): JSX.Element {
 
         <button
           className={`menu-btn ${!props.injected.flags.exportDrawing ? 'menu-btn-hidden' : ''}`}
+          onClick={() =>
+            props.handlers.exportDrawing ? props.handlers.exportDrawing() : undefined
+          }
         >
           <p className="menu-btn-label">
             <span>{'Save mouse artwork as PNG'}</span>

--- a/modules/menu/vitest.config.ts
+++ b/modules/menu/vitest.config.ts
@@ -1,0 +1,26 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { UserConfig } from 'vite';
+
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+import rootConfig from '../../vitest.config';
+
+const dir = dirname(fileURLToPath(import.meta.url));
+
+export default mergeConfig(
+    rootConfig as UserConfig,
+    defineConfig({
+        resolve: {
+            alias: {
+                '#/@types': resolve(dir, '../../@types'),
+            },
+            extensions: ['.tsx', '.ts', '.js', '.scss', '.sass', '.json'],
+        },
+        test: {
+            environment: 'jsdom',
+            setupFiles: ['./vitest.setup.dom.ts'],
+        },
+    }),
+);

--- a/modules/menu/vitest.setup.dom.ts
+++ b/modules/menu/vitest.setup.dom.ts
@@ -1,0 +1,22 @@
+Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    value: () => ({
+        font: '',
+        measureText: () => ({
+            width: 0,
+            actualBoundingBoxAscent: 0,
+            actualBoundingBoxDescent: 0,
+        }),
+        fillText: () => {},
+    }),
+    writable: true,
+});
+
+Object.defineProperty(globalThis, 'ResizeObserver', {
+    value: class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    },
+    configurable: true,
+    writable: true,
+});


### PR DESCRIPTION
## Summary

Fixes the non-responsive "Save mouse artwork as PNG" button in the Menu component. The button was rendered (when the `exportDrawing` feature flag is enabled) but had no `onClick`, so clicking it did nothing.

## Root cause

The export-drawing button in `modules/menu/src/view/components/index.tsx` had no `onClick` handler, and the menu module never registered an `exportDrawing` handler. The underlying infrastructure was already in place:

- `exportDrawing()` exists in `modules/painter/src/core/sketchP5.ts`
- The painter registers `hearEvent('menu.exportDrawing', exportDrawing)`
- The button UI is rendered in the Menu component

Only the connector (the button click wiring and the module handler) was missing.

## Changes

- `modules/menu/src/view/components/index.tsx` - add `onClick` to the export-drawing button that invokes `props.handlers.exportDrawing`.
- `modules/menu/src/index.ts` - register an `exportDrawing` handler that emits `menu.exportDrawing`.
- `@types/components/menu.d.ts` - add `'exportDrawing'` to the menu handlers type record.
- `lib/events/src/index.ts` - add the `emitEvent('menu.exportDrawing')` overload for type safety.
- `modules/menu/package.json`, `modules/menu/vitest.config.ts`, `modules/menu/vitest.setup.dom.ts` - add minimal vitest infra so the menu component has a runnable unit test.
- `modules/menu/src/view/components/index.test.tsx` - regression test asserting the export button calls the `exportDrawing` handler when clicked.

## Verification

- Added a regression test that fails on the old code (the export button's click did not invoke the handler) and passes after the fix.
- `npm run check` - all 15 projects passed.
- `npm run lint` - passed (0 errors).
- `npm run build` - build successful.
- `npm run test` - all menu and other module tests passed; the only failure in a full parallel run is a pre-existing flaky performance test in `modules/runtime` (`layered-map.test.ts` > "should handle large numbers of frames efficiently"), which passes in isolation and is unrelated to this change.

Fixes #482

---

_Automated by pr-pipeline (com.ashutosh.prpipeline)._