### PR TITLE
680 feat(masonry): improve Palette component interactions

### DIFF
--- a/modules/masonry/src/components/Palette/BrickSlot.tsx
+++ b/modules/masonry/src/components/Palette/BrickSlot.tsx
@@ -44,7 +44,7 @@ export function BrickSlot({ brick }: BrickSlotProps) {
         <div
           title={brick.description}
           data-brick-id={brick.id}
-          className="palette-brick-slot flex min-h-11 cursor-grab touch-none items-center px-1 py-1 transition-colors select-none hover:brightness-110 active:cursor-grabbing"
+          className="palette-brick-slot flex min-h-11 w-fit cursor-grab touch-none items-center px-1 py-1 transition-colors select-none hover:brightness-110 active:cursor-grabbing"
         >
           <div className="pointer-events-none">
             <BrickView {...viewProps} />

--- a/modules/masonry/src/components/Palette/Palette.test.tsx
+++ b/modules/masonry/src/components/Palette/Palette.test.tsx
@@ -5,7 +5,7 @@
 // Scope note: jsdom does no layout and does not implement scrollIntoView, so scroll-to is asserted
 // by spying on Element.prototype.scrollIntoView rather than checking real scroll position.
 
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { BrickViewProps } from '@/@types/brick.types';
@@ -189,6 +189,9 @@ describe('Palette', () => {
       // touch-action must be disabled so touch drags reach interact.js instead of scrolling.
       expect(note?.classList.contains('palette-brick-slot')).toBe(true);
       expect(note?.classList.contains('touch-none')).toBe(true);
+      // The slot shrinkwraps the brick preview so the grab cursor only appears over the brick
+      // itself, not across the whole white row.
+      expect(note?.classList.contains('w-fit')).toBe(true);
       // Every slot carries the markup, not just the first.
       expect(container.querySelectorAll('.palette-brick-slot')).toHaveLength(3);
     });
@@ -235,6 +238,31 @@ describe('Palette', () => {
         behavior: 'smooth',
         block: 'start',
       });
+    });
+
+    it('flashes a category header when its button cannot scroll the list', () => {
+      vi.useFakeTimers();
+      try {
+        render(<Palette config={config} />);
+
+        // jsdom fires no scroll events for scrollIntoView, so the click resolves to "nothing
+        // moved" and the header is flashed as feedback.
+        fireEvent.click(screen.getByRole('button', { name: 'Meter' }));
+
+        // The flash lands after the scroll-settle window and then clears itself.
+        act(() => {
+          vi.advanceTimersByTime(800);
+        });
+        const meterHeader = screen.getByRole('heading', { name: 'Meter' }).parentElement as Element;
+        expect(meterHeader.classList.contains('bg-primary/15')).toBe(true);
+
+        act(() => {
+          vi.advanceTimersByTime(700);
+        });
+        expect(meterHeader.classList.contains('bg-primary/15')).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('filters bricks as the user types in the search input', () => {
@@ -361,6 +389,25 @@ describe('Palette', () => {
 
       expect(screen.getByRole('heading', { level: 3, name: 'Rhythm' })).toBeTruthy();
       expect(screen.getByRole('heading', { level: 3, name: 'Meter' })).toBeTruthy();
+    });
+
+    it('titles each sidebar category button with the category name', () => {
+      render(<Palette config={config} />);
+
+      expect(screen.getByRole('button', { name: 'Rhythm' }).getAttribute('title')).toBe('Rhythm');
+      expect(screen.getByRole('button', { name: 'Meter' }).getAttribute('title')).toBe('Meter');
+    });
+
+    it('shows the pointer cursor on every clickable button in the palette', () => {
+      render(<Palette config={config} />);
+
+      // Classification tabs and sidebar category buttons are clickable, so both carry
+      // cursor-pointer; the shared Button base does not set a cursor itself.
+      for (const name of ['Music', 'Logic', 'Rhythm', 'Meter']) {
+        expect(screen.getByRole('button', { name }).classList.contains('cursor-pointer')).toBe(
+          true,
+        );
+      }
     });
 
     it('exposes the search field as a textbox reachable by its placeholder', () => {

--- a/modules/masonry/src/components/Palette/Palette.tsx
+++ b/modules/masonry/src/components/Palette/Palette.tsx
@@ -1,5 +1,5 @@
 import { Search } from 'lucide-react';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import type { PaletteViewProps } from '@/@types/palette.types';
 
@@ -32,11 +32,23 @@ import { BrickSlot } from './BrickSlot';
  * placeholder receives the whole `PaletteBrickConfig` so a later PR can turn it into a drag source
  * that carries the config as its payload without changing the prop contract.
  */
+/** How long a category header stays flashed when its button can't scroll the list. */
+const HEADER_FLASH_MS = 700;
+
 export function Palette({ config }: PaletteViewProps) {
   const [activeClassification, setActiveClassification] = useState(0);
   const [query, setQuery] = useState('');
+  const [flashedCategory, setFlashedCategory] = useState<number | null>(null);
   const categoryRefs = useRef<Array<HTMLElement | null>>([]);
+  const flashTimerRef = useRef<number | null>(null);
   const isDragging = usePaletteDragStore((state) => state.dragged !== null);
+
+  useEffect(
+    () => () => {
+      if (flashTimerRef.current !== null) window.clearTimeout(flashTimerRef.current);
+    },
+    [],
+  );
 
   const classifications = config.classifications;
 
@@ -72,8 +84,31 @@ export function Palette({ config }: PaletteViewProps) {
       .filter(({ category }) => category.bricks.length > 0);
   }, [activeCategories, query]);
 
+  const flashHeader = (index: number) => {
+    if (flashTimerRef.current !== null) window.clearTimeout(flashTimerRef.current);
+    setFlashedCategory(index);
+    flashTimerRef.current = window.setTimeout(() => setFlashedCategory(null), HEADER_FLASH_MS);
+  };
+
+  // Scroll the list to a category's section. When the section is already as far in view as the
+  // scroll container can take it (e.g. pinned at the end of the list), no movement happens, so
+  // the section header is flashed briefly instead to acknowledge the click.
   const scrollToCategory = (index: number) => {
-    categoryRefs.current[index]?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    const target = categoryRefs.current[index];
+    if (!target) return;
+    const container = target.closest('[data-palette-scroll]') as HTMLElement | null;
+
+    let moved = false;
+    const onScroll = () => {
+      moved = true;
+    };
+    container?.addEventListener('scroll', onScroll, { passive: true });
+    target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+    window.setTimeout(() => {
+      container?.removeEventListener('scroll', onScroll);
+      if (!moved) flashHeader(index);
+    }, HEADER_FLASH_MS + 100);
   };
 
   const selectClassification = (index: number) => {
@@ -93,8 +128,9 @@ export function Palette({ config }: PaletteViewProps) {
               key={index}
               variant="ghost"
               size="default"
+              title={category.name}
               onClick={() => scrollToCategory(index)}
-              className="h-auto flex-col gap-1 px-1 py-2 text-[0.7rem]"
+              className="h-auto cursor-pointer flex-col gap-1 px-1 py-2 text-[0.7rem]"
             >
               <Icon className="size-5" style={{ color: category.color }} />
               <span className="w-full truncate text-center">{category.name}</span>
@@ -117,7 +153,7 @@ export function Palette({ config }: PaletteViewProps) {
                 aria-pressed={isActive}
                 title={classification.name}
                 onClick={() => selectClassification(index)}
-                className="h-9 flex-1"
+                className="h-9 flex-1 cursor-pointer"
               >
                 <Icon className="size-5" />
                 <span className="sr-only">{classification.name}</span>
@@ -145,6 +181,7 @@ export function Palette({ config }: PaletteViewProps) {
           </div>
         ) : (
           <div
+            data-palette-scroll
             className={cn(
               'flex-1 overflow-y-auto p-4 transition-[padding-bottom] duration-500',
               isDragging && 'pb-32',
@@ -152,6 +189,7 @@ export function Palette({ config }: PaletteViewProps) {
           >
             {visibleCategories.map(({ category, index }) => {
               const Icon = category.icon;
+              const flashed = flashedCategory === index;
               return (
                 <section
                   key={index}
@@ -160,7 +198,12 @@ export function Palette({ config }: PaletteViewProps) {
                   }}
                   className="mb-6 scroll-mt-4"
                 >
-                  <div className="mb-2 flex items-center gap-2">
+                  <div
+                    className={cn(
+                      'mb-2 flex items-center gap-2 rounded-md px-1 py-0.5 transition-colors duration-300',
+                      flashed ? 'bg-primary/15' : 'bg-transparent',
+                    )}
+                  >
                     <Icon className="size-4" style={{ color: category.color }} />
                     <h3 className="text-sm font-semibold" style={{ color: category.color }}>
                       {category.name}


### PR DESCRIPTION
Fixes #680

Implements the four objectives from the issue for the new Palette component in `modules/masonry/src/components/Palette/`:

- **Pointer cursor on clickable items** — classification tabs and sidebar category buttons now carry `cursor-pointer` (the shared `Button` base sets no cursor).
- **Brick-scoped hover cursor** — brick slots are shrinkwrapped with `w-fit`, so the grab cursor (and the hover brightness highlight) only appear over the brick itself instead of across the whole white row.
- **Titles on section buttons** — each sidebar category button gets `title={category.name}` to match the classification tabs.
- **Feedback when a click can't scroll** — clicking a sidebar button whose section is already as far in view as the container allows (e.g. pinned at the end of the list) now briefly flashes that section's header (`bg-primary/15`, 700 ms fade) instead of doing nothing. Detection listens for actual scroll movement after `scrollIntoView`; if none occurs, the header flashes.

## Testing
- Extended `Palette.test.tsx` (+4 cases): button titles, pointer cursor on all palette buttons, `w-fit` on slots, and the header flash lifecycle under fake timers. All 34 tests pass, eslint and prettier clean.