### PR TITLE
fix(singer): correct octave delta for negative modal indices

### DIFF
--- a/modules/singer/src/core/keySignature.ts
+++ b/modules/singer/src/core/keySignature.ts
@@ -1120,10 +1120,12 @@ export default class KeySignature implements IKeySignature {
     public modalPitchToLetter(modalIndex: number): [string, number] {
         const modeLength = this.modeLength;
         modalIndex = Math.floor(Number(modalIndex));
-        let deltaOctave = Math.floor(modalIndex / modeLength);
+        // Floor division already reports the octave change for negative
+        // indices: -1 wraps to the last note of the previous octave, so the
+        // delta is -1, not -2.
+        const deltaOctave = Math.floor(modalIndex / modeLength);
 
         if (modalIndex < 0) {
-            deltaOctave--;
             while (modalIndex < 0) {
                 modalIndex += modeLength;
             }

--- a/modules/singer/src/core/tests/keySignature.test.ts
+++ b/modules/singer/src/core/tests/keySignature.test.ts
@@ -260,6 +260,11 @@ describe('Key Signature', () => {
 
         // Modal pitch starts at 0
         expect(ks.modalPitchToLetter(4)[0]).toBe('g');
+        // Modal indices past the ends of the mode wrap around, reporting the
+        // relative change in octave.
+        expect(ks.modalPitchToLetter(7)).toEqual(['c', 1]);
+        expect(ks.modalPitchToLetter(-1)).toEqual(['b', -1]);
+        expect(ks.modalPitchToLetter(-7)).toEqual(['c', -1]);
     });
 
     test('pitch type check', () => {


### PR DESCRIPTION
## Summary

`KeySignature.modalPitchToLetter()` maps a modal index to a pitch letter plus a relative change in octave. For negative modal indices it reported the octave one lower than intended, so any note resolved from a negative index played an octave too low.

The delta was computed with floor division, which already handles the negative wrap correctly (e.g. index `-1` wraps to the last note of the previous octave, delta `-1`), and then the negative branch subtracted `1` again, producing `-2`. Floor division alone gives the correct delta, so the extra decrement is dropped.

Example on the default C major signature, `modalPitchToLetter(-1)`:

- before: `['b', -2]` (B in the wrong octave)
- after: `['b', -1]`

## Testing

- Added regression assertions to `keySignature.test.ts` for the `+7`, `-1` and `-7` wrap cases; the `-1` case failed with the old code (reported `['b', -2]`) and passes with the fix.
- Full monorepo test suite (`lerna run test`, 6 projects) passes with the change.
