### PR TITLE
test(masonry): cover WorkspaceManager

### DIFF
--- a/modules/masonry/src/workspace/model/model.test.ts
+++ b/modules/masonry/src/workspace/model/model.test.ts
@@ -1,0 +1,80 @@
+// Unit tests for WorkspaceManager, which owns the map of towers and the one
+// operation that spans two of them. Pure model logic — no DOM — so this runs
+// in the node environment.
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import WorkspaceManager from './model';
+import { createSimpleBrick, resetFactoryCounter } from '../../brick/utils/brickFactory';
+
+describe('WorkspaceManager', () => {
+    let manager: WorkspaceManager;
+
+    beforeEach(() => {
+        resetFactoryCounter();
+        manager = new WorkspaceManager();
+    });
+
+    describe('creating and removing towers', () => {
+        it('creates a tower holding the brick it was given', () => {
+            const brick = createSimpleBrick();
+            const tower = manager.createTower(brick, { x: 10, y: 20 });
+
+            expect(tower.hasBrick(brick.uuid)).toBe(true);
+            expect(manager.getTower(tower.id)).toBe(tower);
+            expect(manager.allTowers).toHaveLength(1);
+        });
+
+        it('gives each tower its own id', () => {
+            const first = manager.createTower(createSimpleBrick(), { x: 0, y: 0 });
+            const second = manager.createTower(createSimpleBrick(), { x: 0, y: 0 });
+
+            expect(first.id).not.toBe(second.id);
+            expect(manager.allTowers).toHaveLength(2);
+        });
+
+        it('removes a tower and reports whether there was one', () => {
+            const tower = manager.createTower(createSimpleBrick(), { x: 0, y: 0 });
+
+            expect(manager.removeTower(tower.id)).toBe(true);
+            expect(manager.removeTower(tower.id)).toBe(false);
+            expect(manager.getTower(tower.id)).toBeUndefined();
+            expect(manager.allTowers).toHaveLength(0);
+        });
+
+        it('returns undefined for a tower that was never created', () => {
+            expect(manager.getTower('tower_404')).toBeUndefined();
+        });
+    });
+
+    describe('clear', () => {
+        it('drops every tower and restarts the id sequence', () => {
+            const first = manager.createTower(createSimpleBrick(), { x: 0, y: 0 });
+            manager.createTower(createSimpleBrick(), { x: 0, y: 0 });
+
+            manager.clear();
+            expect(manager.allTowers).toHaveLength(0);
+
+            // The counter resets, so the next tower takes the first id again.
+            const afterClear = manager.createTower(createSimpleBrick(), { x: 0, y: 0 });
+            expect(afterClear.id).toBe(first.id);
+        });
+    });
+
+    describe('connectBricksAcrossTowers', () => {
+        it('throws when neither brick belongs to a tower', () => {
+            expect(() =>
+                manager.connectBricksAcrossTowers('nope', 'also-nope', 'n1', 'n2', 'top'),
+            ).toThrow('Brick(s) not found');
+        });
+
+        it('throws when only one of the two bricks is in a tower', () => {
+            const brick = createSimpleBrick();
+            manager.createTower(brick, { x: 0, y: 0 });
+
+            expect(() =>
+                manager.connectBricksAcrossTowers(brick.uuid, 'nope', 'n1', 'n2', 'top'),
+            ).toThrow('Brick(s) not found');
+        });
+    });
+});


### PR DESCRIPTION
### Why this file

`WorkspaceManager` was the least covered file in the masonry module — **22.22% statements, 4.76% branches, 37.5% functions**. It owns the map of towers and the one operation that spans two of them, and the workspace stories build on it, but it had no tests.

Picked by measurement rather than taste: I ran the module's coverage report and this was the worst entry in it.

### What is covered

- **Tower lifecycle** — create, get, remove, and that `removeTower` returns `true` then `false` for the same id
- **`clear()`** — drops every tower *and* restarts the id sequence, which is the part easy to break silently
- **`connectBricksAcrossTowers`** — the two argument-validation paths, when neither brick is in a tower and when only one is

After: **55.55% statements, 100% functions** on that file. Module total 76.62% → 77.08%.

### What I deliberately left

The merge path — two towers with real connectable notches, `mergeIn`, and the delete that follows — needs a much larger fixture than this file should carry, and getting it wrong would produce tests that pass for the wrong reason. Happy to do it as a follow-up if that is wanted, or to fold it in here if you would rather have it in one go.

### Testing

`npx vitest run` in `modules/masonry` — **35 files, 523 tests passing**. `eslint` clean.

### AI

I used Claude Code for these tests and this description. The coverage numbers are from running the report before and after.