### PR TITLE
Add keyboard deletion for selected bricks.

### DIFF
--- a/modules/masonry/src/components/Tower/TowerBrick.test.tsx
+++ b/modules/masonry/src/components/Tower/TowerBrick.test.tsx
@@ -1,0 +1,80 @@
+// Guards the cost of a selection change. `TowerBrick` is rendered once per brick on the canvas, so
+// anything it subscribes to that changes workspace-wide is paid for by every brick at once. The
+// mocked `BrickView` is what makes the renders countable.
+
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { TowerStatementNode } from '@/@types/tower.types';
+
+import { makeEmptyStatement } from '@/mocks/tower';
+import { useBrickLayoutStore } from '@/stores/brick';
+import { useWorkspaceStore } from '@/stores/workspace';
+
+const renders = { count: 0 };
+
+vi.mock('@/components/Brick/Brick', () => ({
+  BrickView: (props: { model: { id: string } }) => {
+    renders.count += 1;
+    return <span data-brick={props.model.id} />;
+  },
+}));
+
+const { TowerBrickView } = await import('./TowerBrick');
+
+afterEach(() => {
+  cleanup();
+  useWorkspaceStore.setState({ towers: {}, selectedBrickId: null });
+  useBrickLayoutStore.setState({ coords: {}, mounted: {}, positioned: {} });
+});
+
+/** A single tower of `count` statement bricks joined head to tail, all mounted. */
+function makeChain(count: number): TowerStatementNode[] {
+  const nodes = Array.from({ length: count }, (_, i) => makeEmptyStatement(`b${i}`, 0, false));
+
+  nodes.forEach((node, i) => {
+    if (i === 0) return;
+    nodes[i - 1].next = node;
+    node.prev = nodes[i - 1];
+  });
+
+  useBrickLayoutStore
+    .getState()
+    .setMounted(Object.fromEntries(nodes.map((node) => [node.model.id, true])));
+
+  return nodes;
+}
+
+describe('TowerBrickView', () => {
+  it('re-renders only the bricks whose selected state actually changed', () => {
+    const nodes = makeChain(20);
+
+    const { container } = render(
+      <>
+        {nodes.map((node) => (
+          <TowerBrickView key={node.model.id} id={node.model.id} node={node} />
+        ))}
+      </>,
+    );
+
+    act(() => {
+      useWorkspaceStore.getState().createTower({
+        id: 'chain',
+        root: nodes[0],
+        position: { x: 0, y: 0 },
+      });
+    });
+
+    renders.count = 0;
+    fireEvent.click(container.querySelector('[data-id="b0"]') as HTMLElement);
+    expect(useWorkspaceStore.getState().selectedBrickId).toBe('b0');
+    // Just the brick that gained the selection; nothing was holding it to lose.
+    expect(renders.count).toBeLessThanOrEqual(1);
+
+    renders.count = 0;
+    fireEvent.click(container.querySelector('[data-id="b7"]') as HTMLElement);
+    expect(useWorkspaceStore.getState().selectedBrickId).toBe('b7');
+    // The brick that gained it and the one that lost it, and none of the other eighteen.
+    expect(renders.count).toBeLessThanOrEqual(2);
+  });
+});

--- a/modules/masonry/src/components/Tower/TowerBrick.tsx
+++ b/modules/masonry/src/components/Tower/TowerBrick.tsx
@@ -26,6 +26,9 @@ export const TowerBrickView = memo(function (props: TowerBrickViewProps) {
   const { id, node } = props;
   const ref = useRef<HTMLDivElement>(null);
 
+  const selectedBrickId = useWorkspaceStore((state) => state.selectedBrickId);
+  const selectBrick = useWorkspaceStore((state) => state.selectBrick);
+
   useBrickMove(id, ref);
 
   // We explicitly extract coords without returning a fallback object in the selector.
@@ -47,6 +50,11 @@ export const TowerBrickView = memo(function (props: TowerBrickViewProps) {
 
     useWorkspaceStore.getState().setNestingFold(id, !found.node.model.isNestingFolded);
   }, [id]);
+  const handleClick = useCallback(() => {
+    selectBrick(id);
+  }, [id, selectBrick]);
+
+  const isSelected = selectedBrickId === id;
 
   if (!isMounted) return null;
 
@@ -72,9 +80,12 @@ export const TowerBrickView = memo(function (props: TowerBrickViewProps) {
       ref={ref}
       data-id={id}
       className="absolute"
+      onClick={handleClick}
       style={{
         transform: `translate(${x}px, ${y}px)`,
         visibility: isPositioned ? 'visible' : 'hidden',
+        outline: isSelected ? '2px solid currentColor' : 'none',
+        outlineOffset: '2px',
       }}
     >
       {brick}

--- a/modules/masonry/src/components/Tower/TowerBrick.tsx
+++ b/modules/masonry/src/components/Tower/TowerBrick.tsx
@@ -6,6 +6,10 @@ import { BrickView } from '@/components/Brick/Brick';
 import { useBrickMove } from '@/hooks/useBrickMove';
 import { useBrickLayoutStore } from '@/stores/brick';
 import { findNodeAndTower, useWorkspaceStore } from '@/stores/workspace';
+import { darkenColor } from '@/utils/color';
+
+/** How far a selected brick rises off the canvas, in px. */
+const LIFT_PX = 3;
 
 export interface TowerBrickViewProps {
   /** Unique identifier, kept separate from `node` since `node`'s identity changes every render. */
@@ -26,8 +30,10 @@ export const TowerBrickView = memo(function (props: TowerBrickViewProps) {
   const { id, node } = props;
   const ref = useRef<HTMLDivElement>(null);
 
-  const selectedBrickId = useWorkspaceStore((state) => state.selectedBrickId);
-  const selectBrick = useWorkspaceStore((state) => state.selectBrick);
+  // Subscribed as the derived boolean rather than the id itself: every brick on the canvas holds
+  // one of these, and an id would hand all of them a changed value on every selection change. The
+  // boolean only flips for the two bricks that actually gained or lost the selection.
+  const isSelected = useWorkspaceStore((state) => state.selectedBrickId === id);
 
   useBrickMove(id, ref);
 
@@ -50,11 +56,21 @@ export const TowerBrickView = memo(function (props: TowerBrickViewProps) {
 
     useWorkspaceStore.getState().setNestingFold(id, !found.node.model.isNestingFolded);
   }, [id]);
+  // Read at press time like `toggleFold` above, so the handler stays keyed on `id` alone.
   const handleClick = useCallback(() => {
-    selectBrick(id);
-  }, [id, selectBrick]);
+    useWorkspaceStore.getState().selectBrick(id);
+  }, [id]);
 
-  const isSelected = selectedBrickId === id;
+  // A selected brick is ringed in a deepened shade of its own fill, dark enough to hold against the
+  // light canvas the bricks sit on. `drop-shadow` follows the rendered alpha, so the ring traces the
+  // outline (notches and cavity included) instead of boxing the bounding rect the way an `outline`
+  // would. Chained rather than one wide blur: each pass re-blurs the last, building a solid rim at
+  // the edge that falls off into a glow. The cast shadow comes last, so it is thrown by the ringed
+  // silhouette and lands under the brick the lift raises.
+  const highlight = darkenColor(node.model.colorsDefault.background, 0.45);
+  const highlightFilter =
+    `drop-shadow(0 0 1px ${highlight}) drop-shadow(0 0 2px ${highlight}) ` +
+    `drop-shadow(0 0 4px ${highlight}) drop-shadow(0 ${LIFT_PX + 1}px 3px rgb(0 0 0 / 0.3))`;
 
   if (!isMounted) return null;
 
@@ -84,11 +100,23 @@ export const TowerBrickView = memo(function (props: TowerBrickViewProps) {
       style={{
         transform: `translate(${x}px, ${y}px)`,
         visibility: isPositioned ? 'visible' : 'hidden',
-        outline: isSelected ? '2px solid currentColor' : 'none',
-        outlineOffset: '2px',
       }}
     >
-      {brick}
+      {/*
+        The lift rides an inner wrapper rather than the transform above it: that one is the brick's
+        seat in the tower, and `useBrickMove` and the collision math both measure this element's
+        rect off it. Raising the brick inside leaves all of that reading exactly what it did before,
+        and leaves this transform free to animate without fighting a drag.
+      */}
+      <div
+        style={{
+          transform: isSelected ? `translateY(-${LIFT_PX}px)` : undefined,
+          filter: isSelected ? highlightFilter : undefined,
+          transition: 'transform 120ms ease-out',
+        }}
+      >
+        {brick}
+      </div>
     </div>
   );
 });

--- a/modules/masonry/src/components/Workspace/Workspace.test.tsx
+++ b/modules/masonry/src/components/Workspace/Workspace.test.tsx
@@ -171,6 +171,56 @@ describe('Workspace', () => {
     expect(usePaletteDragStore.getState().dragged).toBeNull();
   });
 
+  it('selects a brick, clears it from the background, and clears it with Escape', () => {
+    const { container } = render(<Workspace config={{ palette: paletteConfig }} />);
+    const tower = makeNestingTower('selection');
+
+    act(() => {
+      useWorkspaceStore.getState().createTower(tower);
+    });
+
+    const canvas = container.querySelector('[data-testid="workspace-canvas"]') as HTMLElement;
+    const brick = container.querySelector('[data-id="selection-outer"]') as HTMLElement;
+
+    fireEvent.click(brick);
+    expect(useWorkspaceStore.getState().selectedBrickId).toBe('selection-outer');
+
+    fireEvent.click(canvas);
+    expect(useWorkspaceStore.getState().selectedBrickId).toBeNull();
+
+    fireEvent.click(brick);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(useWorkspaceStore.getState().selectedBrickId).toBeNull();
+  });
+
+  it('deletes a selected root and extracts then discards a selected nested brick', () => {
+    const { container } = render(<Workspace config={{ palette: paletteConfig }} />);
+    const tower = makeNestingTower('keyboard');
+
+    act(() => {
+      useWorkspaceStore.getState().createTower(tower);
+    });
+
+    const root = container.querySelector('[data-id="keyboard-outer"]') as HTMLElement;
+    fireEvent.click(root);
+    fireEvent.keyDown(window, { key: 'Delete' });
+    expect(useWorkspaceStore.getState().towers).toEqual({});
+
+    const secondTower = makeNestingTower('keyboard-nested');
+    act(() => {
+      useWorkspaceStore.getState().createTower(secondTower);
+    });
+
+    const nested = container.querySelector('[data-id="keyboard-nested-inner"]') as HTMLElement;
+    fireEvent.click(nested);
+    fireEvent.keyDown(window, { key: 'Backspace' });
+
+    const remaining = useWorkspaceStore.getState().towers['keyboard-nested'];
+    expect(remaining).toBeDefined();
+    expect((remaining?.root as TowerStatementNode).nestedNext).toBeNull();
+    expect(Object.keys(useWorkspaceStore.getState().towers)).toEqual(['keyboard-nested']);
+  });
+
   describe('trash', () => {
     it('keeps the trash off an empty canvas, since there is nothing to remove yet', () => {
       const { container } = render(<Workspace config={{ palette: paletteConfig }} />);

--- a/modules/masonry/src/components/Workspace/Workspace.test.tsx
+++ b/modules/masonry/src/components/Workspace/Workspace.test.tsx
@@ -11,7 +11,7 @@ import type { PaletteConfig } from '@/@types/palette.types';
 import type { TowerStatementNode } from '@/@types/tower.types';
 import type { TowerState } from '@/@types/workspace.types';
 
-import { makeEmptyStatement } from '@/mocks/tower';
+import { makeEmptyStatement, makeEmptyValue } from '@/mocks/tower';
 import { useBrickLayoutStore } from '@/stores/brick';
 import { usePaletteDragStore } from '@/stores/palette';
 import { useTrashStore } from '@/stores/trash';
@@ -24,7 +24,7 @@ import { Workspace } from './Workspace';
 afterEach(() => {
   cleanup();
   usePaletteDragStore.setState({ dragged: null });
-  useWorkspaceStore.setState({ towers: {} });
+  useWorkspaceStore.setState({ towers: {}, selectedBrickId: null });
   useTrashStore.setState({ bounds: null, isHovered: false });
   useBrickLayoutStore.setState({ coords: {}, mounted: {}, positioned: {} });
 });
@@ -95,6 +95,28 @@ function makeNestingTower(id: string, folded = false): TowerState {
   useBrickLayoutStore.getState().setMounted({ [outer.model.id]: true, [inner.model.id]: true });
 
   return { id, root: outer, position: { x: 0, y: 0 } };
+}
+
+/**
+ * A one-brick tower whose single argument slot holds a numberbox value brick, so the canvas has a
+ * real `<input>` for the typing guard to be tested against.
+ */
+function makeTowerWithInput(id: string): TowerState {
+  const root = makeEmptyStatement(`${id}-root`, 1);
+  const value = makeEmptyValue(`${id}-value`);
+
+  root.args[0] = value;
+  value.parent = root;
+
+  useBrickLayoutStore.getState().setMounted({ [root.model.id]: true, [value.model.id]: true });
+
+  return { id, root, position: { x: 0, y: 0 } };
+}
+
+/** The wrapper a brick's highlight rides on, inside the element that seats it in the tower. */
+function highlightLayerOf(container: HTMLElement, brickId: string) {
+  return container.querySelector<HTMLElement>(`[data-id="${brickId}"]`)
+    ?.firstElementChild as HTMLElement;
 }
 
 /** The ids of the bricks the canvas has actually put in the DOM. */
@@ -219,6 +241,86 @@ describe('Workspace', () => {
     expect(remaining).toBeDefined();
     expect((remaining?.root as TowerStatementNode).nestedNext).toBeNull();
     expect(Object.keys(useWorkspaceStore.getState().towers)).toEqual(['keyboard-nested']);
+  });
+
+  it('leaves the selection alone while the user types in a brick input', () => {
+    const { container } = render(<Workspace config={{ palette: paletteConfig }} />);
+
+    act(() => {
+      useWorkspaceStore.getState().createTower(makeTowerWithInput('typing'));
+    });
+
+    fireEvent.click(container.querySelector('[data-id="typing-root"]') as HTMLElement);
+
+    const input = container.querySelector('input[type="number"]') as HTMLElement;
+    expect(input).not.toBeNull();
+
+    // Backspace is how a number gets corrected, so it must not reach the brick behind the input.
+    fireEvent.keyDown(input, { key: 'Backspace' });
+
+    expect(useWorkspaceStore.getState().towers['typing']).toBeDefined();
+    expect(useWorkspaceStore.getState().selectedBrickId).toBe('typing-root');
+  });
+
+  it('leaves the canvas untouched when a delete key arrives with nothing selected', () => {
+    render(<Workspace config={{ palette: paletteConfig }} />);
+
+    act(() => {
+      useWorkspaceStore.getState().createTower(makeTower('lonely'));
+    });
+
+    fireEvent.keyDown(window, { key: 'Delete' });
+
+    expect(Object.keys(useWorkspaceStore.getState().towers)).toEqual(['lonely']);
+  });
+
+  it('drops a selection whose brick is already gone rather than throwing', () => {
+    render(<Workspace config={{ palette: paletteConfig }} />);
+
+    act(() => {
+      useWorkspaceStore.getState().createTower(makeTower('present'));
+      useWorkspaceStore.getState().selectBrick('a-brick-that-no-longer-exists');
+    });
+
+    fireEvent.keyDown(window, { key: 'Delete' });
+
+    expect(useWorkspaceStore.getState().selectedBrickId).toBeNull();
+    expect(Object.keys(useWorkspaceStore.getState().towers)).toEqual(['present']);
+  });
+
+  it('keeps the selected brick for every key that is not Delete or Backspace', () => {
+    const { container } = render(<Workspace config={{ palette: paletteConfig }} />);
+
+    act(() => {
+      useWorkspaceStore.getState().createTower(makeNestingTower('other-keys'));
+    });
+
+    fireEvent.click(container.querySelector('[data-id="other-keys-outer"]') as HTMLElement);
+    fireEvent.keyDown(window, { key: 'a' });
+    fireEvent.keyDown(window, { key: 'Enter' });
+
+    expect(useWorkspaceStore.getState().towers['other-keys']).toBeDefined();
+    expect(useWorkspaceStore.getState().selectedBrickId).toBe('other-keys-outer');
+  });
+
+  it('rings the selected brick in its own color and lifts it, leaving the others flat', () => {
+    const { container } = render(<Workspace config={{ palette: paletteConfig }} />);
+
+    act(() => {
+      useWorkspaceStore.getState().createTower(makeNestingTower('highlight'));
+    });
+
+    fireEvent.click(container.querySelector('[data-id="highlight-outer"]') as HTMLElement);
+
+    const selected = highlightLayerOf(container, 'highlight-outer');
+    const unselected = highlightLayerOf(container, 'highlight-inner');
+
+    // The mock bricks are #3498db, so the ring is that fill taken down to #16557f.
+    expect(selected.style.filter).toContain('#16557f');
+    expect(selected.style.transform).toBe('translateY(-3px)');
+
+    expect(unselected.style.filter).toBe('');
+    expect(unselected.style.transform).toBe('');
   });
 
   describe('trash', () => {

--- a/modules/masonry/src/components/Workspace/Workspace.tsx
+++ b/modules/masonry/src/components/Workspace/Workspace.tsx
@@ -11,7 +11,8 @@ import { useDragFromPalette } from '@/hooks/useDragFromPalette';
 import { useTowerLayout } from '@/hooks/useTowerLayout';
 import { useWorkspaceScale } from '@/hooks/useWorkspaceScale';
 import { useBrickLayoutStore } from '@/stores/brick';
-import { useWorkspaceStore } from '@/stores/workspace';
+import { findNodeAndTower, useWorkspaceStore } from '@/stores/workspace';
+import { discardTower } from '@/utils/towerDiscard';
 import { listVisibleNodes } from '@/utils/tower-traversal';
 
 import { DragGhost } from './DragGhost';
@@ -30,8 +31,77 @@ export function Workspace({ config }: WorkspaceViewProps) {
   const { palette } = config;
 
   const towersRecord = useWorkspaceStore((state) => state.towers);
+  const clearSelection = useWorkspaceStore((state) => state.clearSelection);
   const towers = useMemo(() => Object.values(towersRecord), [towersRecord]);
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
 
+      // Do not delete bricks while the user is typing in an input.
+      if (
+        target?.tagName === 'INPUT' ||
+        target?.tagName === 'TEXTAREA' ||
+        target?.tagName === 'SELECT' ||
+        target?.isContentEditable
+      ) {
+        return;
+      }
+
+      const store = useWorkspaceStore.getState();
+
+      // Escape clears the current selection.
+      if (event.key === 'Escape') {
+        store.clearSelection();
+        return;
+      }
+
+      // Only Delete and Backspace remove bricks.
+      if (event.key !== 'Delete' && event.key !== 'Backspace') {
+        return;
+      }
+
+      const selectedBrickId = store.selectedBrickId;
+
+      // Nothing is selected, so there is nothing to delete.
+      if (!selectedBrickId) return;
+
+      event.preventDefault();
+
+      const found = findNodeAndTower(selectedBrickId);
+
+      // The selected brick may have already been removed.
+      if (!found) {
+        store.clearSelection();
+        return;
+      }
+
+      const { node, tower } = found;
+
+      if (node.model.id === tower.root.model.id) {
+        // The selected brick is the root of the tower.
+        discardTower(tower.id);
+      } else {
+        // Detach the selected brick into its own tower, then discard that tower.
+        const newTowerId = store.detachBrickToNewTower(
+          tower.id,
+          selectedBrickId,
+          tower.position,
+        );
+
+        if (newTowerId) {
+          discardTower(newTowerId);
+        }
+      }
+
+      store.clearSelection();
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
   // Only what a fold leaves on screen: a brick inside a folded cavity is never rendered. The
   // memo re-runs off the towers record, which is why `setNestingFold` re-seats the tower it folds:
   // the canvas and the re-layout both follow off that one signal.
@@ -91,7 +161,11 @@ export function Workspace({ config }: WorkspaceViewProps) {
 
       <div
         ref={canvasRef}
+        data-testid="workspace-canvas"
         className="bg-background relative h-full w-full shrink overflow-hidden select-none"
+        onClick={(event) => {
+          if (event.target === event.currentTarget) clearSelection();
+        }}
       >
         {/* TowerLayoutEngine runs the layout hooks for each tower to compute brick positions */}
         {towers.map((tower) => (

--- a/modules/masonry/src/components/Workspace/Workspace.tsx
+++ b/modules/masonry/src/components/Workspace/Workspace.tsx
@@ -33,11 +33,17 @@ export function Workspace({ config }: WorkspaceViewProps) {
   const towersRecord = useWorkspaceStore((state) => state.towers);
   const clearSelection = useWorkspaceStore((state) => state.clearSelection);
   const towers = useMemo(() => Object.values(towersRecord), [towersRecord]);
+
+  // Keyboard deletion of the selected brick. The listener sits on the window rather than the canvas
+  // because the canvas never holds focus: nothing in it is focusable, so a press after a click on a
+  // brick has nowhere else to land. The store is read at press time, which is what keeps the effect
+  // on empty deps and off the re-subscribe treadmill a selection dependency would put it on.
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       const target = event.target as HTMLElement | null;
 
-      // Do not delete bricks while the user is typing in an input.
+      // Backspace is how a value gets corrected in a brick's own widget, so a press that landed in
+      // an editable belongs to that editable and never to the brick behind it.
       if (
         target?.tagName === 'INPUT' ||
         target?.tagName === 'TEXTAREA' ||
@@ -49,27 +55,25 @@ export function Workspace({ config }: WorkspaceViewProps) {
 
       const store = useWorkspaceStore.getState();
 
-      // Escape clears the current selection.
       if (event.key === 'Escape') {
         store.clearSelection();
         return;
       }
 
-      // Only Delete and Backspace remove bricks.
       if (event.key !== 'Delete' && event.key !== 'Backspace') {
         return;
       }
 
       const selectedBrickId = store.selectedBrickId;
-
-      // Nothing is selected, so there is nothing to delete.
       if (!selectedBrickId) return;
 
+      // Held back until there is something to delete, so an unselected canvas leaves Backspace to
+      // the browser's own back navigation rather than swallowing it.
       event.preventDefault();
 
+      // A selection outlives the brick it points at: the trash and a drop that joins two towers
+      // both take bricks off the canvas without going through here.
       const found = findNodeAndTower(selectedBrickId);
-
-      // The selected brick may have already been removed.
       if (!found) {
         store.clearSelection();
         return;
@@ -78,15 +82,13 @@ export function Workspace({ config }: WorkspaceViewProps) {
       const { node, tower } = found;
 
       if (node.model.id === tower.root.model.id) {
-        // The selected brick is the root of the tower.
+        // The root is the tower, so there is nothing to sever it from.
         discardTower(tower.id);
       } else {
-        // Detach the selected brick into its own tower, then discard that tower.
-        const newTowerId = store.detachBrickToNewTower(
-          tower.id,
-          selectedBrickId,
-          tower.position,
-        );
+        // Severed into a tower of its own first, the same path a drag takes a brick out on, and
+        // that tower is what gets discarded. Note this carries off everything below the brick too,
+        // since the detach takes its whole `next` chain with it.
+        const newTowerId = store.detachBrickToNewTower(tower.id, selectedBrickId, tower.position);
 
         if (newTowerId) {
           discardTower(newTowerId);
@@ -163,6 +165,8 @@ export function Workspace({ config }: WorkspaceViewProps) {
         ref={canvasRef}
         data-testid="workspace-canvas"
         className="bg-background relative h-full w-full shrink overflow-hidden select-none"
+        // Only a press on the canvas itself clears: the bricks are its children, so without the
+        // target check every click that selected one would arrive here and drop it again.
         onClick={(event) => {
           if (event.target === event.currentTarget) clearSelection();
         }}

--- a/modules/masonry/src/stores/workspace.test.ts
+++ b/modules/masonry/src/stores/workspace.test.ts
@@ -26,10 +26,41 @@ describe('Workspace Store Collision Space', () => {
         act(() => {
             useWorkspaceStore.setState({
                 towers: {},
+                selectedBrickId: null,
                 statementConnectors: {},
                 argumentConnectors: {},
             });
         });
+    });
+
+    it('selects and clears a brick', () => {
+        const store = useWorkspaceStore.getState();
+
+        act(() => {
+            store.selectBrick('brick-1');
+        });
+        expect(useWorkspaceStore.getState().selectedBrickId).toBe('brick-1');
+
+        act(() => {
+            useWorkspaceStore.getState().clearSelection();
+        });
+        expect(useWorkspaceStore.getState().selectedBrickId).toBeNull();
+    });
+
+    it('clears the selection when the selected tower is removed', () => {
+        const root = makeEmptyStatement('selected-root', 0, false);
+
+        act(() => {
+            useWorkspaceStore.getState().createTower({
+                id: 'selected-tower',
+                root,
+                position: { x: 0, y: 0 },
+            });
+            useWorkspaceStore.getState().selectBrick(root.model.id);
+            useWorkspaceStore.getState().removeTower('selected-tower');
+        });
+
+        expect(useWorkspaceStore.getState().selectedBrickId).toBeNull();
     });
 
     it('extracts and syncs statement connectors correctly', () => {

--- a/modules/masonry/src/stores/workspace.test.ts
+++ b/modules/masonry/src/stores/workspace.test.ts
@@ -63,6 +63,49 @@ describe('Workspace Store Collision Space', () => {
         expect(useWorkspaceStore.getState().selectedBrickId).toBeNull();
     });
 
+    it('keeps a selection that belongs to a tower other than the one removed', () => {
+        const kept = makeEmptyStatement('kept-root', 0, false);
+        const doomed = makeEmptyStatement('doomed-root', 0, false);
+
+        act(() => {
+            useWorkspaceStore.getState().createTower({
+                id: 'kept-tower',
+                root: kept,
+                position: { x: 0, y: 0 },
+            });
+            useWorkspaceStore.getState().createTower({
+                id: 'doomed-tower',
+                root: doomed,
+                position: { x: 0, y: 0 },
+            });
+            useWorkspaceStore.getState().selectBrick(kept.model.id);
+            useWorkspaceStore.getState().removeTower('doomed-tower');
+        });
+
+        expect(useWorkspaceStore.getState().selectedBrickId).toBe('kept-root');
+    });
+
+    it('keeps the selection when a join moves the brick into the tower that absorbs it', () => {
+        const host = makeEmptyStatement('host-root', 0, false);
+        const dragged = makeEmptyStatement('dragged-root', 0, false);
+
+        act(() => {
+            const store = useWorkspaceStore.getState();
+
+            store.createTower({ id: 'host-tower', root: host, position: { x: 0, y: 0 } });
+            store.createTower({ id: 'dragged-tower', root: dragged, position: { x: 0, y: 0 } });
+            store.selectBrick('dragged-root');
+
+            // What a join does: splice the graphs together, then drop the emptied tower.
+            host.next = dragged;
+            dragged.prev = host;
+            store.absorbTower('dragged-tower', 'host-tower');
+        });
+
+        // The brick is still on the canvas, just under a different tower, so it stays selected.
+        expect(useWorkspaceStore.getState().selectedBrickId).toBe('dragged-root');
+    });
+
     it('extracts and syncs statement connectors correctly', () => {
         const root = statementTreeNoNesting;
 

--- a/modules/masonry/src/stores/workspace.ts
+++ b/modules/masonry/src/stores/workspace.ts
@@ -19,6 +19,8 @@ import { listNodes, listVisibleNodes } from '@/utils/tower-traversal';
 export interface WorkspaceStore {
     /** Record of all towers currently in the workspace, keyed by their unique ID */
     towers: Record<string, TowerState>;
+    /** ID of the currently selected brick, or null when nothing is selected */
+    selectedBrickId: string | null;
 
     /** Collision space tracking statement connection points */
     statementCollisionSpace: QuadtreeCollisionSpace;
@@ -34,6 +36,11 @@ export interface WorkspaceStore {
     createTower: (tower: TowerState) => void;
     /** Removes a tower from the workspace by its ID. */
     removeTower: (id: string) => void;
+    /** Selects a brick by its ID */
+    selectBrick: (id: string) => void;
+
+    /** Clears the current brick selection */
+    clearSelection: () => void;
     /** Updates the position of an existing tower. */
     updateTowerPosition: (id: string, position: Point) => void;
     /** Synchronises the statement collision points for a tower after layout */
@@ -67,6 +74,7 @@ export interface WorkspaceStore {
 export const useWorkspaceStore = create<WorkspaceStore>()(
     subscribeWithSelector((set, get) => ({
         towers: {},
+        selectedBrickId: null,
         statementCollisionSpace: new QuadtreeCollisionSpace(4000, 4000),
         statementConnectors: {},
         argumentCollisionSpace: new QuadtreeCollisionSpace(4000, 4000),
@@ -77,11 +85,24 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
                 towers: { ...state.towers, [tower.id]: tower },
             }));
         },
+        selectBrick: (id) => {
+            set({ selectedBrickId: id });
+        },
+        clearSelection: () => {
+            set({ selectedBrickId: null });
+        },
 
         removeTower: (id) => {
             set((state) => {
                 const newTowers = { ...state.towers };
                 delete newTowers[id];
+                const selectedBrickId = state.selectedBrickId;
+                const removedTower = state.towers[id];
+                const selectedNodeBelongsToTower = selectedBrickId && removedTower
+                    ? listNodes(removedTower.root).some(
+                          (node) => node.model.id === selectedBrickId,
+                      )
+                    : false;
 
                 // Cleanup statement collision points
                 const stmtIds = Object.values(state.statementConnectors)
@@ -105,6 +126,7 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
 
                 return {
                     towers: newTowers,
+                    selectedBrickId: selectedNodeBelongsToTower ? null : state.selectedBrickId,
                     statementConnectors: newStatementConnectors,
                     argumentConnectors: newArgumentConnectors,
                 };

--- a/modules/masonry/src/stores/workspace.ts
+++ b/modules/masonry/src/stores/workspace.ts
@@ -96,13 +96,16 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
             set((state) => {
                 const newTowers = { ...state.towers };
                 delete newTowers[id];
+                // The selection follows the brick rather than the tower holding it. A join splices
+                // the dragged brick into its host before the emptied tower is dropped through
+                // here, so leaving this tower is not the same as leaving the canvas: what decides
+                // it is whether any tower that remains still holds the brick.
                 const selectedBrickId = state.selectedBrickId;
-                const removedTower = state.towers[id];
-                const selectedNodeBelongsToTower = selectedBrickId && removedTower
-                    ? listNodes(removedTower.root).some(
-                          (node) => node.model.id === selectedBrickId,
-                      )
-                    : false;
+                const selectionSurvives =
+                    selectedBrickId === null ||
+                    Object.values(newTowers).some((tower) =>
+                        listNodes(tower.root).some((node) => node.model.id === selectedBrickId),
+                    );
 
                 // Cleanup statement collision points
                 const stmtIds = Object.values(state.statementConnectors)
@@ -126,7 +129,7 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
 
                 return {
                     towers: newTowers,
-                    selectedBrickId: selectedNodeBelongsToTower ? null : state.selectedBrickId,
+                    selectedBrickId: selectionSurvives ? state.selectedBrickId : null,
                     statementConnectors: newStatementConnectors,
                     argumentConnectors: newArgumentConnectors,
                 };

--- a/modules/masonry/src/utils/color.test.ts
+++ b/modules/masonry/src/utils/color.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { darkenColor } from './color';
+
+describe('darkenColor', () => {
+    it('drops lightness while keeping the hue', () => {
+        // #ffb703 is hsl(43, 100%, 51%); dropping by 0.45 lands on hsl(43, 100%, 28%).
+        expect(darkenColor('#ffb703', 0.45)).toBe('#8e6500');
+    });
+
+    it('expands the short hex form', () => {
+        expect(darkenColor('#f00', 0.5)).toBe(darkenColor('#ff0000', 0.5));
+    });
+
+    it('keeps grays gray', () => {
+        expect(darkenColor('#808080', 0.5)).toBe('#404040');
+    });
+
+    it('returns the color untouched at zero and black at one', () => {
+        expect(darkenColor('#29b6f6', 0)).toBe('#29b6f6');
+        expect(darkenColor('#29b6f6', 1)).toBe('#000000');
+    });
+
+    it('leaves anything that is not a plain hex color alone', () => {
+        expect(darkenColor('#00000033', 0.5)).toBe('#00000033');
+        expect(darkenColor('rebeccapurple', 0.5)).toBe('rebeccapurple');
+    });
+});

--- a/modules/masonry/src/utils/color.ts
+++ b/modules/masonry/src/utils/color.ts
@@ -1,0 +1,80 @@
+/** Matches `#rgb` and `#rrggbb`, capturing nothing — used only to reject anything else. */
+const HEX_COLOR = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+/**
+ * Expands `#rgb` to the six digits of `#rrggbb`, and returns the six digits of an already-long
+ * form unchanged.
+ */
+function normalizeHex(hex: string): string {
+    const digits = hex.slice(1);
+    return digits.length === 3
+        ? digits
+              .split('')
+              .map((d) => d + d)
+              .join('')
+        : digits;
+}
+
+/**
+ * Darkens a hex color, keeping its hue and saturation.
+ *
+ * The drop happens in HSL rather than by mixing toward black in RGB: mixing muddies the hue, and a
+ * selection highlight has to stay recognisably the brick's own color to read as belonging to it.
+ * Grays stay gray, since a zero saturation survives the round trip.
+ *
+ * @param hex - source color as `#rgb` or `#rrggbb`
+ * @param amount - how far to drop the lightness toward black, 0 (unchanged) to 1 (black)
+ * @returns the darkened color as `#rrggbb`, or `hex` untouched when it isn't a plain hex color
+ */
+export function darkenColor(hex: string, amount: number): string {
+    if (!HEX_COLOR.test(hex)) return hex;
+
+    const digits = normalizeHex(hex);
+    const r = parseInt(digits.slice(0, 2), 16) / 255;
+    const g = parseInt(digits.slice(2, 4), 16) / 255;
+    const b = parseInt(digits.slice(4, 6), 16) / 255;
+
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const chroma = max - min;
+
+    const l = (max + min) / 2;
+    const s = chroma === 0 ? 0 : chroma / (1 - Math.abs(2 * l - 1));
+
+    let h = 0;
+    if (chroma !== 0) {
+        if (max === r) h = ((g - b) / chroma) % 6;
+        else if (max === g) h = (b - r) / chroma + 2;
+        else h = (r - g) / chroma + 4;
+        h *= 60;
+        if (h < 0) h += 360;
+    }
+
+    const clamped = Math.min(Math.max(amount, 0), 1);
+    const dropped = l * (1 - clamped);
+
+    // HSL back to RGB, via the standard chroma/intermediate decomposition.
+    const c = (1 - Math.abs(2 * dropped - 1)) * s;
+    const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+    const m = dropped - c / 2;
+
+    const [r1, g1, b1] =
+        h < 60
+            ? [c, x, 0]
+            : h < 120
+              ? [x, c, 0]
+              : h < 180
+                ? [0, c, x]
+                : h < 240
+                  ? [0, x, c]
+                  : h < 300
+                    ? [x, 0, c]
+                    : [c, 0, x];
+
+    const toHex = (v: number) =>
+        Math.round((v + m) * 255)
+            .toString(16)
+            .padStart(2, '0');
+
+    return `#${toHex(r1)}${toHex(g1)}${toHex(b1)}`;
+}


### PR DESCRIPTION
## Description

Currently, users can delete workspace bricks only by dragging them onto the trash circle. Music Blocks v3 also supports deleting the selected block with `Delete`, so the workspace needs a keyboard deletion route.
## fixes : #818 
## Solution

- Added `selectedBrickId` to the workspace store.
- Clicking a brick selects it.
- Added a visible outline around the selected brick.
- Clicking the empty workspace clears the selection.
- Pressing `Escape` clears the selection.
- Pressing `Delete` or `Backspace`:
  - removes the complete tower when the selected brick is the tower root;
  - extracts and removes the selected brick subtree when the brick is nested.
- Prevented `Backspace` from navigating the browser.
- Prevented deletion while the user is typing in an input.
- Clears stale selection when the selected tower is removed.

The separate Drag & Drop demo boxes were not changed because they are independent demo elements, not workspace bricks.

