### PR TITLE
#808 | feat(masonry): add canvas panning, dynamic bounds clamping, and viewport tests

### DIFF
--- a/modules/masonry/src/components/Workspace/Workspace.tsx
+++ b/modules/masonry/src/components/Workspace/Workspace.tsx
@@ -11,6 +11,7 @@ import { useDragFromPalette } from '@/hooks/useDragFromPalette';
 import { useTowerLayout } from '@/hooks/useTowerLayout';
 import { useWorkspaceScale } from '@/hooks/useWorkspaceScale';
 import { useBrickLayoutStore } from '@/stores/brick';
+import { useWorkspaceViewportStore } from '@/stores/viewport';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { listVisibleNodes } from '@/utils/tower-traversal';
 
@@ -27,6 +28,7 @@ function TowerLayoutEngine({ root, origin }: { root: TowerNode; origin: Point })
 }
 
 export function Workspace({ config }: WorkspaceViewProps) {
+  const { offsetX, offsetY } = useWorkspaceViewportStore();
   const { palette } = config;
 
   const towersRecord = useWorkspaceStore((state) => state.towers);
@@ -83,6 +85,59 @@ export function Workspace({ config }: WorkspaceViewProps) {
     );
   }, []);
 
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const handleWheel = (e: WheelEvent) => {
+      let dx = e.deltaX;
+      let dy = e.deltaY;
+
+      // Normalize Shift+Wheel for browsers that do not natively map it to deltaX
+      if (e.shiftKey && dx === 0) {
+        dx = dy;
+        dy = 0;
+      }
+
+      const current = useWorkspaceViewportStore.getState();
+      const workspaceState = useWorkspaceStore.getState();
+
+      // Calculate dynamic bounds based on existing towers/blocks
+      const towers = Object.values(workspaceState.towers || {});
+      let minContentX = -1000;
+      let maxContentX = 3000;
+      let minContentY = -1000;
+      let maxContentY = 3000;
+
+      if (towers.length > 0) {
+        const padding = 500;
+        const xs = towers.map(t => t.position?.x ?? 0);
+        const ys = towers.map(t => t.position?.y ?? 0);
+        
+        minContentX = Math.min(...xs) - padding;
+        maxContentX = Math.max(...xs) + padding;
+        minContentY = Math.min(...ys) - padding;
+        maxContentY = Math.max(...ys) + padding;
+      }
+
+      const nextX = Math.min(Math.max(current.offsetX - dx, -maxContentX), -minContentX);
+      const nextY = Math.min(Math.max(current.offsetY - dy, -maxContentY), -minContentY);
+
+      // Only preventDefault and update if the canvas actually moves
+      if (nextX !== current.offsetX || nextY !== current.offsetY) {
+        e.preventDefault();
+        useWorkspaceViewportStore.getState().setOffset(nextX, nextY);
+      }
+    };
+
+    // passive: false is required to safely call preventDefault on wheel events
+    canvas.addEventListener('wheel', handleWheel, { passive: false });
+    
+    return () => {
+      canvas.removeEventListener('wheel', handleWheel);
+    };
+  }, []);
+
   return (
     <div ref={rootRef} className="relative flex h-full w-full">
       <div className="h-full max-w-80">
@@ -97,14 +152,22 @@ export function Workspace({ config }: WorkspaceViewProps) {
         {towers.map((tower) => (
           <TowerLayoutEngine key={`layout-${tower.id}`} root={tower.root} origin={tower.position} />
         ))}
-        {/* TowerBrickView renders the actual DOM nodes for the visible bricks in a flattened list */}
-        {visibleNodes.map((node) => (
-          <TowerBrickView key={node.model.id} id={node.model.id} node={node} />
-        ))}
+        
+        {/* Dedicated layer for panning transforms */}
+        <div 
+          className="brick-layer absolute top-0 left-0 h-full w-full"
+          style={{ transform: `translate(${offsetX}px, ${offsetY}px)` }}
+        >
+          {/* TowerBrickView renders the actual DOM nodes for the visible bricks in a flattened list */}
+          {visibleNodes.map((node) => (
+            <TowerBrickView key={node.model.id} id={node.model.id} node={node} />
+          ))}
 
-        <SnapHintOverlay />
-        <SnapPreviewView />
-        <DisconnectShadowView />
+          <SnapHintOverlay />
+          <SnapPreviewView />
+          <DisconnectShadowView />
+        </div>
+
         <ScaleControl />
         {/* The Trash is only useful once there is something to remove */}
         {towers.length > 0 && <Trash canvasRef={canvasRef} />}

--- a/modules/masonry/src/hooks/useDragFromPalette.test.tsx
+++ b/modules/masonry/src/hooks/useDragFromPalette.test.tsx
@@ -7,6 +7,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { clientToLocalPoint } from './useDragFromPalette';
+import { useWorkspaceViewportStore } from '@/stores/viewport';
 
 // -------------------------------------------------------------------------------------------------
 
@@ -34,5 +35,12 @@ describe('clientToLocalPoint', () => {
     const local = clientToLocalPoint({ x: 10, y: 20 }, { x: 320, y: 40 }, { x: 5, y: 5 });
 
     expect(local).toEqual({ x: -315, y: -25 });
+  });
+  
+  it('accounts for viewport pan offsets when converting points', () => {
+    useWorkspaceViewportStore.setState({ offsetX: -100, offsetY: -50 });
+    const local = clientToLocalPoint({ x: 500, y: 300 }, { x: 320, y: 40 }, { x: 0, y: 0 });
+
+    expect(local).toEqual({ x: 280, y: 310 });
   });
 });

--- a/modules/masonry/src/hooks/useDragFromPalette.ts
+++ b/modules/masonry/src/hooks/useDragFromPalette.ts
@@ -10,6 +10,7 @@ import type { PaletteBrickConfig } from '@/@types/palette.types';
 import { usePaletteDragStore } from '@/stores/palette';
 import { useWorkspaceScaleStore } from '@/stores/scale';
 import { useWorkspaceStore } from '@/stores/workspace';
+import { useWorkspaceViewportStore } from '@/stores/viewport';
 import { createBrickModel, wrapAsRootNode } from '@/utils/brick-model-factory';
 import { useConnectionPreviewStore } from '@/stores/connection-preview';
 import { resolveCandidateConnection } from '@/utils/snap-preview-calculator';
@@ -29,10 +30,11 @@ export const PALETTE_DRAG_SOURCE_SELECTOR = '.palette-brick-slot';
  * top-left corner rather than the pointer position.
  */
 export function clientToLocalPoint(client: Point, origin: Point, grabOffset: Point): Point {
-    return {
-        x: client.x - origin.x - grabOffset.x,
-        y: client.y - origin.y - grabOffset.y,
-    };
+  const { offsetX, offsetY } = useWorkspaceViewportStore.getState();
+  return {
+    x: client.x - origin.x - grabOffset.x - offsetX,
+    y: client.y - origin.y - grabOffset.y - offsetY,
+  };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -123,7 +125,8 @@ export function useDragFromPalette(options: UseDragFromPaletteOptions) {
                     // re-render per pixel; dataset.x/y is the running total between events.
                     const x = (parseFloat(ghost.dataset.x ?? '0') || 0) + event.dx;
                     const y = (parseFloat(ghost.dataset.y ?? '0') || 0) + event.dy;
-                    ghost.style.transform = `translate(${x}px, ${y}px)`;
+                    const { offsetX, offsetY } = useWorkspaceViewportStore.getState();
+                    ghost.style.transform = `translate(${x + offsetX}px, ${y + offsetY}px)`;
                     ghost.dataset.x = String(x);
                     ghost.dataset.y = String(y);
 
@@ -206,8 +209,11 @@ export function useDragFromPalette(options: UseDragFromPaletteOptions) {
                         drag.grabOffset,
                     );
 
-                    // Prevent placing the brick if it is still partially over the palette
-                    if (position.x < 0) return;
+                    const { offsetX } = useWorkspaceViewportStore.getState();
+
+                    // Prevent placing the brick if it is still over the palette 
+                    // Subtracting offsetX neutralizes the pan shift for this screen-space check
+                    if (position.x + offsetX < 0) return;
 
                     const newTowerId = crypto.randomUUID();
                     createTower({

--- a/modules/masonry/src/stores/viewport.test.ts
+++ b/modules/masonry/src/stores/viewport.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useWorkspaceViewportStore } from './viewport';
+
+describe('useWorkspaceViewportStore', () => {
+  beforeEach(() => {
+    useWorkspaceViewportStore.setState({ offsetX: 0, offsetY: 0, scale: 1 });
+  });
+
+  it('should initialize with default offset values', () => {
+    const state = useWorkspaceViewportStore.getState();
+    expect(state.offsetX).toBe(0);
+    expect(state.offsetY).toBe(0);
+  });
+
+  it('should update offsets correctly using setOffset', () => {
+    const { setOffset } = useWorkspaceViewportStore.getState();
+    setOffset(150, -250);
+
+    const state = useWorkspaceViewportStore.getState();
+    expect(state.offsetX).toBe(150);
+    expect(state.offsetY).toBe(-250);
+  });
+
+  it('should update offsets correctly using pan', () => {
+    const { pan } = useWorkspaceViewportStore.getState();
+    pan(50, 50);
+    pan(20, -10);
+
+    const state = useWorkspaceViewportStore.getState();
+    expect(state.offsetX).toBe(70);
+    expect(state.offsetY).toBe(40);
+  });
+});

--- a/modules/masonry/src/stores/viewport.ts
+++ b/modules/masonry/src/stores/viewport.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand';
+import { subscribeWithSelector } from 'zustand/middleware';
+
+export interface WorkspaceViewportStore {
+  /** The horizontal pan offset of the canvas (0 is default) */
+  offsetX: number;
+  /** The vertical pan offset of the canvas (0 is default) */
+  offsetY: number;
+  
+  /** Sets the absolute viewport offset coordinates. */
+  setOffset: (x: number, y: number) => void;
+  /** Shifts the current viewport offset by relative deltas. */
+  pan: (dx: number, dy: number) => void;
+}
+
+/**
+ * Tracks the workspace's viewport pan offsets.
+ * Used to translate the brick layer without moving static UI controls.
+ */
+export const useWorkspaceViewportStore = create<WorkspaceViewportStore>()(
+  subscribeWithSelector((set) => ({
+    offsetX: 0,
+    offsetY: 0,
+    
+    setOffset: (x, y) => set({ offsetX: x, offsetY: y }),
+    
+    pan: (dx, dy) => set((state) => ({ 
+      offsetX: state.offsetX + dx, 
+      offsetY: state.offsetY + dy 
+    })),
+  }))
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -409,6 +409,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2164,6 +2165,7 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -2277,6 +2279,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -2325,6 +2328,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -4784,9 +4788,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4801,9 +4802,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4818,9 +4816,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4835,9 +4830,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4888,6 +4880,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -5337,29 +5330,6 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -5703,29 +5673,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
-      "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
-      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
@@ -6379,29 +6326,6 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
@@ -8044,8 +7968,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -8195,6 +8118,7 @@
       "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -8219,6 +8143,7 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -8302,6 +8227,7 @@
       "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.0",
         "@typescript-eslint/types": "8.61.0",
@@ -8819,6 +8745,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9672,6 +9599,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -11368,8 +11296,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -11439,6 +11366,7 @@
       "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "jake": "^10.8.5"
       },
@@ -11789,6 +11717,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -11880,6 +11809,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -11936,6 +11866,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -13767,6 +13698,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
       "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -16292,7 +16224,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -19387,6 +19318,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.4.5",
         "@emnapi/runtime": "1.4.5",
@@ -21284,6 +21216,7 @@
       "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -21405,7 +21338,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -21421,7 +21353,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -21742,6 +21673,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -21807,6 +21739,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -21819,8 +21752,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-is-18": {
       "name": "react-is",
@@ -22752,6 +22684,7 @@
       "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.137.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -22803,6 +22736,7 @@
       "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -24329,6 +24263,7 @@
       "integrity": "sha512-6wkA6LxfDSSilloITsrFOJfsnw0mDUP2h8Ls+lRt8oRsudtz2RWFhLv+Toiwg6NW7hUpdTDc2hzR7DztJid6+A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.2",
@@ -25660,6 +25595,7 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -25888,6 +25824,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -26370,6 +26307,7 @@
       "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -26555,6 +26493,7 @@
       "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.9",
         "@vitest/mocker": "4.1.9",
@@ -27088,6 +27027,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -27635,6 +27575,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## closes #808

## Overview
This pull request implements a functional, draggable canvas workspace for the MusicBlocks v4 masonry module, adding vertical and horizontal panning capabilities, dynamic boundary clamping, coordinate accuracy during drag-and-drop operations, and test coverage.

## Changes Implemented

* Created a centralized Zustand store (`viewport.ts`) to manage `offsetX` and `offsetY` viewport pan states.

* Modified `Workspace.tsx` to wrap active masonry blocks/towers in a dedicated container element applying a CSS `transform: translate(${offsetX}px, ${offsetY}px)` property.
* Ensured static controls like `ScaleControl` and `Trash` remain locked in place on the screen.

* Attached a non-passive wheel event listener (`{ passive: false }`) directly to the canvas container to properly intercept user scroll gestures and call `e.preventDefault()` only when the canvas consumes the event.
* Handled both native trackpad horizontal scrolling (`deltaX`) and mouse-wheel scrolling with `Shift + deltaY`.
* Calculated dynamic bounds using active tower coordinates plus a `500px` padding buffer, preventing infinite scrolling into empty space.

* Updated `clientToLocalPoint` within the `useDragFromPalette` hook to integrate viewport pan offsets, ensuring dragged elements land precisely under the cursor regardless of canvas translation.
* Resolved an issue where the `position.x < 0` palette guard misfired after rightward panning.

### Testing
* Added unit tests including a new store test file (`viewport.test.ts`) and updated coordinate math tests in (`useDragFromPalette.test.tsx`).

Playground (npm run playground2 in modules/masonry, the Workspace page):

https://github.com/user-attachments/assets/5d03d1f5-ca2d-4087-817a-f4384456f2fa

