### PR TITLE
#811 | feat(masonry): clean the workspace into a column of towers

### DIFF
--- a/modules/masonry/src/@types/workspace.types.ts
+++ b/modules/masonry/src/@types/workspace.types.ts
@@ -36,6 +36,23 @@ export interface TowerState {
 }
 
 /**
+ * Options for the workspace store's `cleanWorkspace` action, which lays every tower out in a
+ * column that wraps into further columns to the right.
+ */
+export interface CleanWorkspaceOptions {
+    /**
+     * Height of the area the towers are laid out in, in pixels — the canvas height. A tower whose
+     * bottom edge would cross it (less the padding) starts a new column. Omitted, the column
+     * never wraps.
+     */
+    maxColumnHeight?: number;
+    /** Distance from the canvas edges to the nearest tower, in pixels. */
+    padding?: number;
+    /** Distance between one tower and the next, and between columns, in pixels. */
+    gap?: number;
+}
+
+/**
  * Metadata for a statement connector point in the collision space.
  * Allows querying the corresponding Brick and Tower instance from a collision hit.
  */

--- a/modules/masonry/src/components/Workspace/CleanControl.test.tsx
+++ b/modules/masonry/src/components/Workspace/CleanControl.test.tsx
@@ -1,6 +1,6 @@
 // Component test for the Workspace's CleanControl button.
-// Verifies button rendering, the disabled state off the workspace store, and that a click tidies
-// the towers with the canvas height it is handed.
+// Verifies button rendering, the disabled state off the workspace store, that a click tidies the
+// towers with the canvas height it is handed, and that it brings a panned canvas back home.
 
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -10,6 +10,7 @@ import type { Point } from '@/@types/common.types';
 
 import { makeEmptyStatement } from '@/mocks/tower';
 import { useBrickLayoutStore } from '@/stores/brick';
+import { useWorkspaceViewportStore } from '@/stores/viewport';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { CLEAN_WORKSPACE_GAP, CLEAN_WORKSPACE_PADDING } from '@/utils/constants';
 
@@ -19,6 +20,7 @@ afterEach(() => {
   cleanup();
   useWorkspaceStore.setState({ towers: {}, statementConnectors: {}, argumentConnectors: {} });
   useBrickLayoutStore.setState({ coords: {}, mounted: {}, positioned: {} });
+  useWorkspaceViewportStore.setState({ offset: { x: 0, y: 0 } });
 });
 
 /** A canvas stand-in reporting `clientHeight`, which jsdom would otherwise leave at zero. */
@@ -91,6 +93,22 @@ describe('CleanControl', () => {
 
     expect(useWorkspaceStore.getState().towers['t2'].position).toEqual({
       x: CLEAN_WORKSPACE_PADDING + w + CLEAN_WORKSPACE_GAP,
+      y: CLEAN_WORKSPACE_PADDING,
+    });
+  });
+
+  // cleanWorkspace works in canvas coordinates, so on a panned canvas the tidied column would land
+  // outside the view. The button brings the canvas home first.
+  it('returns a panned canvas to the origin before tidying', () => {
+    addTower('t1', { x: 500, y: 300 });
+    useWorkspaceViewportStore.getState().setOffset({ x: 260, y: 140 });
+    render(<CleanControl canvasRef={{ current: null }} />);
+
+    fireEvent.click(cleanButton());
+
+    expect(useWorkspaceViewportStore.getState().offset).toEqual({ x: 0, y: 0 });
+    expect(useWorkspaceStore.getState().towers['t1'].position).toEqual({
+      x: CLEAN_WORKSPACE_PADDING,
       y: CLEAN_WORKSPACE_PADDING,
     });
   });

--- a/modules/masonry/src/components/Workspace/CleanControl.test.tsx
+++ b/modules/masonry/src/components/Workspace/CleanControl.test.tsx
@@ -1,0 +1,97 @@
+// Component test for the Workspace's CleanControl button.
+// Verifies button rendering, the disabled state off the workspace store, and that a click tidies
+// the towers with the canvas height it is handed.
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { RefObject } from 'react';
+
+import type { Point } from '@/@types/common.types';
+
+import { makeEmptyStatement } from '@/mocks/tower';
+import { useBrickLayoutStore } from '@/stores/brick';
+import { useWorkspaceStore } from '@/stores/workspace';
+import { CLEAN_WORKSPACE_GAP, CLEAN_WORKSPACE_PADDING } from '@/utils/constants';
+
+import { CleanControl } from './CleanControl';
+
+afterEach(() => {
+  cleanup();
+  useWorkspaceStore.setState({ towers: {}, statementConnectors: {}, argumentConnectors: {} });
+  useBrickLayoutStore.setState({ coords: {}, mounted: {}, positioned: {} });
+});
+
+/** A canvas stand-in reporting `clientHeight`, which jsdom would otherwise leave at zero. */
+function canvasOfHeight(clientHeight: number): RefObject<HTMLElement | null> {
+  const canvas = document.createElement('div');
+  Object.defineProperty(canvas, 'clientHeight', { value: clientHeight });
+  return { current: canvas };
+}
+
+/** A one-brick tower whose root has real dims, so the tidy has something to measure. */
+function addTower(id: string, position: Point) {
+  const root = makeEmptyStatement(id, 0);
+  root.model.widgetDims = { w: 40, h: 14 };
+  root.model.computeDims();
+  useWorkspaceStore.getState().createTower({ id, root, position });
+  return root;
+}
+
+function cleanButton() {
+  return screen.getByRole('button', { name: 'Clean workspace' }) as HTMLButtonElement;
+}
+
+describe('CleanControl', () => {
+  it('renders the clean button with its accessibility label', () => {
+    render(<CleanControl canvasRef={{ current: null }} />);
+
+    expect(cleanButton()).toBeTruthy();
+  });
+
+  it('is disabled while the workspace holds no tower', () => {
+    render(<CleanControl canvasRef={{ current: null }} />);
+
+    expect(cleanButton().disabled).toBe(true);
+  });
+
+  it('enables once the workspace holds a tower', () => {
+    render(<CleanControl canvasRef={{ current: null }} />);
+
+    act(() => {
+      addTower('t1', { x: 300, y: 200 });
+    });
+
+    expect(cleanButton().disabled).toBe(false);
+  });
+
+  it('tidies the towers into a column when clicked', () => {
+    addTower('t1', { x: 500, y: 300 });
+    addTower('t2', { x: 100, y: 40 });
+    render(<CleanControl canvasRef={{ current: null }} />);
+
+    fireEvent.click(cleanButton());
+
+    const { towers } = useWorkspaceStore.getState();
+    expect(towers['t2'].position).toEqual({
+      x: CLEAN_WORKSPACE_PADDING,
+      y: CLEAN_WORKSPACE_PADDING,
+    });
+    expect(towers['t1'].position.x).toBe(CLEAN_WORKSPACE_PADDING);
+    expect(towers['t1'].position.y).toBeGreaterThan(CLEAN_WORKSPACE_PADDING);
+  });
+
+  it('wraps the column at the height of the canvas it is given', () => {
+    const first = addTower('t1', { x: 0, y: 0 });
+    addTower('t2', { x: 0, y: 100 });
+    // Room for one tower and no more, so the second one has to start a column of its own.
+    const { w, h } = first.model.dims;
+    render(<CleanControl canvasRef={canvasOfHeight(CLEAN_WORKSPACE_PADDING * 2 + h)} />);
+
+    fireEvent.click(cleanButton());
+
+    expect(useWorkspaceStore.getState().towers['t2'].position).toEqual({
+      x: CLEAN_WORKSPACE_PADDING + w + CLEAN_WORKSPACE_GAP,
+      y: CLEAN_WORKSPACE_PADDING,
+    });
+  });
+});

--- a/modules/masonry/src/components/Workspace/CleanControl.tsx
+++ b/modules/masonry/src/components/Workspace/CleanControl.tsx
@@ -1,0 +1,40 @@
+import { BrushCleaning } from 'lucide-react';
+import type { RefObject } from 'react';
+
+import { useWorkspaceStore } from '@/stores/workspace';
+import { Button } from '@/ui/button';
+
+interface CleanControlProps {
+  /** The canvas the towers stand on; its height is where a column of tidied towers wraps. */
+  canvasRef: RefObject<HTMLElement | null>;
+}
+
+/**
+ * Workspace-wide tidy control: one button that lays every tower out in a column, ordered by where
+ * each stands, wrapping into further columns at the canvas height.
+ *
+ * Sits beside `ScaleControl` in the canvas' bottom-right corner and, like it, renders as an
+ * ordinary button rather than `pointer-events-none`: `useDragFromPalette`'s delegated selector only
+ * ever matches `.palette-brick-slot`, never a button. Disabled while there is nothing to tidy.
+ */
+export function CleanControl({ canvasRef }: CleanControlProps) {
+  const isEmpty = useWorkspaceStore((state) => Object.keys(state.towers).length === 0);
+  const { cleanWorkspace } = useWorkspaceStore.getState();
+
+  return (
+    <div className="absolute right-66 bottom-6 z-40 flex h-14 items-center">
+      <Button
+        variant="outline"
+        size="icon"
+        className="size-14 rounded-full border-2"
+        aria-label="Clean workspace"
+        disabled={isEmpty}
+        onClick={() => cleanWorkspace({ maxColumnHeight: canvasRef.current?.clientHeight })}
+      >
+        <BrushCleaning className="size-6" />
+      </Button>
+    </div>
+  );
+}
+
+export default CleanControl;

--- a/modules/masonry/src/components/Workspace/CleanControl.tsx
+++ b/modules/masonry/src/components/Workspace/CleanControl.tsx
@@ -1,6 +1,7 @@
 import { BrushCleaning } from 'lucide-react';
 import type { RefObject } from 'react';
 
+import { useWorkspaceViewportStore } from '@/stores/viewport';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { Button } from '@/ui/button';
 
@@ -16,10 +17,15 @@ interface CleanControlProps {
  * Sits beside `ScaleControl` in the canvas' bottom-right corner and, like it, renders as an
  * ordinary button rather than `pointer-events-none`: `useDragFromPalette`'s delegated selector only
  * ever matches `.palette-brick-slot`, never a button. Disabled while there is nothing to tidy.
+ *
+ * The tidy also brings the canvas home. `cleanWorkspace` lays the towers out in canvas coordinates,
+ * starting at the padding, so on a panned canvas the tidied column would sit outside what the user
+ * is looking at. Resetting the viewport offset first makes the button mean "tidy, and show me".
  */
 export function CleanControl({ canvasRef }: CleanControlProps) {
   const isEmpty = useWorkspaceStore((state) => Object.keys(state.towers).length === 0);
   const { cleanWorkspace } = useWorkspaceStore.getState();
+  const { resetOffset } = useWorkspaceViewportStore.getState();
 
   return (
     <div className="absolute right-66 bottom-6 z-40 flex h-14 items-center">
@@ -29,7 +35,10 @@ export function CleanControl({ canvasRef }: CleanControlProps) {
         className="size-14 rounded-full border-2"
         aria-label="Clean workspace"
         disabled={isEmpty}
-        onClick={() => cleanWorkspace({ maxColumnHeight: canvasRef.current?.clientHeight })}
+        onClick={() => {
+          resetOffset();
+          cleanWorkspace({ maxColumnHeight: canvasRef.current?.clientHeight });
+        }}
       >
         <BrushCleaning className="size-6" />
       </Button>

--- a/modules/masonry/src/components/Workspace/Workspace.test.tsx
+++ b/modules/masonry/src/components/Workspace/Workspace.test.tsx
@@ -17,7 +17,7 @@ import { usePaletteDragStore } from '@/stores/palette';
 import { useTrashStore } from '@/stores/trash';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { createBrickModel, wrapAsRootNode } from '@/utils/brick-model-factory';
-import { FOLD_TOGGLE_SELECTOR } from '@/utils/constants';
+import { CLEAN_WORKSPACE_PADDING, FOLD_TOGGLE_SELECTOR } from '@/utils/constants';
 
 import { Workspace } from './Workspace';
 
@@ -365,6 +365,47 @@ describe('Workspace', () => {
       });
 
       expect(foldToggleOf(container, 't1-outer')!.disabled).toBe(true);
+    });
+  });
+
+  describe('clean control', () => {
+    /** The clean button on the canvas. */
+    function queryClean(container: HTMLElement) {
+      return container.querySelector<HTMLButtonElement>('button[aria-label="Clean workspace"]');
+    }
+
+    it('keeps the clean control on the canvas, disabled while there is nothing to tidy', () => {
+      const { container } = render(<Workspace config={{ palette: paletteConfig }} />);
+
+      expect(queryClean(container)).not.toBeNull();
+      expect(queryClean(container)!.disabled).toBe(true);
+    });
+
+    it('enables it once the workspace holds a tower', () => {
+      const { container } = render(<Workspace config={{ palette: paletteConfig }} />);
+
+      act(() => {
+        useWorkspaceStore.getState().createTower(makeTower('t1'));
+      });
+
+      expect(queryClean(container)!.disabled).toBe(false);
+    });
+
+    it('moves the towers to the canvas padding when pressed', () => {
+      const { container } = render(<Workspace config={{ palette: paletteConfig }} />);
+
+      act(() => {
+        useWorkspaceStore
+          .getState()
+          .createTower({ ...makeTower('t1'), position: { x: 400, y: 300 } });
+      });
+
+      fireEvent.click(queryClean(container)!);
+
+      expect(useWorkspaceStore.getState().towers['t1'].position).toEqual({
+        x: CLEAN_WORKSPACE_PADDING,
+        y: CLEAN_WORKSPACE_PADDING,
+      });
     });
   });
 });

--- a/modules/masonry/src/components/Workspace/Workspace.tsx
+++ b/modules/masonry/src/components/Workspace/Workspace.tsx
@@ -14,6 +14,7 @@ import { useBrickLayoutStore } from '@/stores/brick';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { listVisibleNodes } from '@/utils/tower-traversal';
 
+import { CleanControl } from './CleanControl';
 import { DragGhost } from './DragGhost';
 import { ScaleControl } from './ScaleControl';
 import { SnapHintOverlay } from './SnapHintOverlay';
@@ -105,6 +106,7 @@ export function Workspace({ config }: WorkspaceViewProps) {
         <SnapHintOverlay />
         <SnapPreviewView />
         <DisconnectShadowView />
+        <CleanControl canvasRef={canvasRef} />
         <ScaleControl />
         {/* The Trash is only useful once there is something to remove */}
         {towers.length > 0 && <Trash canvasRef={canvasRef} />}

--- a/modules/masonry/src/stores/workspace.test.ts
+++ b/modules/masonry/src/stores/workspace.test.ts
@@ -11,9 +11,10 @@ import {
     statementTreeWithNesting,
 } from '@/mocks/tower';
 import { exportWorkspace } from '@/utils/import-export';
-import { listNodes, listVisibleNodes } from '@/utils/tower-traversal';
-import type { Bounds, Point } from '@/@types/common.types';
-import type { TowerExpressionNode, TowerStatementNode } from '@/@types/tower.types';
+import { listNodes, listVisibleNodes, measureTowerExtent } from '@/utils/tower-traversal';
+import { CLEAN_WORKSPACE_GAP, CLEAN_WORKSPACE_PADDING } from '@/utils/constants';
+import type { Bounds, Point, Size } from '@/@types/common.types';
+import type { TowerExpressionNode, TowerNode, TowerStatementNode } from '@/@types/tower.types';
 import type { BrickModel } from '@/models/brick';
 import type { QuadtreeCollisionSpace } from '@/utils/collision';
 
@@ -919,6 +920,322 @@ describe('Workspace Store Collision Space', () => {
             expect(Object.keys(useWorkspaceStore.getState().argumentConnectors).length).toBe(
                 atDefault.argument,
             );
+        });
+    });
+
+    describe('cleanWorkspace', () => {
+        const PADDING = CLEAN_WORKSPACE_PADDING;
+        const GAP = CLEAN_WORKSPACE_GAP;
+
+        afterEach(() => {
+            useBrickLayoutStore.setState({ coords: {}, mounted: {}, positioned: {} });
+        });
+
+        /**
+         * Gives a brick real dims the way the layout pass would: a measured widget, then
+         * `computeDims` over it. Returns what the model settled on, since the outline generator
+         * adds its own margins to the widget.
+         */
+        function measure(node: TowerNode, widget: Size): Size {
+            node.model.widgetDims = widget;
+            node.model.computeDims();
+            return node.model.dims;
+        }
+
+        /** Where the store has put the tower with `id`. */
+        function positionOf(id: string): Point {
+            return useWorkspaceStore.getState().towers[id].position;
+        }
+
+        /**
+         * Three one-brick towers with measured roots, laid out where they stand and scrambled on
+         * the canvas: `b` highest up, `c` and `a` on one row below it with `c` to the left. Reading
+         * order — top to bottom, then left to right — is therefore b, c, a.
+         */
+        function setupScrambledTowers() {
+            const roots = {
+                a: makeEmptyStatement('a', 0),
+                b: makeEmptyStatement('b', 0),
+                c: makeEmptyStatement('c', 0),
+            };
+            const dims = {
+                a: measure(roots.a, { w: 40, h: 14 }),
+                b: measure(roots.b, { w: 160, h: 60 }),
+                c: measure(roots.c, { w: 90, h: 30 }),
+            };
+            const positions = {
+                a: { x: 500, y: 300 },
+                b: { x: 700, y: 40 },
+                c: { x: 100, y: 300 },
+            };
+
+            act(() => {
+                const store = useWorkspaceStore.getState();
+                store.createTower({ id: 'tower-a', root: roots.a, position: positions.a });
+                store.createTower({ id: 'tower-b', root: roots.b, position: positions.b });
+                store.createTower({ id: 'tower-c', root: roots.c, position: positions.c });
+            });
+            useBrickLayoutStore
+                .getState()
+                .setCoords({ a: positions.a, b: positions.b, c: positions.c });
+
+            return { roots, dims };
+        }
+
+        it('orders the towers top to bottom, then left to right, off where they stood', () => {
+            setupScrambledTowers();
+
+            act(() => {
+                useWorkspaceStore.getState().cleanWorkspace();
+            });
+
+            const [b, c, a] = ['tower-b', 'tower-c', 'tower-a'].map(positionOf);
+
+            expect(b.y).toBeLessThan(c.y);
+            expect(c.y).toBeLessThan(a.y);
+            // One column: every tower starts at the padding, the first one at the top of it.
+            expect([b.x, c.x, a.x]).toEqual([PADDING, PADDING, PADDING]);
+            expect(b.y).toBe(PADDING);
+        });
+
+        it('leaves the gap between one tower and the next, so no two overlap', () => {
+            const { dims } = setupScrambledTowers();
+
+            // Measured ahead of the tidy, while `coords` still agree with the positions: no layout
+            // runs here to move the bricks along with their towers.
+            const { coords } = useBrickLayoutStore.getState();
+            const extents = Object.fromEntries(
+                Object.values(useWorkspaceStore.getState().towers).map((tower) => [
+                    tower.id,
+                    measureTowerExtent(tower, coords),
+                ]),
+            );
+
+            act(() => {
+                useWorkspaceStore.getState().cleanWorkspace();
+            });
+
+            const [b, c, a] = ['tower-b', 'tower-c', 'tower-a'].map(positionOf);
+
+            expect(c.y).toBe(b.y + dims.b.h + GAP);
+            expect(a.y).toBe(c.y + dims.c.h + GAP);
+
+            // Against the measured extents rather than the arithmetic above: no box meets another.
+            const boxes = Object.values(useWorkspaceStore.getState().towers).map((tower) => ({
+                ...tower.position,
+                ...extents[tower.id],
+            }));
+            for (const box of boxes) {
+                for (const other of boxes) {
+                    if (other === box) continue;
+                    const apart =
+                        box.x + box.w <= other.x ||
+                        other.x + other.w <= box.x ||
+                        box.y + box.h <= other.y ||
+                        other.y + other.h <= box.y;
+                    expect(apart).toBe(true);
+                }
+            }
+        });
+
+        it('wraps into a second column when the next tower would cross maxColumnHeight', () => {
+            const { dims } = setupScrambledTowers();
+            // Room for b and c, one above the other, and not a pixel more.
+            const maxColumnHeight = PADDING + dims.b.h + GAP + dims.c.h + PADDING;
+
+            act(() => {
+                useWorkspaceStore.getState().cleanWorkspace({ maxColumnHeight });
+            });
+
+            expect(positionOf('tower-b')).toEqual({ x: PADDING, y: PADDING });
+            expect(positionOf('tower-c')).toEqual({ x: PADDING, y: PADDING + dims.b.h + GAP });
+            // The new column starts clear of the widest tower in the one before it.
+            expect(positionOf('tower-a')).toEqual({
+                x: PADDING + Math.max(dims.b.w, dims.c.w) + GAP,
+                y: PADDING,
+            });
+        });
+
+        it('keeps a tower taller than the canvas at the head of a column of its own', () => {
+            const { dims } = setupScrambledTowers();
+
+            // Shorter than every tower: each crosses it, so each can only head a column.
+            act(() => {
+                useWorkspaceStore.getState().cleanWorkspace({ maxColumnHeight: 1 });
+            });
+
+            expect(positionOf('tower-b')).toEqual({ x: PADDING, y: PADDING });
+            expect(positionOf('tower-c')).toEqual({ x: PADDING + dims.b.w + GAP, y: PADDING });
+            expect(positionOf('tower-a')).toEqual({
+                x: PADDING + dims.b.w + GAP + dims.c.w + GAP,
+                y: PADDING,
+            });
+        });
+
+        it('lays out with the padding and gap it is given', () => {
+            const { dims } = setupScrambledTowers();
+
+            act(() => {
+                useWorkspaceStore.getState().cleanWorkspace({ padding: 10, gap: 5 });
+            });
+
+            expect(positionOf('tower-b')).toEqual({ x: 10, y: 10 });
+            expect(positionOf('tower-c')).toEqual({ x: 10, y: 10 + dims.b.h + 5 });
+        });
+
+        it('measures a tower the layout has not placed yet by its root brick, not as nothing', () => {
+            const upper = makeEmptyStatement('upper', 0);
+            const lower = makeEmptyStatement('lower', 0);
+            const upperDims = measure(upper, { w: 40, h: 14 });
+            measure(lower, { w: 40, h: 14 });
+
+            // No coords for either: the towers exist, but no layout pass has reached them.
+            act(() => {
+                const store = useWorkspaceStore.getState();
+                store.createTower({ id: 'tower-upper', root: upper, position: { x: 300, y: 100 } });
+                store.createTower({ id: 'tower-lower', root: lower, position: { x: 300, y: 400 } });
+            });
+
+            act(() => {
+                useWorkspaceStore.getState().cleanWorkspace();
+            });
+
+            // Not on top of the first tower: its root brick still takes its room.
+            expect(upperDims.h).toBeGreaterThan(0);
+            expect(positionOf('tower-lower')).toEqual({
+                x: PADDING,
+                y: PADDING + upperDims.h + GAP,
+            });
+        });
+
+        it('pushes the next tower down by the whole tower above it, not its root brick alone', () => {
+            const head = makeEmptyStatement('head', 0);
+            const tail = makeEmptyStatement('tail', 0);
+            head.next = tail;
+            tail.prev = head;
+            const headDims = measure(head, { w: 40, h: 14 });
+            const tailDims = measure(tail, { w: 40, h: 14 });
+            const lone = makeEmptyStatement('lone', 0);
+            measure(lone, { w: 40, h: 14 });
+
+            act(() => {
+                const store = useWorkspaceStore.getState();
+                store.createTower({ id: 'tower-chain', root: head, position: { x: 300, y: 100 } });
+                store.createTower({ id: 'tower-lone', root: lone, position: { x: 300, y: 400 } });
+            });
+            // Laid out: the tail sits flush below the head.
+            useBrickLayoutStore.getState().setCoords({
+                head: { x: 300, y: 100 },
+                tail: { x: 300, y: 100 + headDims.h },
+                lone: { x: 300, y: 400 },
+            });
+
+            act(() => {
+                useWorkspaceStore.getState().cleanWorkspace();
+            });
+
+            expect(positionOf('tower-lone')).toEqual({
+                x: PADDING,
+                y: PADDING + headDims.h + tailDims.h + GAP,
+            });
+        });
+
+        it('replaces every tower root reference so each layout re-runs', () => {
+            const { roots } = setupScrambledTowers();
+
+            act(() => {
+                useWorkspaceStore.getState().cleanWorkspace();
+            });
+
+            const after = useWorkspaceStore.getState().towers;
+
+            for (const key of ['a', 'b', 'c'] as const) {
+                expect(after[`tower-${key}`].root).not.toBe(roots[key]);
+                // Same bricks either side — only the reference is new.
+                expect(after[`tower-${key}`].root.model).toBe(roots[key].model);
+            }
+        });
+
+        it('writes every position in a single update', () => {
+            setupScrambledTowers();
+            const listener = vi.fn();
+            const unsubscribe = useWorkspaceStore.subscribe(listener);
+
+            act(() => {
+                useWorkspaceStore.getState().cleanWorkspace();
+            });
+            unsubscribe();
+
+            expect(listener).toHaveBeenCalledTimes(1);
+        });
+
+        it('re-syncs both connector spaces once the towers have moved, the way a drop does', async () => {
+            const { roots } = setupScrambledTowers();
+            // An expression too, so the argument space has something to hold.
+            const expression = makeEmptyExpression('expr', 1);
+            measure(expression, { w: 40, h: 14 });
+            act(() => {
+                useWorkspaceStore.getState().createTower({
+                    id: 'tower-expr',
+                    root: expression,
+                    position: { x: 900, y: 500 },
+                });
+            });
+
+            act(() => {
+                useWorkspaceStore.getState().cleanWorkspace();
+            });
+
+            // Deferred, like `useBrickMove`'s re-sync: nothing has been extracted yet.
+            expect(Object.keys(useWorkspaceStore.getState().statementConnectors)).toHaveLength(0);
+            expect(Object.keys(useWorkspaceStore.getState().argumentConnectors)).toHaveLength(0);
+
+            // Stands in for the layout's origin fast-path, which is what moves the models in the
+            // browser between the write above and the microtask below.
+            for (const tower of Object.values(useWorkspaceStore.getState().towers)) {
+                tower.root.model.setPosition(tower.position.x, tower.position.y);
+            }
+            await Promise.resolve();
+
+            const state = useWorkspaceStore.getState();
+            const statementMetas = Object.values(state.statementConnectors);
+            const argumentMetas = Object.values(state.argumentConnectors);
+
+            expect(new Set(statementMetas.map((meta) => meta.towerId))).toEqual(
+                new Set(['tower-a', 'tower-b', 'tower-c']),
+            );
+            expect(argumentMetas.map((meta) => meta.towerId)).toContain('tower-expr');
+
+            // Registered where the bricks now are, not where they stood before the tidy.
+            for (const key of ['a', 'b', 'c'] as const) {
+                const model = roots[key].model;
+                const next = model.getConnectorCoords().next!;
+                const meta = statementMetas.find(
+                    (meta) => meta.brickId === model.id && meta.type === 'next',
+                )!;
+                const hits = state.statementCollisionSpace.checkCollision({
+                    id: -1,
+                    x: model.position.x + next.x,
+                    y: model.position.y + next.y,
+                    w: 1,
+                    h: 1,
+                });
+                expect(hits).toContain(meta.id);
+            }
+        });
+
+        it('does nothing on an empty workspace', async () => {
+            const listener = vi.fn();
+            const unsubscribe = useWorkspaceStore.subscribe(listener);
+
+            act(() => {
+                useWorkspaceStore.getState().cleanWorkspace();
+            });
+            await Promise.resolve();
+            unsubscribe();
+
+            expect(listener).not.toHaveBeenCalled();
+            expect(useWorkspaceStore.getState().towers).toEqual({});
         });
     });
 });

--- a/modules/masonry/src/stores/workspace.ts
+++ b/modules/masonry/src/stores/workspace.ts
@@ -4,6 +4,7 @@ import { subscribeWithSelector } from 'zustand/middleware';
 import type { Point } from '@/@types/common.types';
 import type {
     ArgumentConnectorMeta,
+    CleanWorkspaceOptions,
     StatementConnectorMeta,
     TowerState,
 } from '@/@types/workspace.types';
@@ -14,7 +15,8 @@ import { extractStatementConnectors } from '@/utils/statement-collision';
 import { exportWorkspace as exportWorkspaceUtil, importProject } from '@/utils/import-export';
 import type { ExportedProject, ImportIdStrategy } from '@/@types/import-export.types';
 import { useBrickLayoutStore } from '@/stores/brick';
-import { listNodes, listVisibleNodes } from '@/utils/tower-traversal';
+import { listNodes, listVisibleNodes, measureTowerExtent } from '@/utils/tower-traversal';
+import { CLEAN_WORKSPACE_GAP, CLEAN_WORKSPACE_PADDING } from '@/utils/constants';
 
 export interface WorkspaceStore {
     /** Record of all towers currently in the workspace, keyed by their unique ID */
@@ -50,6 +52,11 @@ export interface WorkspaceStore {
     absorbTower: (draggedTowerId: string, hostTowerId: string) => void;
     /** Re-runs every tower's layout, leaving the towers where they are */
     refreshTowerLayouts: () => void;
+    /**
+     * Tidies every tower into a column ordered by where each stands, wrapping into further columns
+     * when `maxColumnHeight` would be crossed, and re-runs each tower's layout at its new origin
+     */
+    cleanWorkspace: (options?: CleanWorkspaceOptions) => void;
     /** Folds or unfolds a brick's nesting cavity and re-runs the layout of the tower holding it */
     setNestingFold: (brickId: string, isFolded: boolean) => void;
     /** Serializes the entire workspace into a flat JSON-serializable structure */
@@ -315,6 +322,88 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
                 }
 
                 return { towers };
+            });
+        },
+
+        cleanWorkspace: (options = {}) => {
+            const {
+                maxColumnHeight,
+                padding = CLEAN_WORKSPACE_PADDING,
+                gap = CLEAN_WORKSPACE_GAP,
+            } = options;
+
+            const current = get().towers;
+            const ids = Object.keys(current);
+            // Nothing to place: returning ahead of `set` keeps the subscribers quiet, the way
+            // `refreshTowerLayouts` is quiet on an empty workspace.
+            if (ids.length === 0) return;
+
+            // Reading order off where each tower stands now — top to bottom, then left to right —
+            // so the result is predictable and two towers side by side keep their order.
+            const ordered = Object.values(current).sort(
+                (a, b) => a.position.y - b.position.y || a.position.x - b.position.x,
+            );
+
+            // Each tower takes the room it is laid out over, so a tall tower pushes the next one
+            // down by what it actually covers rather than by its root brick alone.
+            const { coords } = useBrickLayoutStore.getState();
+
+            const placed: Record<string, Point> = {};
+            let x = padding;
+            let y = padding;
+            let columnWidth = 0;
+
+            for (const tower of ordered) {
+                const extent = measureTowerExtent(tower, coords);
+
+                // A column runs from `padding` down to `maxColumnHeight - padding`. A tower that
+                // would cross the bottom starts the next column, clear of the widest tower in the
+                // one it left — unless it is the first in its column: a tower taller than the
+                // canvas has nowhere better to go, and wrapping it would leave an empty column.
+                const crosses =
+                    maxColumnHeight !== undefined && y + extent.h > maxColumnHeight - padding;
+                if (crosses && y > padding) {
+                    x += columnWidth + gap;
+                    y = padding;
+                    columnWidth = 0;
+                }
+
+                placed[tower.id] = { x, y };
+                y += extent.h + gap;
+                columnWidth = Math.max(columnWidth, extent.w);
+            }
+
+            set((state) => {
+                const towers: Record<string, TowerState> = {};
+                for (const id of ids) {
+                    const tower = state.towers[id];
+                    // Both the position and the root reference change, in this one write: the new
+                    // position moves the tower through the layout's origin fast-path, and the new
+                    // root reference re-runs its full layout the way `refreshTowerLayouts` does,
+                    // so no tower keeps a stale origin.
+                    towers[id] = { ...tower, position: placed[id], root: { ...tower.root } };
+                }
+
+                return { towers };
+            });
+
+            // The move lands through the layout's origin fast-path, which only writes coords and
+            // never fires the `positioned` subscription the Workspace re-syncs the connector
+            // spaces from; the full pass the re-seat triggers does fire it, but only once it has
+            // settled, ticks later. So the connectors are re-synced here, the way `useBrickMove`
+            // does after a drop. In a microtask: the `set` above has React's flush queued ahead
+            // of it, and that flush runs the fast-path, so by the time this runs every brick model
+            // holds its new position.
+            queueMicrotask(() => {
+                const store = get();
+                for (const id of ids) {
+                    const tower = store.towers[id];
+                    // Gone in the meantime: `removeTower` has purged its points already.
+                    if (!tower) continue;
+
+                    store.syncStatementConnectors(id, tower.root);
+                    store.syncArgumentConnectors(id, tower.root);
+                }
             });
         },
 

--- a/modules/masonry/src/utils/constants.ts
+++ b/modules/masonry/src/utils/constants.ts
@@ -47,3 +47,14 @@ export const MAX_SCALE_LEVEL = SCALE_LEVELS[SCALE_LEVELS.length - 1];
  * toggle folds the cavity instead of dragging the brick out of its tower.
  */
 export const FOLD_TOGGLE_SELECTOR = '[data-fold-toggle]';
+
+// ── Workspace ──
+
+/**
+ * How far `cleanWorkspace` keeps the towers from the canvas edges, in pixels: the first tower of
+ * every column starts here, and a column may run down to this far from the bottom.
+ */
+export const CLEAN_WORKSPACE_PADDING = 24;
+
+/** The room `cleanWorkspace` leaves between one tower and the next, and between columns. */
+export const CLEAN_WORKSPACE_GAP = 24;

--- a/modules/masonry/src/utils/tower-traversal.test.ts
+++ b/modules/masonry/src/utils/tower-traversal.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import type { Point, Size } from '@/@types/common.types';
 import type {
     TowerExpressionNode,
     TowerNode,
@@ -11,6 +12,7 @@ import {
     findNode,
     listNodes,
     listVisibleNodes,
+    measureTowerExtent,
     traverseBottomUp,
     traverseTopDown,
 } from './tower-traversal';
@@ -854,5 +856,88 @@ describe('layout traversals with a folded cavity', () => {
                 [outer, inner, innerNext, tail].map((node) => ({ ...node.model.position })),
             ).toEqual(before);
         });
+    });
+});
+
+describe('measureTowerExtent', () => {
+    const ORIGIN: Point = { x: 200, y: 150 };
+
+    /** Sets a widget size and computes dims, the way the layout's measurement pass does. */
+    function measure(node: TowerNode, widget: Size): Size {
+        node.model.widgetDims = widget;
+        node.model.computeDims();
+        return node.model.dims;
+    }
+
+    /** A statement chain of `ids`, linked in order, every brick measured. */
+    function makeChain(...ids: string[]): TowerStatementNode[] {
+        const nodes = ids.map((id) => makeStatement(id, 0, false));
+        nodes.forEach((node, index) => {
+            node.prev = nodes[index - 1] ?? null;
+            node.next = nodes[index + 1] ?? null;
+            measure(node, { w: 60, h: 20 });
+        });
+        return nodes;
+    }
+
+    it('reports the root brick alone while nothing has been laid out', () => {
+        const [head, tail] = makeChain('head', 'tail');
+
+        // Not laid out: the tail has no place on the canvas yet, so it takes no room.
+        expect(measureTowerExtent({ root: head, position: ORIGIN }, {})).toEqual(head.model.dims);
+        expect(tail.model.dims.h).toBeGreaterThan(0);
+    });
+
+    it('reaches to the farthest brick edge, relative to the tower origin', () => {
+        const [head, tail] = makeChain('head', 'tail');
+        const wide = makeValue('wide');
+        measure(wide, { w: 200, h: 10 });
+        head.args = [wide];
+        wide.parent = head;
+
+        // Laid out: the tail flush below the head, the value off to the right of the head.
+        const coords = {
+            head: ORIGIN,
+            tail: { x: ORIGIN.x, y: ORIGIN.y + head.model.dims.h },
+            wide: { x: ORIGIN.x + 30, y: ORIGIN.y },
+        };
+
+        expect(measureTowerExtent({ root: head, position: ORIGIN }, coords)).toEqual({
+            w: 30 + wide.model.dims.w,
+            h: head.model.dims.h + tail.model.dims.h,
+        });
+    });
+
+    it('leaves out the bricks a folded cavity hides', () => {
+        const outer = makeStatement('outer', 0, true);
+        measure(outer, { w: 60, h: 20 });
+        const [inner] = makeChain('inner');
+        outer.nestedNext = inner;
+        inner.prev = outer;
+
+        const coords = {
+            outer: ORIGIN,
+            inner: { x: ORIGIN.x + 20, y: ORIGIN.y + outer.model.dims.h },
+        };
+        const open = measureTowerExtent({ root: outer, position: ORIGIN }, coords);
+
+        outer.model.isNestingFolded = true;
+        const folded = measureTowerExtent({ root: outer, position: ORIGIN }, coords);
+
+        expect(open.h).toBe(outer.model.dims.h + inner.model.dims.h);
+        expect(folded).toEqual(outer.model.dims);
+    });
+
+    it('never shrinks below the root brick', () => {
+        const [head, tail] = makeChain('head', 'tail');
+
+        // The zero placeholder the layout seeds ahead of its first pass, on a tower that stands
+        // away from the canvas origin: an edge measured from there lands before the origin.
+        const placeholders = { head: { x: 0, y: 0 }, tail: { x: 0, y: 0 } };
+
+        expect(measureTowerExtent({ root: head, position: ORIGIN }, placeholders)).toEqual(
+            head.model.dims,
+        );
+        expect(tail.model.dims.h).toBeGreaterThan(0);
     });
 });

--- a/modules/masonry/src/utils/tower-traversal.ts
+++ b/modules/masonry/src/utils/tower-traversal.ts
@@ -1,5 +1,6 @@
-import type { Point } from '@/@types/common.types';
+import type { Point, Size } from '@/@types/common.types';
 import { TowerNode, TowerStatementNode } from '@/@types/tower.types';
+import type { TowerState } from '@/@types/workspace.types';
 
 /**
  * Pushes `start` onto `stack`, along with the rest of its statement chain if it has one.
@@ -99,6 +100,40 @@ export function listNodes(root: TowerNode): TowerNode[] {
  */
 export function listVisibleNodes(root: TowerNode): TowerNode[] {
     return walk(root, true);
+}
+
+/**
+ * Measures how far a tower reaches right and down from its origin: the farthest right edge and the
+ * farthest bottom edge over its visible bricks, each read as the brick's laid-out position in
+ * `coords` relative to `tower.position`, plus its `model.dims`.
+ *
+ * The root sits at the origin by definition, so its own dims are the floor of the result: a tower
+ * whose bricks have no laid-out position yet — or still hold the zero placeholder the layout seeds
+ * ahead of its first pass — measures as its root brick rather than as nothing, so a caller laying
+ * towers out side by side never stacks two of them on the same spot.
+ *
+ * Bricks inside a folded cavity are not on screen, so they take no room here either.
+ *
+ * @param tower - The tower to measure; only its root and position are read.
+ * @param coords - Laid-out brick positions keyed by brick id, as the brick layout store holds them.
+ * @returns The width and height of the tower's bounding box, anchored at its origin.
+ */
+export function measureTowerExtent(
+    tower: Pick<TowerState, 'root' | 'position'>,
+    coords: Record<string, Point>,
+): Size {
+    const { root, position } = tower;
+    let { w, h } = root.model.dims;
+
+    for (const node of listVisibleNodes(root)) {
+        const at = coords[node.model.id];
+        if (at === undefined) continue;
+
+        w = Math.max(w, at.x - position.x + node.model.dims.w);
+        h = Math.max(h, at.y - position.y + node.model.dims.h);
+    }
+
+    return { w, h };
 }
 
 /**


### PR DESCRIPTION
Fixes #811

Adds a Clean action that tidies every tower on the canvas into a column, in the shape @parthdagia05 confirmed on the issue: a column that wraps into further columns when it reaches the canvas height.

What changed

- stores/workspace.ts: a new cleanWorkspace({ maxColumnHeight?, padding?, gap? }) action. It orders the towers by where they stand (top to bottom, then left to right, so two towers side by side keep their order), measures each tower's laid-out extent from the layout store, and places them one under the other from the top-left padding. A tower whose bottom would cross maxColumnHeight minus the padding starts the next column, clear of the widest tower in the column it left; a tower taller than the canvas stays where it is in its column rather than opening an empty one. Positions and root references are written in one set, so the layout's origin fast-path moves each tower and the re-seated root re-runs its full layout, the same way refreshTowerLayouts does. After the move, syncStatementConnectors and syncArgumentConnectors run for every tower in a microtask, the way useBrickMove does after a drop, so the connector spaces match the new positions. An empty workspace returns before set, so subscribers stay quiet.
- utils/tower-traversal.ts: measureTowerExtent(tower, coords), the width and height a tower covers once laid out, taken from the layout coords of its visible bricks (folded cavities excluded).
- components/Workspace/CleanControl.tsx: one round button with the lucide BrushCleaning icon, in the bottom-right cluster next to ScaleControl and Trash, disabled while the canvas is empty. It calls cleanWorkspace with the canvas' clientHeight as maxColumnHeight.
- utils/constants.ts: CLEAN_WORKSPACE_PADDING and CLEAN_WORKSPACE_GAP (24px each).
- @types/workspace.types.ts: CleanWorkspaceOptions.

Both points from the review of the plan are in: cleanWorkspace calls syncStatementConnectors and syncArgumentConnectors itself after the move (the origin fast path never fires the positioned subscription), and a tower the layout has not placed yet measures as its root brick's model.dims, not as {0, 0}, so towers never stack on the same spot.

Tests

- stores/workspace.test.ts, describe('cleanWorkspace'): orders the towers top to bottom then left to right off where they stood; leaves the gap so no two overlap; wraps into a second column when the next tower would cross maxColumnHeight; keeps a tower taller than the canvas at the head of a column of its own; lays out with the padding and gap it is given; measures an unplaced tower by its root brick; pushes the next tower down by the whole tower above it; replaces every root reference so each layout re-runs; writes every position in a single update; re-syncs both connector spaces once the towers have moved; does nothing on an empty workspace.
- utils/tower-traversal.test.ts, describe('measureTowerExtent'): root brick alone while nothing is laid out; reaches to the farthest brick edge relative to the origin; leaves out the bricks a folded cavity hides; never shrinks below the root brick.
- components/Workspace/CleanControl.test.tsx: renders with its accessibility label; disabled with no tower; enables once a tower exists; tidies into a column when clicked; wraps at the height of the canvas it is given.
- components/Workspace/Workspace.test.tsx, describe('clean control'): the control is on the canvas and disabled while empty; enables with a tower; moves the towers to the canvas padding when pressed.

npm run test in modules/masonry: 35 files, 539 tests pass. eslint and prettier are clean on the touched files.

Playground (npm run playground2, Workspace page): <img width="960" height="540" alt="811-clean-workspace" src="https://github.com/user-attachments/assets/9f216bba-35d1-416a-ad5a-ec0db533503a" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
