### PR TITLE
#820 | feat(masonry): replace a filled argument slot on drop

### DIFF
--- a/modules/masonry/src/hooks/useBrickMove.ts
+++ b/modules/masonry/src/hooks/useBrickMove.ts
@@ -77,11 +77,20 @@ export function tryConnect(towerId: string): boolean {
                     x: hostTower.position.x + residentPos.x + 24,
                     y: hostTower.position.y + residentPos.y + 48,
                 };
-                store.detachBrickToNewTower(
+                const newTowerId = store.detachBrickToNewTower(
                     argument.hostTowerId,
                     argument.residentNode.model.id,
                     dropPos,
                 );
+
+                if (newTowerId) {
+                    const latestStore = useWorkspaceStore.getState();
+                    const newTower = latestStore.towers[newTowerId];
+                    if (newTower) {
+                        latestStore.syncStatementConnectors(newTowerId, newTower.root);
+                        latestStore.syncArgumentConnectors(newTowerId, newTower.root);
+                    }
+                }
             }
         }
 

--- a/modules/masonry/src/hooks/useBrickMove.ts
+++ b/modules/masonry/src/hooks/useBrickMove.ts
@@ -67,6 +67,24 @@ export function tryConnect(towerId: string): boolean {
     }
 
     if (argument !== null) {
+        if (argument.residentNode) {
+            const hostTower = store.towers[argument.hostTowerId];
+            if (hostTower) {
+                // Place the evicted subtree just below and to the right of its old slot so it
+                // lands visibly beside the host without overlapping.
+                const residentPos = argument.residentNode.model.position;
+                const dropPos = {
+                    x: hostTower.position.x + residentPos.x + 24,
+                    y: hostTower.position.y + residentPos.y + 48,
+                };
+                store.detachBrickToNewTower(
+                    argument.hostTowerId,
+                    argument.residentNode.model.id,
+                    dropPos,
+                );
+            }
+        }
+
         joinArg(argument);
         store.absorbTower(argument.absorbedTowerId, argument.hostTowerId);
         triggerBrickAnimation(towerId, 'brick-snap-pulse');

--- a/modules/masonry/src/utils/argument-connect.test.ts
+++ b/modules/masonry/src/utils/argument-connect.test.ts
@@ -151,7 +151,7 @@ describe('resolveArgumentConnection', () => {
             expect(result?.slotIndex).toBe(2);
         });
 
-        it('skips an occupied slot', () => {
+        it('allows replacing an occupied slot', () => {
             const host = makeEmptyExpression('host', 1);
             host.model.setPosition(500, 500);
             const dragged = makeEmptyValue('dragged');
@@ -166,7 +166,8 @@ describe('resolveArgumentConnection', () => {
             ]);
 
             // Filled after the space was seeded, so only the live graph knows the slot is taken.
-            host.args[0] = makeEmptyValue('sitting-tenant');
+            const sittingTenant = makeEmptyValue('sitting-tenant');
+            host.args[0] = sittingTenant;
 
             const result = resolveArgumentConnection({
                 draggedTowerId: 'dragged-tower',
@@ -175,7 +176,72 @@ describe('resolveArgumentConnection', () => {
                 towers,
             });
 
-            expect(result).toBeNull();
+            expect(result).toMatchObject({
+                parent: host,
+                child: dragged,
+                slotIndex: 0,
+                hostTowerId: 'host-tower',
+                absorbedTowerId: 'dragged-tower',
+                residentNode: sittingTenant,
+            });
+        });
+
+        it('reports no resident when the slot is empty', () => {
+            const host = makeEmptyExpression('host', 1);
+            host.model.setPosition(500, 500);
+            const dragged = makeEmptyValue('dragged');
+
+            const { space, connectors, towers } = workspace([
+                { id: 'host-tower', root: host, position: { x: 500, y: 500 } },
+                {
+                    id: 'dragged-tower',
+                    root: dragged,
+                    position: positionOutputAt(dragged, slotCenter(host, 0)),
+                },
+            ]);
+
+            const result = resolveArgumentConnection({
+                draggedTowerId: 'dragged-tower',
+                space,
+                connectors,
+                towers,
+            });
+
+            expect(result?.residentNode).toBeNull();
+        });
+
+        it('returns the whole expression subtree as the resident when the slot holds one', () => {
+            const host = makeEmptyExpression('host', 1);
+            host.model.setPosition(500, 500);
+            const dragged = makeEmptyValue('dragged');
+
+            // The resident is an expression with its own filled argument.
+            const resident = makeEmptyExpression('resident', 1);
+            const leaf = makeEmptyValue('leaf');
+            resident.args[0] = leaf;
+            leaf.parent = resident;
+            host.args[0] = resident;
+            resident.parent = host;
+
+            const { space, connectors, towers } = workspace([
+                { id: 'host-tower', root: host, position: { x: 500, y: 500 } },
+                {
+                    id: 'dragged-tower',
+                    root: dragged,
+                    position: positionOutputAt(dragged, slotCenter(host, 0)),
+                },
+            ]);
+
+            const result = resolveArgumentConnection({
+                draggedTowerId: 'dragged-tower',
+                space,
+                connectors,
+                towers,
+            });
+
+            expect(result?.residentNode).toBe(resident);
+            // The resident keeps its own subtree intact.
+            expect(resident.args[0]).toBe(leaf);
         });
 
         it('never plugs into a slot the dragged tower already owns', () => {
@@ -258,6 +324,78 @@ describe('resolveArgumentConnection', () => {
             expect(result?.parent).toBe(dragged);
             expect(result?.child).toBe(settled);
             expect(result?.slotIndex).toBe(1);
+        });
+
+        it('allows picking up a block when the slot is occupied', () => {
+            const settled = makeEmptyValue('settled');
+            settled.model.setPosition(500, 500);
+            const dragged = makeEmptyExpression('dragged', 1);
+
+            const sittingTenant = makeEmptyValue('sitting-tenant');
+            dragged.args[0] = sittingTenant;
+
+            const { output } = settled.model.getConnectorCoords();
+            const outputCentre = { x: 500 + output!.x, y: 500 + output!.y };
+
+            const { space, connectors, towers } = workspace([
+                { id: 'settled-tower', root: settled, position: { x: 500, y: 500 } },
+                {
+                    id: 'dragged-tower',
+                    root: dragged,
+                    position: positionSlotAt(dragged, 0, outputCentre),
+                },
+            ]);
+
+            const result = resolveArgumentConnection({
+                draggedTowerId: 'dragged-tower',
+                space,
+                connectors,
+                towers,
+            });
+
+            expect(result).toMatchObject({
+                parent: dragged,
+                child: settled,
+                slotIndex: 0,
+                hostTowerId: 'dragged-tower',
+                absorbedTowerId: 'settled-tower',
+                residentNode: sittingTenant,
+            });
+        });
+
+        it('returns the whole expression subtree as the resident when the dragged slot holds one', () => {
+            const settled = makeEmptyValue('settled');
+            settled.model.setPosition(500, 500);
+            const dragged = makeEmptyExpression('dragged', 1);
+
+            const resident = makeEmptyExpression('resident', 1);
+            const leaf = makeEmptyValue('leaf');
+            resident.args[0] = leaf;
+            leaf.parent = resident;
+            dragged.args[0] = resident;
+            resident.parent = dragged;
+
+            const { output } = settled.model.getConnectorCoords();
+            const outputCentre = { x: 500 + output!.x, y: 500 + output!.y };
+
+            const { space, connectors, towers } = workspace([
+                { id: 'settled-tower', root: settled, position: { x: 500, y: 500 } },
+                {
+                    id: 'dragged-tower',
+                    root: dragged,
+                    position: positionSlotAt(dragged, 0, outputCentre),
+                },
+            ]);
+
+            const result = resolveArgumentConnection({
+                draggedTowerId: 'dragged-tower',
+                space,
+                connectors,
+                towers,
+            });
+
+            expect(result?.residentNode).toBe(resident);
+            expect(resident.args[0]).toBe(leaf);
         });
 
         it('refuses a brick that is already filling another brick’s slot', () => {

--- a/modules/masonry/src/utils/argument-connect.ts
+++ b/modules/masonry/src/utils/argument-connect.ts
@@ -13,7 +13,7 @@ export type ArgumentChildNode = TowerValueNode | TowerExpressionNode;
 
 /** A validated argument connection between two towers, ready to be spliced and merged. */
 export interface ArgumentConnection {
-    /** The node whose empty argument slot is being filled. */
+    /** The node whose argument slot is being filled (may already be occupied). */
     parent: ArgumentParentNode;
     /** The node being plugged into that slot. */
     child: ArgumentChildNode;
@@ -25,6 +25,8 @@ export interface ArgumentConnection {
     absorbedTowerId: string;
     /** Gap between the two connectors at drop time; used to pick between rival connections. */
     distance: number;
+    /** The node currently occupying the slot, if any; `null` when the slot is empty. */
+    residentNode: ArgumentChildNode | null;
 }
 
 export interface ResolveArgumentConnectionParams {
@@ -39,9 +41,10 @@ export interface ResolveArgumentConnectionParams {
 }
 
 /**
- * Direction 1 — the dragged tower plugs itself in: its root's output tab seeks an empty argument
- * slot on a settled tower, which becomes the host. Only the root is considered, since every other
- * brick in the tower already has its output filled.
+ * Direction 1 — the dragged tower plugs itself in: its root's output tab seeks an argument
+ * slot (empty or occupied) on a settled tower, which becomes the host. When the slot already holds
+ * a brick, that resident is recorded so the caller can evict it before merging. Only the root is
+ * considered, since every other brick in the tower already has its output filled.
  */
 function resolveOutputIntoSlot(
     dragged: TowerState,
@@ -71,8 +74,7 @@ function resolveOutputIntoSlot(
         const parent = findNode(host.root, meta.brickId);
         if (!parent || (parent.kind !== 'expression' && parent.kind !== 'statement')) continue;
 
-        // Empty-only: no displace, no replace.
-        if (parent.args[meta.slotIndex] !== null) continue;
+        const residentNode = parent.args[meta.slotIndex] as ArgumentChildNode | null;
 
         const input = parent.model.getConnectorCoords().inputs[meta.slotIndex];
         if (!input) continue;
@@ -90,6 +92,7 @@ function resolveOutputIntoSlot(
                 hostTowerId: host.id,
                 absorbedTowerId: dragged.id,
                 distance,
+                residentNode,
             };
         }
     }
@@ -98,9 +101,10 @@ function resolveOutputIntoSlot(
 }
 
 /**
- * Direction 2 — the dragged tower picks something up: one of its own empty argument slots seeks the
- * free output tab of a settled tower, which is absorbed into it. Every empty slot in the dragged
- * tower is a candidate, not just the root's, since all of them are equally free to be filled.
+ * Direction 2 — the dragged tower picks something up: one of its own argument slots (empty or
+ * occupied) seeks the free output tab of a settled tower, which is absorbed into it. Every slot in
+ * the dragged tower is a candidate, not just the root's, since all of them are equally free to be
+ * filled. When a slot already holds a brick, that resident is recorded so the caller can evict it.
  *
  * Only the slots the drag carries in plain sight, though: a brick hidden inside a folded cavity
  * offers none, since it is drawn nowhere and its recorded position is wherever the layout left it
@@ -117,9 +121,8 @@ function resolveSlotOntoOutput(
 
         const inputs = parent.model.getConnectorCoords().inputs;
 
-        parent.args.forEach((arg, slotIndex) => {
-            if (arg !== null) return;
-
+        parent.args.forEach((_resident, slotIndex) => {
+            const residentNode = _resident as ArgumentChildNode | null;
             const input = inputs[slotIndex];
             if (!input) return;
 
@@ -157,6 +160,7 @@ function resolveSlotOntoOutput(
                         hostTowerId: dragged.id,
                         absorbedTowerId: absorbed.id,
                         distance,
+                        residentNode,
                     };
                 }
             }
@@ -193,12 +197,12 @@ export function resolveArgumentConnection(
 }
 
 /**
- * Plugs `child` into `parent`'s empty argument slot by editing tower-node pointers in place. Pure
+ * Plugs `child` into `parent`'s argument slot by editing tower-node pointers in place. Pure
  * with respect to stores and layout: the caller merges the two towers, which re-runs the layout and
  * thereby recomputes the parent's `argDims` and outline.
  *
- * The caller guarantees the slot is empty and that the two nodes come from different towers; see
- * {@link resolveArgumentConnection}.
+ * When the slot is occupied, the caller is responsible for evicting the resident first (via
+ * `detachBrickToNewTower` in the hook layer); see {@link resolveArgumentConnection}.
  */
 export function joinArg({
     parent,


### PR DESCRIPTION
closes #820

## Summary

Dropping a value brick onto an already-filled argument slot now evicts the old occupant onto the canvas as its own tower and snaps the new one into place. Previously the drop was silently rejected.

## UI 
[Screencast from 2026-09-12 16-23-16.webm](https://github.com/user-attachments/assets/8076308c-8adf-40e8-ad3b-a340e4af6e2d)


## What changed

- **`argument-connect.ts`** — Removed the empty-slot guards in both resolvers so filled slots are valid connection candidates. Added a `residentNode` field to `ArgumentConnection` so the caller knows what to evict.
- **`useBrickMove.ts`** — In `tryConnect`, if `residentNode` is set, calls `detachBrickToNewTower` to pop the old brick out before `joinArg`. Placement offset is +24px / +48px so it lands beside the host.
- **`argument-connect.test.ts`** — 6 new tests: occupied-slot replacement, empty-slot null check, and nested-expression subtree integrity — for both directions. Updated the old `skips an occupied slot` test to `allows replacing an occupied slot`.

## Checklist

- [x] `npm run check` — no errors
- [x] `npm run lint` — no errors

If any kind of changes are required in this PR, please let me know — happy to update!